### PR TITLE
fix: fixup task include

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,7 +5,7 @@ dotenv: ['.env', '.env.local']
 includes:
   tools:
     taskfile: ./tools.Taskfile.yml
-  bindings/go/descriptor:
+  bindings/go/descriptor/v2:
     optional: true
     taskfile: ./bindings/go/descriptor/v2/Taskfile.yml
     dir: ./bindings/go/descriptor/v2


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

include prefixes are used in the test task to correctly run tasks. thats why the include must match the taskfile dir exactly. v2 was missing

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
