### PR TITLE
fix: make sure that CTFs do not write a global access into the local blob

### DIFF
--- a/bindings/go/oci/ctf/store_test.go
+++ b/bindings/go/oci/ctf/store_test.go
@@ -40,7 +40,7 @@ func TestStoreForReference(t *testing.T) {
 	s := NewFromCTF(ctf)
 	result, err := s.StoreForReference(t.Context(), "test:reference")
 	assert.NoError(t, err)
-	assert.Equal(t, "test", result.(*repositoryStore).repo)
+	assert.Equal(t, "test", result.(*Repository).repo)
 }
 
 func TestComponentVersionReference(t *testing.T) {
@@ -241,7 +241,7 @@ func TestFetchReference(t *testing.T) {
 	require.NoError(t, ctf.SetIndex(ctx, index))
 
 	t.Run("successful fetch reference", func(t *testing.T) {
-		desc, reader, err := store.(*repositoryStore).FetchReference(ctx, "test-tag")
+		desc, reader, err := store.(*Repository).FetchReference(ctx, "test-tag")
 		assert.NoError(t, err)
 		assert.NotNil(t, reader)
 		assert.Equal(t, ociImageSpecV1.MediaTypeImageManifest, desc.MediaType)
@@ -253,7 +253,7 @@ func TestFetchReference(t *testing.T) {
 	})
 
 	t.Run("fetch reference not found", func(t *testing.T) {
-		desc, reader, err := store.(*repositoryStore).FetchReference(ctx, "nonexistent-tag")
+		desc, reader, err := store.(*Repository).FetchReference(ctx, "nonexistent-tag")
 		assert.Error(t, err)
 		assert.Nil(t, reader)
 		assert.Empty(t, desc)
@@ -297,7 +297,7 @@ func TestTags(t *testing.T) {
 
 	t.Run("list tags for repository", func(t *testing.T) {
 		var tags []string
-		err := store.(*repositoryStore).Tags(ctx, "", func(t []string) error {
+		err := store.(*Repository).Tags(ctx, "", func(t []string) error {
 			tags = t
 			return nil
 		})


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Currently local resources added into a CV return a resource that has the globalAccess field set always. However, because CTFs are local archives that global reference contains the virtual `ctf.ocm.software` address as a reference which is not global. That means we should ONLY write the global access if we are working in a remote repository, otherwise we should only write the localBlob with its local reference (which can always be resolved if you know where the component version is).

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

During testing of component constructors I noticed my local blobs had incorrect global accesses in them that pointed to the virtual CTF domain, which is not correct.

I remove the image mode (which was not exposed as option anyways) and automatically deduce what to do based on the repository implementation underneath