### PR TITLE
chore: enforce more linters

### DIFF
--- a/.github/config/golangci.yml
+++ b/.github/config/golangci.yml
@@ -8,17 +8,6 @@ run:
 linters:
   enable-all: true
   disable:
-    - tenv
-    # We are working on it
-    - wrapcheck
-
-    # Logical next step
-    - forcetypeassert  # Priority: that can lead to serious crashes.
-    - revive           # Too many issues.
-                       #   It's important to at least address:
-                       #     - no camel_case
-                       #     - no this and self
-                       #     - receiver name a should be consistent
     - gomoddirectives  # Replacement statements are not allowed in a library.
                        #   if it has a replace statement, other can't use the
                        #   library at all (go does not allow that)
@@ -26,71 +15,51 @@ linters:
                        # a related GitHub issue.
                        #   Added an exclude-rules for that, if a TODO/FIXME/BUG
                        #   line has an URL on the line, it counts as valid mark.
-    - errcheck         # Too many issues.
-    - stylecheck       # Too many issues.
-                       #   No snake_case in Go.
-                       #   convert_ComponentReferences_from should be convertComponentReferencesFrom
-    - prealloc         # Performance.
-    - nilerr           # There a few places where we don't return with an error
-                       #   in an 'if err != nil {}' block. If it's intentional,
-                       #   we should add a '//nolint: nilerr // Reason why...'
-    - nlreturn         # Use empty line at least before return/break/continue.
     - err113         # Do not define dynamic errors with Errorf.
-    - varnamelen       # m, d, p < These are not so meaningful variables.
-    - testpackage      # Blackbox testing is preferred.
-    - funlen           # Break long functions.
-    - ireturn          # Accept interface, return concrete.
-    - nestif           # Some nexted if statements are 8 or 9 deep.
-    - dupl             # Check code duplications.
-    - cyclop           # Complex functions are not good.
-    - gochecknoinits   # Init functions cause an import to have side effects,
-                       #   and side effects are hard to test,
-                       #   reduce readability and increase the complexity of code.
-    - gocyclo          # We shouldn't have functions with complexity 51
-    - gocognit         # Another complexity check, they check different things.
-    - containedctx     # Struct should not contain context, action does.
-    - nilnil           # A function should return either something valuable
-                       #   or an error, but both value and error as nil is
-                       #   useless. Like when I call it, why is it nil? Tell me
-                       #   in an error why.
-    - bodyclose
-    - unparam
-    - nonamedreturns   # Either named return, or use simply `return`.
 
-    # Opinionated (we may want to keep it disabled)
     - gochecknoglobals
     - lll
     - paralleltest
-    - tagliatelle
     - wsl
-    - interfacebloat
     - inamedparam
     - mnd
-    - perfsprint
-
-
-    # Disabled with reason
-    - nakedret
-    - depguard
-    - mirror
-    - dogsled
+    - ireturn
+    - varnamelen
+    - nlreturn
+    - nonamedreturns
+    - gochecknoinits
     - exhaustruct      # Doesn't really make sense.
     - exhaustive       # Doesn't really make sense.
-    - loggercheck         # Doesn't really make sense.
-    - goimports        # acts weirdly, dci handles imports anyway
-    - intrange         # Confusing, since manipulating a range variable in a loop does not change the number of
-    # iterations. Thus, an integer range is constant.
-
-    # Disabled because of generics in go 1.18
-    - contextcheck
-    - rowserrcheck
-    - sqlclosecheck
-    - wastedassign
-
-    # Seriously, who wants every comment to end in a period???
+    - goimports        # gci handles imports anyway
+    - tenv           # Replaced by usetesting.
     - godot
 
 linters-settings:
