### PR TITLE
feat: compressed / decompressed blobs

### DIFF
--- a/bindings/go/blob/compression/blob.go
+++ b/bindings/go/blob/compression/blob.go
@@ -1,0 +1,202 @@
+// Package compression provides functionality for handling compressed blobs in the Open Component Model.
+// It supports various compression methods and provides utilities for working with compressed data streams.
+package compression
+
+import (
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"ocm.software/open-component-model/bindings/go/blob"
+)
+
+const (
+	MediaTypeGzip       = "application/gzip"
+	MediaTypeGzipSuffix = "+gzip"
+)
+
+// Method represents the type of compression algorithm used for blob compression.
+type Method string
+
+const (
+	// MethodCanonical is the default compression method used by the package.
+	MethodCanonical = MethodGzip
+
+	// MethodGzip represents GZIP compression.
+	MethodGzip Method = "gzip"
+)
+
+// Compress creates a new compressed Blob with the specified base blob and default compression method.
+// The base blob will be compressed using the canonical compression method (GZIP).
+func Compress(b blob.ReadOnlyBlob) *Blob {
+	return &Blob{ReadOnlyBlob: b, CompressionMethod: MethodCanonical}
+}
+
+// Blob represents a compressed blob that wraps a base ReadOnlyBlob.
+// It implements the MediaTypeAware interface and provides compression functionality.
+type Blob struct {
+	blob.ReadOnlyBlob
+	CompressionMethod Method
+}
+
+// MediaType returns the media type of the compressed blob.
+// It appends the appropriate compression suffix to the base blob's media type.
+// Returns the media type and true if the media type is known.
+func (b *Blob) MediaType() (mediaType string, known bool) {
+	return mediaTypeForBlob(b.ReadOnlyBlob, b.CompressionMethod), true
+}
+
+// mediaTypeForBlob determines the media type for a blob based on its compression method.
+// It handles different compression methods and returns the appropriate media type string.
+func mediaTypeForBlob(b blob.ReadOnlyBlob, method Method) string {
+	var mediaType string
+	switch method {
+	case MethodGzip:
+		fallthrough
+	default:
+		mediaType = getMediaType(b, MediaTypeGzipSuffix, MediaTypeGzip)
+	}
+	return mediaType
+}
+
+// getMediaType determines the media type for a blob, considering its compression.
+// If the blob implements MediaTypeAware, it uses that media type and appends the compression suffix.
+// Otherwise, it returns the default media type for the compression method.
+func getMediaType(b blob.ReadOnlyBlob, ext, def string) string {
+	var mediaType string
+	if mediaTypeAware, ok := b.(blob.MediaTypeAware); ok {
+		if mediaType, ok = mediaTypeAware.MediaType(); ok {
+			mediaType += ext
+		}
+	}
+	if mediaType == "" {
+		mediaType = def
+	}
+	return mediaType
+}
+
+// ReadCloser returns an io.ReadCloser that provides access to the compressed blob data.
+// The returned reader will automatically compress the data from the base blob using the specified compression method.
+// The caller is responsible for closing the returned ReadCloser.
+func (b *Blob) ReadCloser() (io.ReadCloser, error) {
+	base, err := b.ReadOnlyBlob.ReadCloser()
+	if err != nil {
+		return nil, err
+	}
+
+	reader, writer := io.Pipe()
+
+	go compress(base, writer, b.CompressionMethod)
+
+	return reader, nil
+}
+
+// compress compresses the data from the reader with the specified compression method and writes it to the writer.
+func compress(reader io.ReadCloser, writer *io.PipeWriter, method Method) {
+	var compressed io.WriteCloser
+	switch method {
+	case MethodGzip:
+		fallthrough
+	default:
+		compressed = gzip.NewWriter(writer)
+	}
+
+	_, err := io.Copy(compressed, reader)
+	writer.CloseWithError(errors.Join(err, compressed.Close(), reader.Close()))
+}
+
+// Decompress creates a decompressed version of the given blob if it is compressed.
+// It detects the compression method based on the blob's media type and returns a new
+// blob that provides access to the decompressed data. If the blob is not compressed,
+// it returns the original blob unchanged.
+//
+// The function supports GZIP compression and handles both standalone GZIP files
+// (MediaTypeGzip) and compressed content with MediaTypeGzipSuffix suffix.
+//
+// Returns:
+//   - A ReadOnlyBlob that provides access to the decompressed data
+//   - An error if the blob cannot be decompressed
+func Decompress(b blob.ReadOnlyBlob) (blob.ReadOnlyBlob, error) {
+	var method Method
+	var mediaType string
+	if mediaTypeAware, ok := b.(blob.MediaTypeAware); ok {
+		if mediaType, ok = mediaTypeAware.MediaType(); ok {
+			if isGzip := mediaType == MediaTypeGzip || strings.HasSuffix(mediaType, MediaTypeGzipSuffix); isGzip {
+				method = MethodGzip
+				if mediaType == MediaTypeGzip {
+					mediaType = "application/octet-stream"
+				}
+				mediaType = strings.TrimSuffix(mediaType, MediaTypeGzipSuffix)
+			}
+		}
+	}
+	if method == "" {
+		// we can return the data as is because it is not knowingly compressed
+		return b, nil
+	}
+	return &DecompressedBlob{
+		ReadOnlyBlob:      b,
+		compressionMethod: method,
+		mediaType:         mediaType,
+	}, nil
+}
+
+// DecompressedBlob represents a blob that has been decompressed from its original compressed form.
+// It wraps the original compressed blob and provides transparent access to the decompressed data.
+type DecompressedBlob struct {
+	blob.ReadOnlyBlob
+	compressionMethod Method
+	mediaType         string
+}
+
+// MediaType returns the media type of the decompressed blob.
+// For GZIP compressed blobs, it removes the "+gzip" suffix or changes "application/gzip"
+// to "application/octet-stream" to indicate the decompressed content type.
+func (d *DecompressedBlob) MediaType() (string, bool) {
+	return d.mediaType, true
+}
+
+// ReadCloser returns an io.ReadCloser that provides access to the decompressed blob data.
+// The returned reader will automatically decompress the data from the base blob using
+// the appropriate decompression method. The caller is responsible for closing the returned ReadCloser.
+//
+// Returns:
+//   - An io.ReadCloser that provides access to the decompressed data
+//   - An error if the decompression fails or if the compressed data cannot be read
+func (d *DecompressedBlob) ReadCloser() (io.ReadCloser, error) {
+	data, err := d.ReadOnlyBlob.ReadCloser()
+	if err != nil {
+		return nil, fmt.Errorf("error reading compressed blob: %w", err)
+	}
+
+	var decompressed io.ReadCloser
+
+	switch d.compressionMethod {
+	case MethodGzip:
+		fallthrough
+	default:
+		gzReader, err := gzip.NewReader(data)
+		if err != nil {
+			return nil, fmt.Errorf("error creating gzip reader: %w", err)
+		}
+		decompressed = gzReader
+	}
+
+	return struct {
+		io.Reader
+		io.Closer
+	}{
+		Reader: decompressed,
+		Closer: closerFunc(func() error {
+			return errors.Join(decompressed.Close(), data.Close())
+		}),
+	}, nil
+}
+
+type closerFunc func() error
+
+func (f closerFunc) Close() error {
+	return f()
+}

