### PR TITLE
fix!: remove grouped typings

### DIFF
--- a/bindings/go/runtime/raw_test.go
+++ b/bindings/go/runtime/raw_test.go
@@ -14,7 +14,7 @@ func TestRaw_UnmarshalJSON_Success(t *testing.T) {
 	err := json.Unmarshal([]byte(input), &raw)
 
 	require.NoError(t, err)
-	require.Equal(t, NewUngroupedUnversionedType("example"), raw.Type)
+	require.Equal(t, NewUnversionedType("example"), raw.Type)
 	require.NotEmpty(t, raw.Data)
 
 	// Ensure data is canonicalized (e.g., keys are sorted)
@@ -36,7 +36,7 @@ func TestRaw_MarshalJSON(t *testing.T) {
 	original := []byte(`{"foo":"bar","type":"example"}`)
 
 	raw := Raw{
-		Type: NewUngroupedUnversionedType("example"),
+		Type: NewUnversionedType("example"),
 		Data: original,
 	}
 
@@ -48,9 +48,9 @@ func TestRaw_MarshalJSON(t *testing.T) {
 
 func TestRaw_GetSetType(t *testing.T) {
 	raw := &Raw{}
-	raw.SetType(NewUngroupedUnversionedType("testtype"))
+	raw.SetType(NewUnversionedType("testtype"))
 
-	require.Equal(t, NewUngroupedUnversionedType("testtype"), raw.GetType())
+	require.Equal(t, NewUnversionedType("testtype"), raw.GetType())
 }
 
 func TestRaw_String(t *testing.T) {

--- a/bindings/go/runtime/registry.go
+++ b/bindings/go/runtime/registry.go
@@ -70,7 +70,7 @@ func (r *Scheme) MustRegister(prototype Typed, version string) {
 		panic("All types must be pointers to structs.")
 	}
 	t = t.Elem()
-	r.MustRegisterWithAlias(prototype, NewUngroupedVersionedType(t.Name(), version))
+	r.MustRegisterWithAlias(prototype, NewVersionedType(t.Name(), version))
 }
 
 func (r *Scheme) TypeForPrototype(prototype any) (Type, error) {

--- a/bindings/go/runtime/registry_convert_test.go
+++ b/bindings/go/runtime/registry_convert_test.go
@@ -158,7 +158,7 @@ func TestConvert_Errors(t *testing.T) {
 
 	t.Run("unregistered type (Raw → Typed)", func(t *testing.T) {
 		scheme := runtime.NewScheme()
-		r := runtime.Raw{Type: runtime.NewUngroupedVersionedType("TestType", "v1"),
+		r := runtime.Raw{Type: runtime.NewVersionedType("TestType", "v1"),
 			Data: []byte(`{"type": "TestType/v1", "foo": "bar"}`)}
 
 		err := scheme.Convert(&r, &TestType{})
@@ -167,7 +167,7 @@ func TestConvert_Errors(t *testing.T) {
 
 	t.Run("unregistered type (Typed → Raw)", func(t *testing.T) {
 		scheme := runtime.NewScheme()
-		typ := runtime.NewUngroupedVersionedType("TestType", "v1")
+		typ := runtime.NewVersionedType("TestType", "v1")
 		r := runtime.Raw{}
 
 		err := scheme.Convert(&TestType{Type: typ, Foo: "bar"}, &r)

--- a/bindings/go/runtime/registry_test.go
+++ b/bindings/go/runtime/registry_test.go
@@ -29,7 +29,7 @@ func (t *TestType) DeepCopyTyped() Typed {
 
 func TestRegistry_Decode(t *testing.T) {
 	r := require.New(t)
-	typ := NewType("test", "v1", "type")
+	typ := NewVersionedType("test", "v1")
 	registry := NewScheme()
 	registry.MustRegisterWithAlias(&TestType{}, typ)
 

--- a/bindings/go/runtime/type_test.go
+++ b/bindings/go/runtime/type_test.go
@@ -18,18 +18,14 @@ func TestTypeFromString(t *testing.T) {
 	}{
 		// Unversioned types
 		{"OCIArtifact", runtime.Type{Name: "OCIArtifact"}, false},
-		{"software.ocm.accessType.OCIArtifact", runtime.Type{Group: "software.ocm.accessType", Name: "OCIArtifact"}, false},
 
 		// Versioned types
 		{"OCIArtifact/v1", runtime.Type{Name: "OCIArtifact", Version: "v1"}, false},
-		{"software.ocm.accessType.OCIArtifact/v1", runtime.Type{Group: "software.ocm.accessType", Name: "OCIArtifact", Version: "v1"}, false},
 
 		// Invalid formats
 		{"", runtime.Type{}, true},
-		{"software.ocm.accessType./v1", runtime.Type{}, true},
-		{"./v1", runtime.Type{}, true},
 		{"/v1", runtime.Type{}, true},
-		{"software.ocm.accessType.OCIArtifact/v1/extra", runtime.Type{}, true},
+		{"OCIArtifact/v1/extra", runtime.Type{}, true},
 	}
 
 	for _, tt := range tests {
@@ -52,8 +48,6 @@ func TestTypeString(t *testing.T) {
 	}{
 		{runtime.Type{Name: "OCIArtifact"}, "OCIArtifact"},
 		{runtime.Type{Name: "OCIArtifact", Version: "v1"}, "OCIArtifact/v1"},
-		{runtime.Type{Group: "software.ocm.accessType", Name: "OCIArtifact"}, "software.ocm.accessType.OCIArtifact"},
-		{runtime.Type{Group: "software.ocm.accessType", Name: "OCIArtifact", Version: "v1"}, "software.ocm.accessType.OCIArtifact/v1"},
 	}
 
 	for _, tt := range tests {
@@ -71,13 +65,10 @@ func TestTypeEqual(t *testing.T) {
 	}{
 		{runtime.Type{Name: "OCIArtifact"}, runtime.Type{Name: "OCIArtifact"}, true},
 		{runtime.Type{Name: "OCIArtifact", Version: "v1"}, runtime.Type{Name: "OCIArtifact", Version: "v1"}, true},
-		{runtime.Type{Group: "software.ocm.accessType", Name: "OCIArtifact"}, runtime.Type{Group: "software.ocm.accessType", Name: "OCIArtifact"}, true},
-		{runtime.Type{Group: "software.ocm.accessType", Name: "OCIArtifact", Version: "v1"}, runtime.Type{Group: "software.ocm.accessType", Name: "OCIArtifact", Version: "v1"}, true},
 
 		// Different cases
 		{runtime.Type{Name: "OCIArtifact"}, runtime.Type{Name: "Node"}, false},
 		{runtime.Type{Name: "OCIArtifact", Version: "v1"}, runtime.Type{Name: "OCIArtifact", Version: "v2"}, false},
-		{runtime.Type{Group: "software.ocm.accessType", Name: "OCIArtifact"}, runtime.Type{Group: "apps", Name: "OCIArtifact"}, false},
 	}
 
 	for _, tt := range tests {
@@ -94,8 +85,6 @@ func TestJSONMarshalling(t *testing.T) {
 	}{
 		{runtime.Type{Name: "OCIArtifact"}, `"OCIArtifact"`},
 		{runtime.Type{Name: "OCIArtifact", Version: "v1"}, `"OCIArtifact/v1"`},
-		{runtime.Type{Group: "software.ocm.accessType", Name: "OCIArtifact"}, `"software.ocm.accessType.OCIArtifact"`},
-		{runtime.Type{Group: "software.ocm.accessType", Name: "OCIArtifact", Version: "v1"}, `"software.ocm.accessType.OCIArtifact/v1"`},
 	}
 
 	for _, tt := range tests {
@@ -115,14 +104,11 @@ func TestJSONUnmarshalling(t *testing.T) {
 	}{
 		{`"OCIArtifact"`, runtime.Type{Name: "OCIArtifact"}, false},
 		{`"OCIArtifact/v1"`, runtime.Type{Name: "OCIArtifact", Version: "v1"}, false},
-		{`"software.ocm.accessType.OCIArtifact"`, runtime.Type{Group: "software.ocm.accessType", Name: "OCIArtifact"}, false},
-		{`"software.ocm.accessType.OCIArtifact/v1"`, runtime.Type{Group: "software.ocm.accessType", Name: "OCIArtifact", Version: "v1"}, false},
 
 		// Invalid JSON cases
 		{`""`, runtime.Type{}, true},
-		{`"software.ocm.accessType./v1"`, runtime.Type{}, true},
-		{`"./v1"`, runtime.Type{}, true},
-		{`"software.ocm.accessType.OCIArtifact/v1/extra"`, runtime.Type{}, true},
+		{`"/v1"`, runtime.Type{}, true},
+		{`"OCIArtifact/v1/extra"`, runtime.Type{}, true},
 		{`123`, runtime.Type{}, true}, // Not a string
 	}
 

--- a/bindings/go/runtime/unstructured_test.go
+++ b/bindings/go/runtime/unstructured_test.go
@@ -67,12 +67,12 @@ func TestUnstructured(t *testing.T) {
 						"componentNameMapping": "urlPath",
 					},
 				}
-				un.SetType(runtime.NewType("group", "version", "name"))
+				un.SetType(runtime.NewVersionedType("name", "version"))
 				return &un
 			},
 			// comparing string so if there is a conflict it's easier to see
 			assertResult: func(t *testing.T, data []byte) {
-				assert.Equal(t, "{\"componentNameMapping\":\"urlPath\",\"type\":\"group.name/version\"}", string(data))
+				assert.Equal(t, "{\"componentNameMapping\":\"urlPath\",\"type\":\"name/version\"}", string(data))
 			},
 		},
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

It becomes evident that conversion logic centered around migrating from the old OCM Type system to the new type system is too big of a break. As such we will adopt the existing Type nomenclature of OCM which is completely untyped.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
The effects of this will be:

- There is a context for ungrouped types that needs to be used (e.g. are you resolving an access type or an input type)
- Based on this knowledge, one has to use a correct well known registry.
- Based on this well-known registry, we can avoid conflicts with other ungrouped types based on other well-known registries.

