### PR TITLE
fix: ensure that for single layer artifacts, we fetch the blob directly

### DIFF
--- a/bindings/go/oci/integration/integration_test.go
+++ b/bindings/go/oci/integration/integration_test.go
@@ -559,14 +559,10 @@ func uploadDownloadLocalResource(t *testing.T, repo oci.ComponentVersionReposito
 	r.NoError(err)
 	r.Equal(resFromGet.ElementMeta, newRes.ElementMeta)
 
-	store, err := tar.ReadOCILayout(t.Context(), downloadedBlob)
-	r.NoError(err)
-	t.Cleanup(func() {
-		r.NoError(store.Close())
-	})
-	r.NotNil(store)
-	r.Len(store.Index.Manifests, 1)
+	var data bytes.Buffer
+	r.NoError(blob.Copy(&data, downloadedBlob))
 
+	r.Equal(testData, data.Bytes())
 }
 
 func getUserAndPasswordWithGitHubCLIAndJQ(t *testing.T) (string, string) {

--- a/bindings/go/oci/internal/fetch/fetch.go
+++ b/bindings/go/oci/internal/fetch/fetch.go
@@ -1,0 +1,146 @@
+// Package fetch provides core functionality for retrieving OCI artifacts and their contents.
+// It handles the low-level operations of fetching manifests, layers, and blobs from OCI registries.
+package fetch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2"
+
+	"ocm.software/open-component-model/bindings/go/blob"
+	ociblob "ocm.software/open-component-model/bindings/go/oci/blob"
+	"ocm.software/open-component-model/bindings/go/oci/spec/annotations"
+)
+
+// LocalBlob represents a content-addressable piece of data stored in an OCI repository.
+// It provides a unified interface for accessing both the content and metadata of OCI blobs.
+type LocalBlob interface {
+	blob.ReadOnlyBlob
+	blob.SizeAware
+	blob.DigestAware
+	blob.MediaTypeAware
+}
+
+// SingleLayerLocalBlobFromManifestByIdentity finds and retrieves a specific layer from an OCI manifest
+// based on its identity annotations. This is useful for extracting specific resources from OCI artifacts.
+//
+// Parameters:
+//   - ctx: Context for the operation
+//   - store: The OCI store to fetch from
+//   - manifest: The OCI manifest containing the layers
+//   - identity: Map of annotations used to identify the desired layer
+//
+// Returns:
+//   - A LocalBlob representing the matching layer
+//   - An error if the layer cannot be found or fetched
+func SingleLayerLocalBlobFromManifestByIdentity(ctx context.Context, store oras.ReadOnlyTarget, manifest *ociImageSpecV1.Manifest, identity map[string]string) (LocalBlob, error) {
+	layer, err := annotations.FilterFirstMatchingArtifact(manifest.Layers, identity, annotations.ArtifactKindResource)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find matching layer: %w", err)
+	}
+	data, err := store.Fetch(ctx, layer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch layer data: %w", err)
+	}
+	if data == nil {
+		return nil, fmt.Errorf("received nil data for layer %s", layer.Digest)
+	}
+	return ociblob.NewDescriptorBlob(data, layer), nil
+}
+
+// SingleLayerManifestBlobFromIndex locates a specific manifest in an OCI index and retrieves its first layer.
+// This is commonly used to access the primary content of a multi-arch OCI artifact.
+//
+// Parameters:
+//   - ctx: Context for the operation
+//   - store: The OCI store to fetch from
+//   - index: The OCI index containing the manifests
+//   - identity: Map of annotations used to identify the desired manifest
+//
+// Returns:
+//   - A LocalBlob representing the first layer of the matching manifest
+//   - An error if the manifest cannot be found or its layer cannot be fetched
+func SingleLayerManifestBlobFromIndex(ctx context.Context, store oras.ReadOnlyTarget, index *ociImageSpecV1.Index, identity map[string]string) (LocalBlob, error) {
+	manifestDesc, err := annotations.FilterFirstMatchingArtifact(index.Manifests, identity, annotations.ArtifactKindResource)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find matching layer: %w", err)
+	}
+	return SingleLayerManifestBlobFromManifestDescriptor(ctx, store, manifestDesc)
+}
+
+// SingleLayerManifestBlobFromManifestDescriptor retrieves the primary content layer from a manifest.
+// This is the standard way to access the main content of an OCI artifact.
+//
+// Parameters:
+//   - ctx: Context for the operation
+//   - store: The OCI store to fetch from
+//   - manifestDesc: The descriptor of the manifest to fetch
+//
+// Returns:
+//   - A LocalBlob representing the first layer of the manifest
+//   - An error if the manifest or its layer cannot be fetched
+func SingleLayerManifestBlobFromManifestDescriptor(ctx context.Context, store oras.ReadOnlyTarget, manifestDesc ociImageSpecV1.Descriptor) (LocalBlob, error) {
+	manifest, err := Manifest(ctx, store, manifestDesc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch manifest data: %w", err)
+	}
+	layerDesc, err := LayerFromManifest(manifest, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch layer data: %w", err)
+	}
+	layerData, err := store.Fetch(ctx, layerDesc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch layer data: %w", err)
+	}
+
+	return ociblob.NewDescriptorBlob(layerData, layerDesc), nil
+}
+
+// LayerFromManifest provides access to a specific layer within an OCI manifest.
+// It handles validation of layer indices and ensures safe access to manifest contents.
+//
+// Parameters:
+//   - manifest: The OCI manifest containing the layers
+//   - layer: The index of the layer to retrieve (0-based)
+//
+// Returns:
+//   - The descriptor of the requested layer
+//   - An error if the layer index is invalid or the manifest has no layers
+func LayerFromManifest(manifest ociImageSpecV1.Manifest, layer int) (ociImageSpecV1.Descriptor, error) {
+	if len(manifest.Layers) == 0 {
+		return ociImageSpecV1.Descriptor{}, fmt.Errorf("manifest has no layers and cannot be used to get a local blob")
+	}
+	if layer >= len(manifest.Layers) || layer < 0 {
+		return ociImageSpecV1.Descriptor{}, fmt.Errorf("layer at index %d does not exist in manifest (%d layers in total)", layer, len(manifest.Layers))
+	}
+	return manifest.Layers[layer], nil
+}
+
+// Manifest decodes an OCI manifest from its descriptor.
+// This is the entry point for accessing the structure and contents of an OCI artifact.
+//
+// Parameters:
+//   - ctx: Context for the operation
+//   - store: The OCI store to fetch from
+//   - desc: The descriptor of the manifest to fetch
+//
+// Returns:
+//   - The decoded OCI manifest
+//   - An error if the manifest cannot be fetched or decoded
+func Manifest(ctx context.Context, store oras.ReadOnlyTarget, desc ociImageSpecV1.Descriptor) (ociImageSpecV1.Manifest, error) {
+	data, err := store.Fetch(ctx, desc)
+	if err != nil {
+		return ociImageSpecV1.Manifest{}, fmt.Errorf("failed to fetch layer data: %w", err)
+	}
+	defer func() {
+		_ = data.Close()
+	}()
+	manifest := ociImageSpecV1.Manifest{}
+	if err := json.NewDecoder(data).Decode(&manifest); err != nil {
+		return ociImageSpecV1.Manifest{}, fmt.Errorf("failed to decode manifest: %w", err)
+	}
+	return manifest, nil
+}

