### PR TITLE
chore: fixup dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
   - component/github-actions
 - package-ecosystem: "gomod"
   directories:
+    - "/cli"
     - "/bindings/go/*"
   groups:
     go:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,57 +17,13 @@ updates:
   - kind/skip-release-notes
   - component/github-actions
 - package-ecosystem: "gomod"
-  directory: "/"
+  directories:
+    - "/bindings/go/*"
   groups:
     go:
       update-types: [ "minor", "patch" ]
   schedule:
-    interval: "weekly"
-    day: "sunday"
-  labels:
-  - kind/dependency
-  - kind/chore
-- package-ecosystem: "docker"
-  directory: "/"
-  groups:
-    docker:
-      update-types: [ "minor", "patch" ]
-  schedule:
-    interval: "weekly"
-    day: "sunday"
-  labels:
-  - kind/dependency
-  - kind/chore
-- package-ecosystem: "bundler"
-  directory: "/"
-  groups:
-    ruby:
-      update-types: [ "minor", "patch" ]
-  schedule:
-    interval: "weekly"
-    day: "sunday"
-  labels:
-  - kind/dependency
-  - kind/chore
-- package-ecosystem: "pip"
-  directory: "/"
-  groups:
-    python:
-      update-types: [ "minor", "patch" ]
-  schedule:
-    interval: "weekly"
-    day: "sunday"
-  labels:
-  - kind/dependency
-  - kind/chore
-- package-ecosystem: "npm"
-  directory: "/"
-  groups:
-    node:
-      update-types: [ "minor", "patch" ]
-  schedule:
-    interval: "weekly"
-    day: "sunday"
+    interval: "daily"
   labels:
   - kind/dependency
   - kind/chore


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

This makes sure we receive dependabot updates in our go bindings

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
