### PR TITLE
fix: oci logger formatting

### DIFF
--- a/bindings/go/oci/internal/log/logging_test.go
+++ b/bindings/go/oci/internal/log/logging_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"log/slog"
 	"testing"
-	"time"
 
 	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
@@ -21,19 +20,19 @@ func TestOperation(t *testing.T) {
 	var buf bytes.Buffer
 	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 		if a.Key == "time" {
-			return slog.Time("time", time.Time{})
+			return slog.Attr{}
 		}
 		return a
 	}})))
 
 	done := Operation(ctx, "test-operation", slog.String("test", "value"))
-	assert.Equal(t, "time=0001-01-01T00:00:00.000Z level=INFO msg=\"INFO starting operation realm=oci operation=test-operation test=value\"\n", buf.String())
+	assert.Equal(t, "level=INFO msg=\"operation starting\" realm=oci operation=test-operation test=value\n", buf.String())
 	buf.Reset()
 	done(nil) // No error
-	assert.Contains(t, buf.String(), "time=0001-01-01T00:00:00.000Z level=INFO msg=\"INFO operation completed realm=oci operation=test-operation test=value")
+	assert.Contains(t, buf.String(), "level=INFO msg=\"operation completed\" realm=oci operation=test-operation")
 	buf.Reset()
 	done(assert.AnError) // With error
-	assert.Contains(t, buf.String(), "time=0001-01-01T00:00:00.000Z level=INFO msg=\"ERROR operation failed realm=oci operation=test-operation test=value")
+	assert.Contains(t, buf.String(), "level=ERROR msg=\"operation failed\" realm=oci operation=test-operation")
 }
 
 func TestDescriptorLogAttr(t *testing.T) {

--- a/bindings/go/oci/repository.go
+++ b/bindings/go/oci/repository.go
@@ -305,7 +305,7 @@ func (repo *Repository) GetLocalResource(ctx context.Context, component, version
 		return nil, nil, fmt.Errorf("found %d candidates while looking for resource %q, but expected exactly one", len(candidates), identity)
 	}
 	resource := candidates[0]
-	log.Base.Info("found resource in descriptor", "resource", resource.ToIdentity())
+	log.Base().Info("found resource in descriptor", "resource", resource.ToIdentity())
 
 	if resource.Access.GetType().IsEmpty() {
 		return nil, nil, fmt.Errorf("resource access type is empty")
@@ -557,12 +557,12 @@ func validateDigest(res *descriptor.Resource, blobDigest digest.Digest) error {
 // getDescriptorOCIImageManifest retrieves the manifest for a given reference from the store.
 // It handles both OCI image indexes and OCI image manifests.
 func getDescriptorOCIImageManifest(ctx context.Context, store spec.Store, reference string) (manifest ociImageSpecV1.Manifest, index *ociImageSpecV1.Index, err error) {
-	log.Base.Log(ctx, slog.LevelInfo, "resolving descriptor", slog.String("reference", reference))
+	log.Base().Log(ctx, slog.LevelInfo, "resolving descriptor", slog.String("reference", reference))
 	base, err := store.Resolve(ctx, reference)
 	if err != nil {
 		return ociImageSpecV1.Manifest{}, nil, fmt.Errorf("failed to resolve reference %q: %w", reference, err)
 	}
-	log.Base.Log(ctx, slog.LevelInfo, "fetching descriptor", log.DescriptorLogAttr(base))
+	log.Base().Log(ctx, slog.LevelInfo, "fetching descriptor", log.DescriptorLogAttr(base))
 	manifestRaw, err := store.Fetch(ctx, ociImageSpecV1.Descriptor{
 		MediaType: base.MediaType,
 		Digest:    base.Digest,

--- a/bindings/go/oci/store_descriptor.go
+++ b/bindings/go/oci/store_descriptor.go
@@ -61,7 +61,7 @@ func AddDescriptorToStore(ctx context.Context, store spec.Store, descriptor *des
 	}
 
 	eg.Go(func() error {
-		log.Base.Log(egctx, slog.LevelDebug, "pushing component descriptor", log.DescriptorLogAttr(descriptorOCIDescriptor))
+		log.Base().Log(egctx, slog.LevelDebug, "pushing component descriptor", log.DescriptorLogAttr(descriptorOCIDescriptor))
 		if err := store.Push(egctx, descriptorOCIDescriptor, bytes.NewReader(descriptorBytes)); err != nil {
 			return fmt.Errorf("unable to push component descriptor: %w", err)
 		}
@@ -75,7 +75,7 @@ func AddDescriptorToStore(ctx context.Context, store spec.Store, descriptor *des
 	}
 
 	eg.Go(func() error {
-		log.Base.Log(egctx, slog.LevelDebug, "pushing component config", log.DescriptorLogAttr(componentConfigDescriptor))
+		log.Base().Log(egctx, slog.LevelDebug, "pushing component config", log.DescriptorLogAttr(componentConfigDescriptor))
 		if err := store.Push(egctx, componentConfigDescriptor, bytes.NewReader(componentConfigRaw)); err != nil {
 			return fmt.Errorf("unable to push component config: %w", err)
 		}
@@ -122,7 +122,7 @@ It is used to store the component descriptor in an OCI registry and can be refer
 		Size:         int64(len(manifestRaw)),
 		Annotations:  manifest.Annotations,
 	}
-	log.Base.Log(ctx, slog.LevelInfo, "pushing descriptor artifact manifest", log.DescriptorLogAttr(manifestDescriptor))
+	log.Base().Log(ctx, slog.LevelInfo, "pushing descriptor artifact manifest", log.DescriptorLogAttr(manifestDescriptor))
 	if err := store.Push(ctx, manifestDescriptor, bytes.NewReader(manifestRaw)); err != nil {
 		return nil, fmt.Errorf("unable to push manifest: %w", err)
 	}
@@ -169,7 +169,7 @@ It is used to store the component descriptor manifest and other related blob man
 		Size:        int64(len(idxRaw)),
 		Annotations: idx.Annotations,
 	}
-	log.Base.Log(ctx, slog.LevelInfo, "pushing descriptor artifact image index", log.DescriptorLogAttr(idxDescriptor))
+	log.Base().Log(ctx, slog.LevelInfo, "pushing descriptor artifact image index", log.DescriptorLogAttr(idxDescriptor))
 	if err := store.Push(ctx, idxDescriptor, bytes.NewReader(idxRaw)); err != nil {
 		return nil, fmt.Errorf("unable to push index: %w", err)
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

the oci Base and Operation logger were currently working incorrectly. The Base Logger didnt get updated when a new slog default logger was specified, and the Operation logger wrongly encapsulated the attributes causing double logged LEVELs and wrongly encoded messages.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
I fixed this behavior and adjusted the test, which even checked for the incorrect value (my bad ...)