--- a/bindings/go/oci/internal/fetch/fetch_test.go
+++ b/bindings/go/oci/internal/fetch/fetch_test.go
@@ -1,0 +1,210 @@
+package fetch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/content/memory"
+
+	"ocm.software/open-component-model/bindings/go/oci/spec/annotations"
+)
+
+func TestSingleLayerLocalBlobFromManifestByIdentity(t *testing.T) {
+	ctx := context.Background()
+	store := memory.New()
+
+	// Create a test manifest with a single layer
+	layerContent := []byte("test layer content")
+	layerDigest := digest.FromBytes(layerContent)
+	manifest := &ociImageSpecV1.Manifest{
+		Layers: []ociImageSpecV1.Descriptor{
+			{
+				MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+				Digest:    layerDigest,
+				Size:      int64(len(layerContent)),
+				Annotations: map[string]string{
+					annotations.ArtifactAnnotationKey: `[{"kind": "resource", "identity": {"test": "value"}}]`,
+				},
+			},
+		},
+	}
+
+	// Store the layer content
+	err := store.Push(ctx, manifest.Layers[0], bytes.NewReader(layerContent))
+	require.NoError(t, err)
+
+	// Store the manifest
+	manifestBytes, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	manifestDigest := digest.FromBytes(manifestBytes)
+	manifestDesc := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageManifest,
+		Digest:    manifestDigest,
+		Size:      int64(len(manifestBytes)),
+	}
+	err = store.Push(ctx, manifestDesc, bytes.NewReader(manifestBytes))
+	require.NoError(t, err)
+
+	// Test successful case
+	identity := map[string]string{
+		"test": "value",
+	}
+	blob, err := SingleLayerLocalBlobFromManifestByIdentity(ctx, store, manifest, identity)
+	require.NoError(t, err)
+	assert.NotNil(t, blob)
+	digest, _ := blob.Digest()
+	assert.Equal(t, layerDigest.String(), digest)
+	size := blob.Size()
+	assert.Equal(t, int64(len(layerContent)), size)
+	mediaType, _ := blob.MediaType()
+	assert.Equal(t, "application/vnd.oci.image.layer.v1.tar+gzip", mediaType)
+
+	// Test case where no matching layer is found
+	identity = map[string]string{
+		"nonexistent": "value",
+	}
+	_, err = SingleLayerLocalBlobFromManifestByIdentity(ctx, store, manifest, identity)
+	assert.Error(t, err)
+}
+
+func TestSingleLayerManifestBlobFromIndex(t *testing.T) {
+	ctx := context.Background()
+	store := memory.New()
+
+	// Create a test manifest
+	layerContent := []byte("test layer content")
+	layerDigest := digest.FromBytes(layerContent)
+	manifest := ociImageSpecV1.Manifest{
+		Layers: []ociImageSpecV1.Descriptor{
+			{
+				MediaType: "application/vnd.oci.image.layer.v1.tar+gzip",
+				Digest:    layerDigest,
+				Size:      int64(len(layerContent)),
+			},
+		},
+	}
+
+	// Store the layer content
+	err := store.Push(ctx, manifest.Layers[0], bytes.NewReader(layerContent))
+	require.NoError(t, err)
+
+	// Store the manifest
+	manifestBytes, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	manifestDigest := digest.FromBytes(manifestBytes)
+	manifestDesc := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageManifest,
+		Digest:    manifestDigest,
+		Size:      int64(len(manifestBytes)),
+		Annotations: map[string]string{
+			annotations.ArtifactAnnotationKey: `[{"kind": "resource", "identity": {"test": "value"}}]`,
+		},
+	}
+	err = store.Push(ctx, manifestDesc, bytes.NewReader(manifestBytes))
+	require.NoError(t, err)
+
+	// Create a test index
+	index := &ociImageSpecV1.Index{
+		Manifests: []ociImageSpecV1.Descriptor{manifestDesc},
+	}
+	indexBytes, err := json.Marshal(index)
+	require.NoError(t, err)
+	indexDigest := digest.FromBytes(indexBytes)
+	indexDesc := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageIndex,
+		Digest:    indexDigest,
+		Size:      int64(len(indexBytes)),
+	}
+	err = store.Push(ctx, indexDesc, bytes.NewReader(indexBytes))
+	require.NoError(t, err)
+
+	// Test successful case
+	identity := map[string]string{
+		"test": "value",
+	}
+	blob, err := SingleLayerManifestBlobFromIndex(ctx, store, index, identity)
+	require.NoError(t, err)
+	assert.NotNil(t, blob)
+
+	// Test case where no matching manifest is found
+	identity = map[string]string{
+		"nonexistent": "value",
+	}
+	_, err = SingleLayerManifestBlobFromIndex(ctx, store, index, identity)
+	assert.Error(t, err)
+}
+
+func TestLayerFromManifest(t *testing.T) {
+	manifest := ociImageSpecV1.Manifest{
+		Layers: []ociImageSpecV1.Descriptor{
+			{
+				MediaType: "layer1",
+				Digest:    digest.Digest("sha256:123"),
+			},
+			{
+				MediaType: "layer2",
+				Digest:    digest.Digest("sha256:456"),
+			},
+		},
+	}
+
+	// Test successful case
+	desc, err := LayerFromManifest(manifest, 0)
+	require.NoError(t, err)
+	assert.Equal(t, "layer1", desc.MediaType)
+	assert.Equal(t, "sha256:123", desc.Digest.String())
+
+	// Test out of bounds case
+	_, err = LayerFromManifest(manifest, 2)
+	assert.Error(t, err)
+
+	// Test empty manifest case
+	emptyManifest := ociImageSpecV1.Manifest{}
+	_, err = LayerFromManifest(emptyManifest, 0)
+	assert.Error(t, err)
+}
+
+func TestManifest(t *testing.T) {
+	ctx := context.Background()
+	store := memory.New()
+
+	// Create a test manifest
+	testManifest := ociImageSpecV1.Manifest{
+		Config: ociImageSpecV1.Descriptor{
+			MediaType: "config",
+			Digest:    digest.Digest("sha256:config123"),
+		},
+		Layers: []ociImageSpecV1.Descriptor{
+			{
+				MediaType: "layer1",
+				Digest:    digest.Digest("sha256:123"),
+			},
+		},
+	}
+
+	// Store the manifest
+	manifestBytes, err := json.Marshal(testManifest)
+	require.NoError(t, err)
+	manifestDigest := digest.FromBytes(manifestBytes)
+	desc := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageManifest,
+		Digest:    manifestDigest,
+		Size:      int64(len(manifestBytes)),
+	}
+	err = store.Push(ctx, desc, bytes.NewReader(manifestBytes))
+	require.NoError(t, err)
+
+	// Test successful case
+	manifest, err := Manifest(ctx, store, desc)
+	require.NoError(t, err)
+	assert.Equal(t, "config", manifest.Config.MediaType)
+	assert.Equal(t, "sha256:config123", manifest.Config.Digest.String())
+	assert.Len(t, manifest.Layers, 1)
+	assert.Equal(t, "layer1", manifest.Layers[0].MediaType)
+}