+  wrapcheck:
+    extra-ignore-sigs:
+      - .Unmarshal(
+      - .Marshal(
+      - (*github.com/spf13/pflag.FlagSet).GetString(
+      - ocm.software/open-component-model
+  revive:
+    rules:
+      - name: redefines-builtin-id
+        disabled: true
+  depguard:
+    rules:
+      main:
+        list-mode: strict
+        allow:
+          - $gostd
+          - ocm.software/open-component-model
+          - sigs.k8s.io/yaml # json + yaml conversion is done the same way as k8s
+          - github.com/cyberphone/json-canonicalization # we need canonicalization
+          - github.com/opencontainers/go-digest # we need OCI style digests
+          - golang.org/x/sync/errgroup # errgroups are ok
+          - github.com/opencontainers/image-spec # oci image spec is okay
+          - github.com/nlepage/go-tarfs # tar based filesystems are important for us
+          - github.com/spf13/cobra # for building a CLI
+          - github.com/spf13/pflag # for building a CLI
   gci:
     sections:
       - standard
@@ -99,49 +68,17 @@ linters-settings:
       - default
       - prefix(ocm.software/open-component-model)
     custom-order: true
-  funlen:
-    lines: 110
-    statements: 60
   cyclop:
     max-complexity: 15
     skip-tests: true
-  nolintlint:
-    allow-unused: false
-    require-explanation: true
-    require-specific: false
-  varnamelen:
-    ignore-names:
-    - err
-    - wg
-    - id
   lll:
     line-length: 120
-  gosec:
-    exclude-generated: true
-  gocritic:
-    disabled-checks:
-      - elseif
   recvcheck:
-    disable-builtin: true
     exclusions:
       - "*.UnmarshalJSON" # UnmarshalJSON always needs pointer values to do proper value assignments
-
+  perfsprint:
+    strconcat: false
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-  exclude:
-    - composites
-  exclude-rules:
-    - source: "https://"
-      linters:
-        - lll
-    - path: _test\.go
-      linters:
-        - err113
-        - gocyclo
-        - errcheck
-        - gosec
-        - dupl
-        - funlen
-        - scopelint
 

--- a/bindings/go/blob/buffered_reader.go
+++ b/bindings/go/blob/buffered_reader.go
@@ -40,6 +40,7 @@ var (
 	_ MediaTypeAware = &EagerBufferedReader{}
 )
 
+//nolint:wrapcheck // err should be propagated as is
 func (b *EagerBufferedReader) LoadEagerly() error {
 	if b.Loaded() {
 		return nil
@@ -71,6 +72,7 @@ func (b *EagerBufferedReader) Loaded() bool {
 	return b.loaded
 }
 
+//nolint:wrapcheck // read should be propagated as is
 func (b *EagerBufferedReader) Read(p []byte) (n int, err error) {
 	if err := b.LoadEagerly(); err != nil {
 		return -1, err
@@ -78,6 +80,7 @@ func (b *EagerBufferedReader) Read(p []byte) (n int, err error) {
 	return b.buf.Read(p)
 }
 
+//nolint:wrapcheck // close should be propagated as is
 func (b *EagerBufferedReader) Close() error {
 	closeable, ok := b.reader.(io.Closer)
 	if !ok {

--- a/bindings/go/blob/filesystem/file.go
+++ b/bindings/go/blob/filesystem/file.go
@@ -59,7 +59,7 @@ func CopyBlobToOSPath(blob blob.ReadOnlyBlob, path string) error {
 		err = errors.Join(err, file.Close())
 	}()
 
-	buf := ioBufPool.Get().(*[]byte)
+	buf := ioBufPool.Get().(*[]byte) //nolint:forcetypeassert // we know the type of the buffer
 	defer ioBufPool.Put(buf)
 	if _, err := io.CopyBuffer(file, data, *buf); err != nil {
 		return fmt.Errorf("failed to copy resource data: %w", err)

--- a/bindings/go/blob/filesystem/file_blob.go
+++ b/bindings/go/blob/filesystem/file_blob.go
@@ -54,7 +54,7 @@ func (f *Blob) WriteCloser() (io.WriteCloser, error) {
 	}
 	file, err := f.fileSystem.OpenFile(f.path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, mode)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to open file %q: %w", f.path, err)
 	}
 	writeable, ok := file.(io.WriteCloser)
 	if !ok {

--- a/bindings/go/ctf/ctf.go
+++ b/bindings/go/ctf/ctf.go
@@ -19,7 +19,7 @@ import (
 // The zero value of FileFormat is FormatDirectory, and also the default.
 type FileFormat int
 
-var ErrUnsupportedFormat = fmt.Errorf("unsupported format")
+var ErrUnsupportedFormat = errors.New("unsupported format")
 
 const (
 	// FormatUnknown represents an unknown format.
@@ -40,6 +40,8 @@ func (f FileFormat) String() string {
 }
 
 // Flags to OpenCTF. They are not bound to a type because the underlying type changes based on syscall interfaces.
+//
+//nolint:stylecheck // ignore style error, as the flags replicating the os package mode
 const (
 	// O_RDONLY indicates that the CTF is opened in read-only mode.
 	O_RDONLY = os.O_RDONLY

--- a/bindings/go/ctf/ctx_reader.go
+++ b/bindings/go/ctf/ctx_reader.go
@@ -2,6 +2,7 @@ package ctf
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 )
@@ -17,13 +18,14 @@ func newCtxReader(ctx context.Context, r io.Reader) (io.Reader, error) {
 		}
 		if d, ok := r.(deadliner); ok {
 			if err := d.SetReadDeadline(deadline); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to set read deadline: %w", err)
 			}
 		}
 	}
 	return ctxReader{ctx, r}, nil
 }
 
+//nolint:containedctx // ctxReader is an io.Reader that checks the context for cancellation so a context is important
 type ctxReader struct {
 	ctx context.Context
 	r   io.Reader

--- a/bindings/go/ctf/filesystem_ctf.go
+++ b/bindings/go/ctf/filesystem_ctf.go
@@ -126,7 +126,7 @@ func (c *FileSystemCTF) writeFile(name string, raw io.Reader) (err error) {
 		return fmt.Errorf("file %s is read only and cannot be saved", name)
 	}
 
-	buf := ioBufPool.Get().(*[]byte)
+	buf := ioBufPool.Get().(*[]byte) //nolint:forcetypeassert // we know the type of the buffer
 	defer ioBufPool.Put(buf)
 	if _, err = io.CopyBuffer(writeable, raw, *buf); err != nil {
 		return fmt.Errorf("unable to write artifact index: %w", err)

--- a/bindings/go/ctf/index/v1/index.go
+++ b/bindings/go/ctf/index/v1/index.go
@@ -54,7 +54,7 @@ func DecodeIndex(data io.Reader) (Index, error) {
 	decoder.DisallowUnknownFields()
 
 	if err := decoder.Decode(&d); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to decode index: %w", err)
 	}
 
 	if d.SchemaVersion != SchemaVersion {

--- a/bindings/go/ctf/tar.go
+++ b/bindings/go/ctf/tar.go
@@ -84,7 +84,7 @@ func extractTARToFilesystemCTF(reader *tar.Reader, ctf *FileSystemCTF) (err erro
 			break
 		}
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to extract tar to filesystem ctf: %w", err)
 		}
 		if strings.Contains(header.Name, "..") {
 			return fmt.Errorf("invalid tar entry, contains %q: %s", "..", header.Name)
@@ -154,7 +154,7 @@ func ArchiveDirectory(ctx context.Context, ctf CTF, path string) error {
 		}
 
 		if err := group.Wait(); err != nil {
-			return err
+			return fmt.Errorf("unable to save blob group concurrently: %w", err)
 		}
 	}
 
@@ -237,7 +237,7 @@ func ArchiveTARToWriter(ctx context.Context, ctf CTF, writer io.Writer, format F
 		}
 		name := filepath.Join(BlobsDirectoryName, file)
 		if err := blob.ArchiveBlob(name, size.Size(), digest, b, tarWriter, copyBuffer); err != nil {
-			return err
+			return fmt.Errorf("unable to archive blob %s: %w", digest, err)
 		}
 	}
 

--- a/bindings/go/descriptor/runtime/convert_v2.go
+++ b/bindings/go/descriptor/runtime/convert_v2.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"strings"
@@ -9,6 +10,15 @@ import (
 
 	v2 "ocm.software/open-component-model/bindings/go/descriptor/v2"
 	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+var (
+	// ErrEmptyProvider is returned when a provider string is empty
+	ErrEmptyProvider = errors.New("empty provider string")
+	// ErrNilBlob is returned when a blob is nil
+	ErrNilBlob = errors.New("nil blob")
+	// ErrNilContexts is returned when repository contexts are nil
+	ErrNilContexts = errors.New("nil repository contexts")
 )
 
 // ConvertFromV2 converts a v2.Descriptor to the internal Descriptor format.
@@ -88,11 +98,11 @@ func ConvertToV2(scheme *runtime.Scheme, descriptor *Descriptor) (*v2.Descriptor
 // ConvertFromV2Provider parses a provider string to an Identity map or JSON structure.
 func ConvertFromV2Provider(provider string) (runtime.Identity, error) {
 	if provider == "" {
-		return nil, nil
+		return nil, ErrEmptyProvider
 	}
 	if strings.HasPrefix(strings.TrimSpace(provider), "{") {
 		if !json.Valid([]byte(provider)) {
-			return nil, fmt.Errorf("invalid JSON format")
+			return nil, errors.New("invalid JSON format")
 		}
 		id := runtime.Identity{}
 		if err := json.Unmarshal([]byte(provider), &id); err != nil {
@@ -253,18 +263,18 @@ func ConvertFromV2Signatures(signatures []v2.Signature) []Signature {
 // ConvertToV2Provider converts an internal provider identity to a string format expected by v2.
 func ConvertToV2Provider(provider runtime.Identity) (string, error) {
 	if provider == nil {
-		return "", nil
+		return "", ErrEmptyProvider
 	}
 	if name, ok := provider[v2.IdentityAttributeName]; ok {
 		return name, nil
 	}
-	return "", fmt.Errorf("provider name not found")
+	return "", errors.New("provider name not found")
 }
 
 // ConvertToV2RepositoryContexts deep copies internal repository contexts to v2 format.
 func ConvertToV2RepositoryContexts(scheme *runtime.Scheme, contexts []runtime.Typed) ([]*runtime.Raw, error) {
 	if contexts == nil {
-		return nil, nil
+		return nil, ErrNilContexts
 	}
 	n := make([]*runtime.Raw, len(contexts))
 	for i := range contexts {
@@ -403,7 +413,7 @@ func ConvertToV2Signatures(signatures []Signature) []v2.Signature {
 // ConvertFromV2LocalBlob converts a v2.LocalBlob to runtime.LocalBlob.
 func ConvertFromV2LocalBlob(scheme *runtime.Scheme, blob *v2.LocalBlob) (*LocalBlob, error) {
 	if blob == nil {
-		return nil, nil
+		return nil, ErrNilBlob
 	}
 	result := &LocalBlob{
 		Type:           blob.Type,
@@ -420,7 +430,7 @@ func ConvertFromV2LocalBlob(scheme *runtime.Scheme, blob *v2.LocalBlob) (*LocalB
 // ConvertToV2LocalBlob converts a runtime.LocalBlob to v2.LocalBlob.
 func ConvertToV2LocalBlob(scheme *runtime.Scheme, blob *LocalBlob) (*v2.LocalBlob, error) {
 	if blob == nil {
-		return nil, nil
+		return nil, ErrNilBlob
 	}
 	result := &v2.LocalBlob{
 		Type:           blob.Type,

--- a/bindings/go/descriptor/runtime/validate.go
+++ b/bindings/go/descriptor/runtime/validate.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -74,7 +75,7 @@ func findDuplicates(identities map[uint64][]indexedIdentity, elementType string)
 			// Create a list of indices for the duplicates
 			indices := make([]string, len(elements))
 			for i, elem := range elements {
-				indices[i] = fmt.Sprintf("%d", elem.index)
+				indices[i] = strconv.Itoa(elem.index)
 			}
 
 			duplicates = append(duplicates, fmt.Sprintf("identity '%v' appears %d times at %s indices [%s]",

--- a/bindings/go/descriptor/v2/descriptor.go
+++ b/bindings/go/descriptor/v2/descriptor.go
@@ -299,6 +299,8 @@ func (t *Timestamp) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 // The time is expected to be a quoted string in RFC 3339 format.
+//
+//nolint:wrapcheck // ignore because we want the error to be the same as the standard library
 func (t *Timestamp) UnmarshalJSON(data []byte) error {
 	// Ignore null, like in the main JSON package.
 	if string(data) == "null" {

--- a/bindings/go/descriptor/v2/time.go
+++ b/bindings/go/descriptor/v2/time.go
@@ -95,6 +95,8 @@ func (t Time) Rfc3339Copy() Time {
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface.
+//
+//nolint:wrapcheck // copied from k8s codebase, part of contract
 func (t *Time) UnmarshalJSON(b []byte) error {
 	if len(b) == 4 && string(b) == "null" {
 		t.Time = time.Time{}

--- a/bindings/go/generator/ocmtypegen/main.go
+++ b/bindings/go/generator/ocmtypegen/main.go
@@ -72,7 +72,7 @@ func scanSinglePackage(folder string) (string, []string, error) {
 
 	files, err := os.ReadDir(folder)
 	if err != nil {
-		return "", nil, err
+		return "", nil, fmt.Errorf("unable to read dir %s: %w", folder, err)
 	}
 
 	for _, f := range files {
@@ -83,7 +83,7 @@ func scanSinglePackage(folder string) (string, []string, error) {
 		fullPath := filepath.Join(folder, f.Name())
 		file, err := parser.ParseFile(fset, fullPath, nil, parser.ParseComments)
 		if err != nil {
-			return "", nil, err
+			return "", nil, fmt.Errorf("unable to parse file %s: %w", fullPath, err)
 		}
 
 		if packageName == "" {
@@ -126,7 +126,7 @@ func findGoPackages(root string) ([]string, error) {
 		}
 		files, err := os.ReadDir(path)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to read dir %s: %w", path, err)
 		}
 		for _, file := range files {
 			if !file.IsDir() && isValidGoFile(file.Name()) {
@@ -136,7 +136,10 @@ func findGoPackages(root string) ([]string, error) {
 		}
 		return nil
 	})
-	return packages, err
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk directory %s: %w", root, err)
+	}
+	return packages, nil
 }
 
 // isValidGoFile checks if a file should be considered for parsing.
@@ -181,7 +184,7 @@ func hasRuntimeTypeField(s *ast.StructType) bool {
 func getImportPath(folder string) (string, error) {
 	absFolder, err := filepath.Abs(folder)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("unable to get abs folder %s: %w", folder, err)
 	}
 
 	dir := absFolder
@@ -194,7 +197,7 @@ func getImportPath(folder string) (string, error) {
 			}
 			relPath, err := filepath.Rel(dir, absFolder)
 			if err != nil {
-				return "", err
+				return "", fmt.Errorf("unable to get relative path of %s: %w", absFolder, err)
 			}
 			if relPath == "." {
 				return modulePath, nil
@@ -215,7 +218,7 @@ func getImportPath(folder string) (string, error) {
 func readModulePath(goModPath string) (string, error) {
 	file, err := os.Open(goModPath)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("unable to open %s: %w", goModPath, err)
 	}
 	defer file.Close()
 
@@ -234,7 +237,7 @@ func generateCode(folder, pkg string, types []string) error {
 	outputPath := filepath.Join(folder, generatedFile)
 	out, err := os.Create(outputPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to create %s: %w", outputPath, err)
 	}
 	defer out.Close()
 

--- a/bindings/go/runtime/deep_copy_json.go
+++ b/bindings/go/runtime/deep_copy_json.go
@@ -24,6 +24,8 @@ import (
 // DeepCopyJSON deep copies the passed value, assuming it is a valid JSON representation i.e. only contains
 // types produced by json.Unmarshal() and also int64.
 // bool, int64, float64, string, []interface{}, map[string]interface{}, json.Number and nil
+//
+//nolint:forcetypeassert // we know that the value is a map[string]interface{}
 func DeepCopyJSON(x map[string]interface{}) map[string]interface{} {
 	return DeepCopyJSONValue(x).(map[string]interface{})
 }

--- a/bindings/go/runtime/identity.go
+++ b/bindings/go/runtime/identity.go
@@ -136,7 +136,7 @@ func ParseURLAndAllowNoScheme(urlToParse string) (*url.URL, error) {
 	}
 	parsedURL, err := url.Parse(urlToParse)
 	if err != nil {
-		return nil, err
+		return nil, err //nolint:wrapcheck // for url parsing we don't want to wrap here
 	}
 	if parsedURL.Scheme == dummyScheme {
 		parsedURL.Scheme = ""

--- a/bindings/go/runtime/identity_match.go
+++ b/bindings/go/runtime/identity_match.go
@@ -77,7 +77,7 @@ func (i Identity) Match(o Identity, matchers ...ChainableIdentityMatcher) bool {
 
 // MatchAll is a convenience function that creates an AndMatcher that matches all provided matchers.
 // In other words, it returns true if all given ChainableIdentityMatcher.Match return true.
-func MatchAll(matchers ...ChainableIdentityMatcher) ChainableIdentityMatcher {
+func MatchAll(matchers ...ChainableIdentityMatcher) *AndMatcher {
 	return &AndMatcher{Matchers: matchers}
 }
 

--- a/cli/cmd/generate-docs.go
+++ b/cli/cmd/generate-docs.go
@@ -36,11 +36,11 @@ var GenerateDocsCmd = &cobra.Command{
 		}
 		if dir == "" {
 			if dir, err = os.Getwd(); err != nil {
-				return err
+				return fmt.Errorf("unable to determine current directory: %w", err)
 			}
 		}
 		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-			return err
+			return fmt.Errorf("unable to create %s: %w", dir, err)
 		}
 
 		mode, err := enum.Get(cmd.Flags(), FlagMode)

--- a/cli/configuration/v1/ocm_config.go
+++ b/cli/configuration/v1/ocm_config.go
@@ -97,7 +97,7 @@ func GetOCMConfig(additional ...string) (*Config, error) {
 func GetConfigFromPath(path string) (*Config, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to open %s: %w", path, err)
 	}
 	defer func() {
 		err = errors.Join(err, file.Close())
@@ -105,7 +105,7 @@ func GetConfigFromPath(path string) (*Config, error) {
 
 	var instance Config
 	if err := scheme.Decode(file, &instance); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to decode %s: %w", path, err)
 	}
 	return &instance, nil
 }

--- a/tools.Taskfile.yml
+++ b/tools.Taskfile.yml
@@ -31,19 +31,27 @@ tasks:
 
   golangci-lint/run:
     desc: "Run golangci-lint on all go modules"
-    deps: [golangci-lint/install]
-    cmds:
+    deps:
       - for: { var: GO_MODULES }
-        cmd: |
-          cd {{.ITEM}} && 
-          {{ .ROOT_DIR }}/tmp/bin/golangci-lint run \
-            --timeout 10m \
-            --config={{ .ROOT_DIR }}/.github/config/golangci.yml \
-            --path-prefix {{.ITEM}} \
-            {{ .CLI_ARGS }} ./...          
+        task: golangci-lint/run/item
+        vars:
+          ITEM: '{{ .ITEM }}'
+
+  golangci-lint/run/item:
+    internal: true
+    deps: [golangci-lint/install]
+    cmd: |
+      cd {{.ITEM}} && 
+      {{ .ROOT_DIR }}/tmp/bin/golangci-lint run \
+        --timeout 10m \
+        --config={{ .ROOT_DIR }}/.github/config/golangci.yml \
+        --path-prefix {{ .ROOT_DIR }}/{{.ITEM}} \
+        {{ .CLI_ARGS }} ./...
+    
             
 
   golangci-lint/install:
+    silent: true
     desc: "Install golangci-lint at {{ .GOLANGCI_LINT_TARGET_VERSION }} into tmp ({{ .ROOT_DIR }}/tmp/bin) if not already present"
     vars:
       CURRENT_VERSION:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

our lint settings were take over from old OCM and were quite lenient. We can make them stricter.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