--- a/bindings/go/blob/compression/blob_test.go
+++ b/bindings/go/blob/compression/blob_test.go
@@ -1,0 +1,180 @@
+package compression_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"ocm.software/open-component-model/bindings/go/blob"
+	"ocm.software/open-component-model/bindings/go/blob/compression"
+)
+
+type testBlob struct {
+	data []byte
+	err  error
+}
+
+func (b *testBlob) ReadCloser() (io.ReadCloser, error) {
+	if b.err != nil {
+		return nil, b.err
+	}
+	return io.NopCloser(bytes.NewReader(b.data)), nil
+}
+
+func TestCompressedBlob(t *testing.T) {
+	t.Run("successful compression and decompression", func(t *testing.T) {
+		r := require.New(t)
+		a := assert.New(t)
+		// Create test data
+		testData := []byte("Hello, this is a test string for compression!")
+
+		// Create a simple read-only blob
+		baseBlob := &testBlob{data: testData}
+
+		// Create compressed blob
+		compressedBlob := compression.Compress(baseBlob)
+
+		// GetFor the compressed reader
+		rc, err := compressedBlob.ReadCloser()
+		r.NoError(err)
+		t.Cleanup(func() { r.NoError(rc.Close()) })
+
+		// Read and decompress the data
+		gzReader, err := gzip.NewReader(rc)
+		r.NoError(err)
+		t.Cleanup(func() { r.NoError(gzReader.Close()) })
+
+		// Read the decompressed data
+		decompressedData, err := io.ReadAll(gzReader)
+		r.NoError(err)
+
+		// Verify the decompressed data matches the original
+		a.Equal(testData, decompressedData)
+
+		// Verify media type
+		mediaType, known := compressedBlob.MediaType()
+		a.True(known)
+		a.Equal("application/gzip", mediaType)
+
+		t.Run("decompressed blob", func(t *testing.T) {
+			a := assert.New(t)
+			decompressedBlob, err := compression.Decompress(compressedBlob)
+			a.NoError(err)
+			a.IsType(&compression.DecompressedBlob{}, decompressedBlob)
+			mediaType, ok := decompressedBlob.(blob.MediaTypeAware).MediaType()
+			a.True(ok)
+			a.Equal("application/octet-stream", mediaType)
+
+			drc, err := decompressedBlob.ReadCloser()
+			a.NoError(err)
+			t.Cleanup(func() { r.NoError(drc.Close()) })
+			decompressedData, err = io.ReadAll(drc)
+			r.NoError(err)
+			r.Equal(testData, decompressedData)
+		})
+	})
+
+	t.Run("error from base blob", func(t *testing.T) {
+		// Create a blob that returns an error
+		expectedErr := errors.New("test error")
+		baseBlob := &testBlob{err: expectedErr}
+
+		// Create compressed blob
+		compressedBlob := compression.Compress(baseBlob)
+
+		// Attempt to get reader
+		rc, err := compressedBlob.ReadCloser()
+		assert.ErrorIs(t, err, expectedErr)
+		assert.Nil(t, rc)
+	})
+
+	t.Run("empty blob", func(t *testing.T) {
+		r := require.New(t)
+		// Create an empty blob
+		baseBlob := &testBlob{data: []byte{}}
+
+		// Create compressed blob
+		compressedBlob := compression.Compress(baseBlob)
+
+		// GetFor the compressed reader
+		rc, err := compressedBlob.ReadCloser()
+		r.NoError(err)
+		t.Cleanup(func() { r.NoError(rc.Close()) })
+
+		// Read and decompress the data
+		gzReader, err := gzip.NewReader(rc)
+		r.NoError(err)
+		t.Cleanup(func() { r.NoError(gzReader.Close()) })
+
+		// Read the decompressed data
+		decompressedData, err := io.ReadAll(gzReader)
+		r.NoError(err)
+
+		// Verify empty data
+		assert.Empty(t, decompressedData)
+	})
+
+	t.Run("media type handling", func(t *testing.T) {
+		r := require.New(t)
+		a := assert.New(t)
+
+		// Test with custom media type
+		baseBlob := &testBlob{data: []byte("test")}
+		compressedBlob := compression.Compress(baseBlob)
+
+		// Test media type for compressed blob
+		mediaType, known := compressedBlob.MediaType()
+		a.True(known)
+		a.Equal("application/gzip", mediaType)
+
+		// Test decompression with custom media type
+		decompressedBlob, err := compression.Decompress(compressedBlob)
+		r.NoError(err)
+		mediaType, known = decompressedBlob.(blob.MediaTypeAware).MediaType()
+		a.True(known)
+		a.Equal("application/octet-stream", mediaType)
+	})
+
+	t.Run("decompression error handling", func(t *testing.T) {
+		r := require.New(t)
+		a := assert.New(t)
+
+		// Test with invalid gzip data
+		nogzip := []byte("not a valid gzip stream")
+		baseBlob := &testBlob{data: nogzip}
+		compressedBlob := compression.Compress(baseBlob)
+
+		// Try to decompress
+		decompressedBlob, err := compression.Decompress(compressedBlob)
+		r.NoError(err) // Decompression should succeed initially
+
+		// Reading should be transparent
+		rc, err := decompressedBlob.ReadCloser()
+		r.NoError(err)
+		t.Cleanup(func() { r.NoError(rc.Close()) })
+
+		data, err := io.ReadAll(rc)
+		a.NoError(err)
+		a.Equal(nogzip, data)
+	})
+
+	t.Run("decompress non-compressed blob", func(t *testing.T) {
+		r := require.New(t)
+		a := assert.New(t)
+
+		// Create a non-compressed blob
+		baseBlob := &testBlob{data: []byte("test")}
+
+		// Try to decompress
+		decompressedBlob, err := compression.Decompress(baseBlob)
+		r.NoError(err)
+
+		// Should return the original blob
+		a.Equal(baseBlob, decompressedBlob)
+	})
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

adds a library set of functions to the blob package that allows for transparently compressed or decompressed blobs. currently only gzip is implemented

useful if one wants to work with transparently compressed / non-compressed content (e.g. a file that automatically should be compressed like the file input type)

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
needed for https://github.com/open-component-model/ocm-project/issues/460