--- a/bindings/go/oci/internal/pack/pack.go
+++ b/bindings/go/oci/internal/pack/pack.go
@@ -25,6 +25,11 @@ import (
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
+// AnnotationSingleLayerArtifact is the annotation key used to identify single-layer artifacts.
+// If set, it contains the digest of the single layer packaged within the manifest.
+// It is set on the manifest and not on the layer itself.
+const AnnotationSingleLayerArtifact = "software.ocm.artifact.singlelayer"
+
 // LocalResourceAdoptionMode defines how local resources should be accessed in the repository.
 type LocalResourceAdoptionMode int
 
@@ -117,6 +122,7 @@ func ResourceLocalBlobOCISingleLayerArtifact(ctx context.Context, storage conten
 
 	annotations := maps.Clone(layer.Annotations)
 	maps.Copy(annotations, opts.ManifestAnnotations)
+	annotations[AnnotationSingleLayerArtifact] = layer.Digest.String()
 
 	desc, err := oras.PackManifest(ctx, storage, oras.PackManifestVersion1_1, access.MediaType, oras.PackManifestOptions{
 		Layers:              []ociImageSpecV1.Descriptor{layer},

--- a/bindings/go/oci/repository.go
+++ b/bindings/go/oci/repository.go
@@ -22,6 +22,7 @@ import (
 	v2 "ocm.software/open-component-model/bindings/go/descriptor/v2"
 	ociblob "ocm.software/open-component-model/bindings/go/oci/blob"
 	"ocm.software/open-component-model/bindings/go/oci/cache"
+	"ocm.software/open-component-model/bindings/go/oci/internal/fetch"
 	"ocm.software/open-component-model/bindings/go/oci/internal/lister"
 	complister "ocm.software/open-component-model/bindings/go/oci/internal/lister/component"
 	"ocm.software/open-component-model/bindings/go/oci/internal/log"
@@ -33,19 +34,13 @@ import (
 	descriptor2 "ocm.software/open-component-model/bindings/go/oci/spec/descriptor"
 	digestv1 "ocm.software/open-component-model/bindings/go/oci/spec/digest/v1"
 	indexv1 "ocm.software/open-component-model/bindings/go/oci/spec/index/component/v1"
-	"ocm.software/open-component-model/bindings/go/oci/spec/layout"
 	"ocm.software/open-component-model/bindings/go/oci/tar"
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
 // LocalBlob represents a blob that is stored locally in the OCI repository.
 // It provides methods to access the blob's metadata and content.
-type LocalBlob interface {
-	blob.ReadOnlyBlob
-	blob.SizeAware
-	blob.DigestAware
-	blob.MediaTypeAware
-}
+type LocalBlob fetch.LocalBlob
 
 // ComponentVersionRepository defines the interface for storing and retrieving OCM component versions
 // and their associated resources in a Store.
@@ -171,7 +166,7 @@ func (repo *Repository) AddComponentVersion(ctx context.Context, descriptor *des
 		return err
 	}
 
-	manifest, err := addDescriptorToStore(ctx, store, descriptor, storeDescriptorOptions{
+	manifest, err := AddDescriptorToStore(ctx, store, descriptor, AddDescriptorOptions{
 		Scheme:                        repo.scheme,
 		Author:                        repo.creatorAnnotation,
 		AdditionalDescriptorManifests: repo.localResourceManifestCache.Get(reference),
@@ -317,42 +312,51 @@ func (repo *Repository) GetLocalResource(ctx context.Context, component, version
 
 	switch typed := typed.(type) {
 	case *v2.LocalBlob:
-		if index == nil {
-			// if the index does not exist, we can only use the manifest
-			// and thus local blobs can only be available as image layers
-			b, err := getLocalBlob(ctx, manifest, identity, store)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to get local blob from manifest: %w", err)
-			}
-			return b, &resource, nil
-		}
-
-		// if the index exists, we can use it to find certain media types that are compatible with
-		// oci repositories.
-		switch typed.MediaType {
-		// for local blobs that are complete image layouts, we can directly push them as part of the
-		// descriptor index
-		case layout.MediaTypeOCIImageLayoutV1 + "+tar", layout.MediaTypeOCIImageLayoutV1 + "+tar+gzip", ociImageSpecV1.MediaTypeImageIndex, ociImageSpecV1.MediaTypeImageManifest:
-			artifact, err := annotations.FilterFirstMatchingArtifact(index.Manifests, identity, annotations.ArtifactKindResource)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to find matching descriptor: %w", err)
-			}
-			b, err := repo.generateOCILayout(ctx, &resource, store, artifact)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to get local blob from discovered image layout: %w", err)
-			}
-			return b, &resource, nil
-		// for anything else we cannot really do anything other than use a local blob
-		default:
-			b, err := getSingleLayerManifestBlob(ctx, index, identity, store)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to get local blob from single layer manifest: %w", err)
-			}
-			return b, &resource, nil
-		}
+		return repo.getLocalBlobResource(ctx, store, index, manifest, resource, typed, identity)
 	default:
 		return nil, nil, fmt.Errorf("unsupported resource access type: %T", typed)
 	}
+}
+
+func (repo *Repository) getLocalBlobResource(ctx context.Context, store spec.Store, index *ociImageSpecV1.Index, manifest *ociImageSpecV1.Manifest, resource descriptor.Resource, typed *v2.LocalBlob, identity runtime.Identity) (LocalBlob, *descriptor.Resource, error) {
+	// if the index does not exist, we can only use the manifest
+	// and thus local blobs can only be available as image layers
+	if index == nil {
+		b, err := fetch.SingleLayerLocalBlobFromManifestByIdentity(ctx, store, manifest, identity)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get local blob from manifest: %w", err)
+		}
+		return b, &resource, nil
+	}
+
+	artifact, err := annotations.FilterFirstMatchingArtifact(index.Manifests, identity, annotations.ArtifactKindResource)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to find matching descriptor: %w", err)
+	}
+
+	// if we are a single layer OCM style Artifact, we can assume that we only care about a single layer
+	// that means we can just return the blob that contains that exact layer and not the entire oci layout
+	if expectedSingleLayerDigest, ok := asOCMSingleLayerArtifact(artifact); ok {
+		// Validate the digest of the downloaded content matches what we expect
+		if err := validateDigest(&resource, artifact, ""); err != nil {
+			return nil, nil, fmt.Errorf("failed to validate digest: %w", err)
+		}
+		b, err := fetch.SingleLayerManifestBlobFromManifestDescriptor(ctx, store, artifact)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get local blob from single layer manifest: %w", err)
+		}
+		if actualDigest, _ := b.Digest(); actualDigest != expectedSingleLayerDigest {
+			return nil, nil, fmt.Errorf("expected single layer artifact digest %q but got %q", expectedSingleLayerDigest, actualDigest)
+		}
+		return b, &resource, nil
+	}
+
+	// if we dont have a single layer we have to copy not only the manifest or index, but all layers that are part of it!
+	b, err := generateOCILayout(ctx, &resource, store, artifact, repo.resourceCopyOptions.CopyGraphOptions)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get local blob from discovered image layout: %w", err)
+	}
+	return b, &resource, nil
 }
 
 func (repo *Repository) getStore(ctx context.Context, component string, version string) (ref string, store spec.Store, err error) {
@@ -487,23 +491,37 @@ func (repo *Repository) DownloadResource(ctx context.Context, res *descriptor.Re
 			return nil, fmt.Errorf("failed to resolve reference %q: %w", typed.ImageReference, err)
 		}
 
-		return repo.generateOCILayout(ctx, res, src, desc, typed.ImageReference)
+		return generateOCILayout(ctx, res, src, desc, repo.resourceCopyOptions.CopyGraphOptions, typed.ImageReference)
 	default:
 		return nil, fmt.Errorf("unsupported resource access type: %T", typed)
 	}
 }
 
 // generateOCILayout creates an OCI layout from a store for a given descriptor.
-func (repo *Repository) generateOCILayout(ctx context.Context, res *descriptor.Resource, src spec.Store, desc ociImageSpecV1.Descriptor, tags ...string) (_ LocalBlob, err error) {
+func generateOCILayout(ctx context.Context, res *descriptor.Resource, src spec.Store, desc ociImageSpecV1.Descriptor, copyOpts oras.CopyGraphOptions, tags ...string) (_ LocalBlob, err error) {
 	downloaded, err := tar.CopyToOCILayoutInMemory(ctx, src, desc, tar.CopyToOCILayoutOptions{
-		CopyGraphOptions: repo.resourceCopyOptions.CopyGraphOptions,
+		CopyGraphOptions: copyOpts,
 		Tags:             tags,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to copy to OCI layout: %w", err)
 	}
 
-	dig, ok := downloaded.Digest()
+	b, err := newValidatedResourceBlob(downloaded, res, desc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create validated resource blob from top level descriptor after copying OCI layout: %w", err)
+	}
+
+	return b, nil
+}
+
+func newValidatedResourceBlob(downloaded blob.ReadOnlyBlob, res *descriptor.Resource, desc ociImageSpecV1.Descriptor) (*ociblob.ResourceBlob, error) {
+	digestAware, ok := downloaded.(blob.DigestAware)
+	if !ok {
+		return nil, fmt.Errorf("downloaded blob does not implement digest awareness and cannot be validated")
+	}
+
+	dig, ok := digestAware.Digest()
 	if !ok {
 		return nil, fmt.Errorf("failed to get digest from downloaded blob")
 	}
@@ -517,9 +535,10 @@ func (repo *Repository) generateOCILayout(ctx context.Context, res *descriptor.R
 		return nil, fmt.Errorf("digest validation failed: %w", err)
 	}
 
-	res.Size = downloaded.Size()
-
 	dc := res.DeepCopy()
+	if sizeAware, ok := downloaded.(blob.SizeAware); ok {
+		dc.Size = sizeAware.Size()
+	}
 	dc.Digest = &descriptor.Digest{
 		NormalisationAlgorithm: "genericBlobDigest/v1",
 		HashAlgorithm:          digestv1.ReverseSHAMapping[blobDigest.Algorithm()],
@@ -529,7 +548,6 @@ func (repo *Repository) generateOCILayout(ctx context.Context, res *descriptor.R
 	if err != nil {
 		return nil, fmt.Errorf("failed to create resource blob from oci layout: %w", err)
 	}
-
 	return b, nil
 }
 
@@ -558,49 +576,6 @@ func validateDigest(res *descriptor.Resource, desc ociImageSpecV1.Descriptor, bl
 	}
 
 	return nil
-}
-
-func getSingleLayerManifestBlob(ctx context.Context, index *ociImageSpecV1.Index, identity map[string]string, store oras.ReadOnlyTarget) (LocalBlob, error) {
-	layer, err := annotations.FilterFirstMatchingArtifact(index.Manifests, identity, annotations.ArtifactKindResource)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find matching layer: %w", err)
-	}
-	data, err := store.Fetch(ctx, layer)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch layer data: %w", err)
-	}
-	defer func() {
-		_ = data.Close()
-	}()
-	manifest := ociImageSpecV1.Manifest{}
-	if err := json.NewDecoder(data).Decode(&manifest); err != nil {
-		return nil, fmt.Errorf("failed to decode manifest: %w", err)
-	}
-	if len(manifest.Layers) == 0 {
-		return nil, fmt.Errorf("manifest has no layers and cannot be used to get a local blob")
-	}
-	layer = manifest.Layers[0]
-	layerData, err := store.Fetch(ctx, layer)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch layer data: %w", err)
-	}
-
-	return ociblob.NewDescriptorBlob(layerData, layer), nil
-}
-
-func getLocalBlob(ctx context.Context, manifest *ociImageSpecV1.Manifest, identity map[string]string, store oras.ReadOnlyTarget) (LocalBlob, error) {
-	layer, err := annotations.FilterFirstMatchingArtifact(manifest.Layers, identity, annotations.ArtifactKindResource)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find matching layer: %w", err)
-	}
-	data, err := store.Fetch(ctx, layer)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch layer data: %w", err)
-	}
-	if data == nil {
-		return nil, fmt.Errorf("received nil data for layer %s", layer.Digest)
-	}
-	return ociblob.NewDescriptorBlob(data, layer), nil
 }
 
 // getDescriptorOCIImageManifest retrieves the manifest for a given reference from the store.
