### PR TITLE
feat: creates stringeable, parseable implementations for identities

### DIFF
--- a/bindings/go/runtime/identity.go
+++ b/bindings/go/runtime/identity.go
@@ -69,6 +69,36 @@ func (i Identity) CanonicalHashV1() uint64 {
 	return h.Sum64()
 }
 
+// String returns a stable fmt.Stringer "native" format representation of the identity.
+// It can be used for stable string comparison. For generation of unique identities as hashes
+// use CanonicalHashV1 instead.
+func (i Identity) String() string {
+	parts := make([]string, 0, len(i))
+	for key := range slices.Values(slices.Sorted(maps.Keys(i))) {
+		parts = append(parts, fmt.Sprintf("%s=%s", key, i[key]))
+	}
+	return strings.Join(parts, ",")
+}
+
+// ParseIdentity parses a string into an Identity, using the format "key=value,key2=value2".
+// ParseIdentity is able to parse all Identities returned from Identity.String.
+func ParseIdentity(s string) (Identity, error) {
+	parts := strings.Split(s, ",")
+	identity := make(Identity, len(parts))
+	for _, part := range parts {
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) != 2 {
+			return nil, fmt.Errorf("invalid identity part %q", part)
+		}
+		key, value := strings.TrimSpace(kv[0]), strings.TrimSpace(kv[1])
+		if key == "" || value == "" {
+			return nil, fmt.Errorf("invalid identity part %q", part)
+		}
+		identity[key] = value
+	}
+	return identity, nil
+}
+
 // GetType extracts the type or panics if failing.
 // It should only be used if the type is known to be present and valid.
 // For more information, check ParseType.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

especially useful if identities should be used for cache keys (because String() is stable sorted), or simply for debugging. A corresponding parser allows reversely creating identities from strings

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
