### PR TITLE
fix: introduce CI failure check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
       contents: read
       # Optional: allow write access to checks to allow the action to annotate code in the PR.
       checks: write
+    if: ${{ fromJSON(needs.discover_modules.outputs.modules_json)[0] != null }} # skip if no modules are found
     strategy:
       matrix:
         module: ${{ fromJSON(needs.discover_modules.outputs.modules_json) }}
@@ -102,6 +103,7 @@ jobs:
     name: "Unit Tests"
     needs: discover_modules
     runs-on: ubuntu-latest
+    if: ${{ fromJSON(needs.discover_modules.outputs.modules_json)[0] != null }} # skip if no modules are found
     strategy:
       matrix:
         module: ${{ fromJSON(needs.discover_modules.outputs.modules_json) }}
@@ -130,6 +132,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
+    if: ${{ fromJSON(needs.discover_modules.outputs.modules_json)[0] != null }} # skip if no modules are found
     strategy:
       fail-fast: false
       matrix:
@@ -157,6 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Code Generation"
     needs: discover_modules
+    if: ${{ fromJSON(needs.discover_modules.outputs.modules_json)[0] != null }} # skip if no modules are found
     strategy:
       matrix:
         module: ${{ fromJSON(needs.discover_modules.outputs.modules_json) }}
@@ -188,3 +192,22 @@ jobs:
           fi
           echo "${gitStatus}"
           exit 1
+
+  # failure aggregation job
+  # Our CI matrix is dynamic so it cannot be used for required status checks in github.
+  # However we can add a failure step that can get triggered if any dependency fails or is cancelled.
+  # If this is the case, this job will fail. If CI is successful, the CI Completion Check will be skipped.
+  # see https://github.com/orgs/community/discussions/60792 for details on why this is needed
+  check-completion:
+    name: "Completion"
+    runs-on: ubuntu-latest
+    needs:
+      - discover_modules
+      - generate
+      - analyze-go
+      - run_unit_tests
+      - golangci_lint
+    if: failure()
+    steps:
+      - name: Some CI step failed or was cancelled!
+        run: exit 1


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Our CI matrix is dynamic so it cannot be used for required status checks in github. However we can add a failure step that can get triggered if any dependency fails or is cancelled. If this is the case, this job will fail. If CI is successful, the CI Completion Check will be skipped.

This will allow me to set `CI / Completion` as a required status check that I set in the github project settings

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
