### PR TITLE
fix: make sure that manifests are discovered always and set global access

### DIFF
--- a/bindings/go/oci/ctf/store.go
+++ b/bindings/go/oci/ctf/store.go
@@ -21,6 +21,7 @@ import (
 	v1 "ocm.software/open-component-model/bindings/go/ctf/index/v1"
 	"ocm.software/open-component-model/bindings/go/oci"
 	ociblob "ocm.software/open-component-model/bindings/go/oci/blob"
+	"ocm.software/open-component-model/bindings/go/oci/internal/introspection"
 	"ocm.software/open-component-model/bindings/go/oci/internal/looseref"
 	"ocm.software/open-component-model/bindings/go/oci/spec"
 )
@@ -125,7 +126,7 @@ func (s *Repository) Push(ctx context.Context, expected ociImageSpecV1.Descripto
 	if err := s.archive.SaveBlob(ctx, ociblob.NewDescriptorBlob(io.NopCloser(data), expected)); err != nil {
 		return fmt.Errorf("unable to save blob for descriptor %v: %w", expected, err)
 	}
-	if isManifest(expected) {
+	if introspection.IsOCICompliantManifest(expected) {
 		if err := s.Tag(ctx, expected, expected.Digest.String()); err != nil {
 			return fmt.Errorf("unable to save manifest for descriptor %v: %w", expected, err)
 		}
@@ -286,14 +287,4 @@ func addOrUpdateArtifactMetadataInIndex(idx v1.Index, meta v1.ArtifactMetadata) 
 	}
 
 	idx.AddArtifact(meta)
-}
-
-func isManifest(desc ociImageSpecV1.Descriptor) bool {
-	switch desc.MediaType {
-	case ociImageSpecV1.MediaTypeImageManifest,
-		ociImageSpecV1.MediaTypeImageIndex:
-		return true
-	default:
-		return false
-	}
 }

--- a/bindings/go/oci/internal/introspection/manifest.go
+++ b/bindings/go/oci/internal/introspection/manifest.go
@@ -1,0 +1,18 @@
+package introspection
+
+import (
+	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// IsOCICompliantManifest checks if a descriptor describes a manifest that is recognizable by OCI.
+func IsOCICompliantManifest(desc ociImageSpecV1.Descriptor) bool {
+	switch desc.MediaType {
+	// TODO(jakobmoellerdev): currently only Image Indexes and OCI manifests are supported,
+	//  but we may want to extend this down the line with additional media types such as docker manifests.
+	case ociImageSpecV1.MediaTypeImageManifest,
+		ociImageSpecV1.MediaTypeImageIndex:
+		return true
+	default:
+		return false
+	}
+}

--- a/bindings/go/oci/internal/introspection/manifest_test.go
+++ b/bindings/go/oci/internal/introspection/manifest_test.go
@@ -1,0 +1,44 @@
+package introspection_test
+
+import (
+	"testing"
+
+	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+
+	"ocm.software/open-component-model/bindings/go/oci/internal/introspection"
+)
+
+func TestIsManifest(t *testing.T) {
+	tests := []struct {
+		name      string
+		mediaType string
+		expected  bool
+	}{
+		{
+			name:      "oci image manifest",
+			mediaType: ociImageSpecV1.MediaTypeImageManifest,
+			expected:  true,
+		},
+		{
+			name:      "oci image index",
+			mediaType: ociImageSpecV1.MediaTypeImageIndex,
+			expected:  true,
+		},
+		{
+			name:      "non-manifest media type",
+			mediaType: "application/octet-stream",
+			expected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			desc := ociImageSpecV1.Descriptor{
+				MediaType: tt.mediaType,
+			}
+			result := introspection.IsOCICompliantManifest(desc)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/bindings/go/oci/tar/oci_layout_tar_writer_test.go
+++ b/bindings/go/oci/tar/oci_layout_tar_writer_test.go
@@ -319,55 +319,6 @@ func TestBlobPath(t *testing.T) {
 	}
 }
 
-func TestIsManifest(t *testing.T) {
-	tests := []struct {
-		name      string
-		mediaType string
-		expected  bool
-	}{
-		{
-			name:      "docker manifest v2",
-			mediaType: "application/vnd.docker.distribution.manifest.v2+json",
-			expected:  true,
-		},
-		{
-			name:      "docker manifest list v2",
-			mediaType: "application/vnd.docker.distribution.manifest.list.v2+json",
-			expected:  true,
-		},
-		{
-			name:      "oci artifact manifest v1",
-			mediaType: "application/vnd.oci.artifact.manifest.v1+json",
-			expected:  true,
-		},
-		{
-			name:      "oci image manifest",
-			mediaType: ociImageSpecV1.MediaTypeImageManifest,
-			expected:  true,
-		},
-		{
-			name:      "oci image index",
-			mediaType: ociImageSpecV1.MediaTypeImageIndex,
-			expected:  true,
-		},
-		{
-			name:      "non-manifest media type",
-			mediaType: "application/octet-stream",
-			expected:  false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			desc := ociImageSpecV1.Descriptor{
-				MediaType: tt.mediaType,
-			}
-			result := isManifest(desc)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestMemoryResolver(t *testing.T) {
 	resolver := newMemoryResolver()
 	desc := ociImageSpecV1.Descriptor{


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

This makes it so that the global access is set to a layer if we have a non-manifest type, and an oci image if we do. This is because single layers are not full oci images so they should be references as oci image layers.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