@@ -649,4 +624,12 @@ func getDescriptorOCIImageManifest(ctx context.Context, store spec.Store, refere
 		return ociImageSpecV1.Manifest{}, nil, err
 	}
 	return manifest, index, nil
+}
+
+func asOCMSingleLayerArtifact(artifact ociImageSpecV1.Descriptor) (dig string, ok bool) {
+	if artifact.Annotations == nil {
+		return "", false
+	}
+	dig, ok = artifact.Annotations[pack.AnnotationSingleLayerArtifact]
+	return
 }

--- a/bindings/go/oci/store_descriptor.go
+++ b/bindings/go/oci/store_descriptor.go
@@ -23,18 +23,19 @@ import (
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
-// storeDescriptorOptions defines the options for adding a component descriptor to a Store.
-type storeDescriptorOptions struct {
+// AddDescriptorOptions defines the options for adding a component descriptor to a Store.
+type AddDescriptorOptions struct {
 	Scheme                        *runtime.Scheme
 	Author                        string
 	AdditionalDescriptorManifests []ociImageSpecV1.Descriptor
+	AdditionalLayers              []ociImageSpecV1.Descriptor
 }
 
-// addDescriptorToStore uploads a component descriptor to any given Store.
+// AddDescriptorToStore uploads a component descriptor to any given Store.
 // The returned descriptor is the manifest descriptor of the uploaded component.
 // It can be used to retrieve the component descriptor later.
 // To persist the descriptor, the manifest still has to be tagged.
-func addDescriptorToStore(ctx context.Context, store spec.Store, descriptor *descriptor.Descriptor, opts storeDescriptorOptions) (*ociImageSpecV1.Descriptor, error) {
+func AddDescriptorToStore(ctx context.Context, store spec.Store, descriptor *descriptor.Descriptor, opts AddDescriptorOptions) (*ociImageSpecV1.Descriptor, error) {
 	component, version := descriptor.Component.Name, descriptor.Component.Version
 
 	// we can concurrently upload certain parts of the descriptor!
@@ -107,7 +108,7 @@ It is used to store the component descriptor in an OCI registry and can be refer
 			ociImageSpecV1.AnnotationSource:        "https://github.com/open-component-model/open-component-model",
 			ociImageSpecV1.AnnotationVersion:       version,
 		},
-		Layers:  []ociImageSpecV1.Descriptor{descriptorOCIDescriptor},
+		Layers:  append([]ociImageSpecV1.Descriptor{descriptorOCIDescriptor}, opts.AdditionalLayers...),
 		Subject: &indexv1.Descriptor,
 	}
 	manifestRaw, err := json.Marshal(manifest)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

when we encounter single layer artifacts that we recognize as such, we can shortcut and fetch the only layer present instead of returning them as OCI image manifests

however if we do not encounter single layer artifacts we can just copy them as oci layouts instead.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
makes sure the blob content when stored as single layer artifact is also received back as such. (see change in integration test)

also adds some tests for old component versions (like the old library implements)
