### PR TITLE
chore: fixup dag module path

### DIFF
--- a/bindings/go/dag/go.mod
+++ b/bindings/go/dag/go.mod
@@ -1,4 +1,4 @@
-module ocm.software/pocm/bindings/golang/dag
+module ocm.software/open-component-model/bindings/go/dag
 
 go 1.24.1
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

The dag module still had the incorrect module math, now that should be different due to a vanity

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
