### PR TITLE
chore: fixup unstable test case because roots are not ordered by contract

### DIFF
--- a/bindings/go/dag/dag_test.go
+++ b/bindings/go/dag/dag_test.go
@@ -52,7 +52,7 @@ func TestDAGAddNode(t *testing.T) {
 		r := require.New(t)
 		roots := d.Roots()
 		r.Len(roots, 2, "expected 2 roots, but got %d", len(d.Roots()))
-		r.EqualValues([]string{"A", "B"}, d.Roots(), "expected roots to be [A B], but got %v", d.Roots())
+		r.ElementsMatch([]string{"A", "B"}, d.Roots(), "expected roots to be [A B], but got %v", d.Roots())
 	})
 
 	t.Run("degrees", func(t *testing.T) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

fix failure as observed in [Details](https://github.com/open-component-model/open-component-model/actions/runs/14444482917/job/40501789190)

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
