### PR TITLE
feat: inmemory cached blobs

### DIFF
--- a/bindings/go/blob/cache/inmemory/blob.go
+++ b/bindings/go/blob/cache/inmemory/blob.go
@@ -1,0 +1,191 @@
+// Package inmemory provides an in-memory caching implementation for blob storage.
+// It wraps a ReadOnlyBlob and caches its data in memory for efficient repeated access.
+package inmemory
+
+import (
+	"bytes"
+	"io"
+	"sync"
+
+	"github.com/opencontainers/go-digest"
+
+	"ocm.software/open-component-model/bindings/go/blob"
+)
+
+// Cache creates a new in-memory cached blob from a ReadOnlyBlob.
+// The returned blob will cache the data of the original blob in memory
+// for efficient repeated access.
+func Cache(b blob.ReadOnlyBlob) *Blob {
+	return &Blob{ReadOnlyBlob: b}
+}
+
+// Blob implements an in-memory caching wrapper around a ReadOnlyBlob.
+// It stores the blob's data in memory after the first read for efficient
+// subsequent access. The implementation is thread-safe.
+type Blob struct {
+	blob.ReadOnlyBlob
+	data []byte
+	mu   sync.RWMutex
+}
+
+// ReadCloser returns an io.ReadCloser that provides access to the blob's data.
+// The data is cached in memory after the first read for efficient subsequent access.
+func (c *Blob) ReadCloser() (io.ReadCloser, error) {
+	// If we have cached data, use it
+	if data := c.getData(); data != nil {
+		return io.NopCloser(bytes.NewReader(data)), nil
+	}
+
+	// Get a reader from the source
+	reader, err := c.ReadOnlyBlob.ReadCloser()
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	// Get size first
+	size := c.Size()
+	if size == blob.SizeUnknown {
+		// If size is unknown, fall back to ReadAll
+		data, err := io.ReadAll(reader)
+		if err != nil {
+			return nil, err
+		}
+		c.setData(data)
+		return io.NopCloser(bytes.NewReader(data)), nil
+	}
+
+	// Create buffer with exact size
+	buf := make([]byte, size)
+	if _, err = io.ReadFull(reader, buf); err != nil {
+		return nil, err
+	}
+	c.setData(buf)
+	return io.NopCloser(bytes.NewReader(buf)), nil
+}
+
+// Size returns the size of the blob in bytes.
+// If the size is unknown, it returns blob.SizeUnknown.
+func (c *Blob) Size() int64 {
+	// If we have cached data, use its length
+	if data := c.getData(); data != nil {
+		return int64(len(data))
+	}
+
+	// Try to get size from the source
+	if sizeAware, ok := c.ReadOnlyBlob.(blob.SizeAware); ok {
+		return sizeAware.Size()
+	}
+
+	return blob.SizeUnknown
+}
+
+// Digest calculates and returns the digest of the blob's data.
+// Returns the digest string and a boolean indicating if the digest was successfully computed.
+func (c *Blob) Digest() (string, bool) {
+	// If we have cached data, use it
+	if data := c.getData(); data != nil {
+		dig := digest.FromBytes(data)
+		return dig.String(), true
+	}
+
+	// For unknown size, we need to read the entire blob
+	reader, err := c.ReadOnlyBlob.ReadCloser()
+	if err != nil {
+		return "", false
+	}
+	defer reader.Close()
+
+	// Get size first
+	size := c.Size()
+	hasher := digest.Canonical.Digester()
+
+	if size != blob.SizeUnknown {
+		// If we know the size, use a buffer of exact size
+		buf := make([]byte, size)
+		teeReader := io.TeeReader(reader, hasher.Hash())
+		if _, err := io.ReadFull(teeReader, buf); err != nil {
+			return "", false
+		}
+		c.setData(buf)
+	} else {
+		// For unknown size, use a buffer to store the data
+		var buf bytes.Buffer
+		teeReader := io.TeeReader(reader, hasher.Hash())
+		if _, err := io.Copy(&buf, teeReader); err != nil {
+			return "", false
+		}
+		c.setData(buf.Bytes())
+	}
+
+	return hasher.Digest().String(), true
+}
+
+// MediaType returns the media type of the blob if it is available.
+// If the underlying blob implements MediaTypeAware, its media type is returned.
+// Otherwise, returns an empty string and false.
+func (c *Blob) MediaType() (mediaType string, known bool) {
+	if mediaTypeAware, ok := c.ReadOnlyBlob.(blob.MediaTypeAware); ok {
+		return mediaTypeAware.MediaType()
+	}
+	return "", false
+}
+
+// Data returns the complete data of the blob as a byte slice.
+// The data is cached in memory after the first read for efficient subsequent access.
+func (c *Blob) Data() ([]byte, error) {
+	// Try to get cached data first
+	if data := c.getData(); data != nil {
+		return data, nil
+	}
+
+	// Read and cache the data
+	reader, err := c.ReadOnlyBlob.ReadCloser()
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	// Get size first
+	size := c.Size()
+	if size == blob.SizeUnknown {
+		// If size is unknown, fall back to ReadAll
+		data, err := io.ReadAll(reader)
+		if err != nil {
+			return nil, err
+		}
+		c.setData(data)
+		return data, nil
+	}
+
+	// Create buffer with exact size
+	buf := make([]byte, size)
+	if _, err = io.ReadFull(reader, buf); err != nil {
+		return nil, err
+	}
+	c.setData(buf)
+	return buf, nil
+}
+
+// setData stores the blob's data in memory.
+// This method is thread-safe and should only be called internally.
+func (c *Blob) setData(data []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data = data
+}
+
+// getData retrieves the cached data of the blob.
+// This method is thread-safe and should only be called internally.
+func (c *Blob) getData() []byte {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.data
+}
+
+// ClearCache clears the cached data, freeing up memory.
+func (c *Blob) ClearCache() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data = nil
+}

--- a/bindings/go/blob/cache/inmemory/blob_test.go
+++ b/bindings/go/blob/cache/inmemory/blob_test.go
@@ -1,0 +1,466 @@
+package inmemory
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"ocm.software/open-component-model/bindings/go/blob"
+)
+
+type mockBlob struct {
+	data        []byte
+	mediaType   string
+	unknownSize bool
+}
+
+func (m *mockBlob) ReadCloser() (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(m.data)), nil
+}
+
+func (m *mockBlob) Size() int64 {
+	if m.unknownSize {
+		return blob.SizeUnknown
+	}
+	return int64(len(m.data))
+}
+
+func (m *mockBlob) MediaType() (string, bool) {
+	if m.mediaType != "" {
+		return m.mediaType, true
+	}
+	return "", false
+}
+
+func TestCache_ReadCloser(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        []byte
+		mediaType   string
+		unknownSize bool
+	}{
+		{
+			name:      "empty blob",
+			data:      []byte{},
+			mediaType: "",
+		},
+		{
+			name:      "small blob",
+			data:      []byte("hello"),
+			mediaType: "text/plain",
+		},
+		{
+			name:      "large blob",
+			data:      bytes.Repeat([]byte("x"), 1024*1024), // 1MB
+			mediaType: "application/octet-stream",
+		},
+		{
+			name:        "unknown size empty blob",
+			data:        []byte{},
+			mediaType:   "",
+			unknownSize: true,
+		},
+		{
+			name:        "unknown size small blob",
+			data:        []byte("hello"),
+			mediaType:   "text/plain",
+			unknownSize: true,
+		},
+		{
+			name:        "unknown size large blob",
+			data:        bytes.Repeat([]byte("x"), 1024*1024), // 1MB
+			mediaType:   "application/octet-stream",
+			unknownSize: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockBlob{
+				data:        tt.data,
+				mediaType:   tt.mediaType,
+				unknownSize: tt.unknownSize,
+			}
+
+			// Create cached blob
+			cached := Cache(mock)
+
+			// Test first read
+			reader, err := cached.ReadCloser()
+			require.NoError(t, err)
+			data, err := io.ReadAll(reader)
+			require.NoError(t, err)
+			assert.Equal(t, tt.data, data)
+
+			// Test second read (should use cache)
+			reader, err = cached.ReadCloser()
+			require.NoError(t, err)
+			data, err = io.ReadAll(reader)
+			require.NoError(t, err)
+			assert.Equal(t, tt.data, data)
+		})
+	}
+}
+
+func TestCache_Size(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        []byte
+		expected    int64
+		unknownSize bool
+	}{
+		{
+			name:     "empty blob",
+			data:     []byte{},
+			expected: 0,
+		},
+		{
+			name:     "small blob",
+			data:     []byte("hello"),
+			expected: 5,
+		},
+		{
+			name:     "large blob",
+			data:     bytes.Repeat([]byte("x"), 1024*1024), // 1MB
+			expected: 1024 * 1024,
+		},
+		{
+			name:        "unknown size empty blob",
+			data:        []byte{},
+			expected:    blob.SizeUnknown,
+			unknownSize: true,
+		},
+		{
+			name:        "unknown size small blob",
+			data:        []byte("hello"),
+			expected:    blob.SizeUnknown,
+			unknownSize: true,
+		},
+		{
+			name:        "unknown size large blob",
+			data:        bytes.Repeat([]byte("x"), 1024*1024), // 1MB
+			expected:    blob.SizeUnknown,
+			unknownSize: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockBlob{
+				data:        tt.data,
+				unknownSize: tt.unknownSize,
+			}
+
+			// Create cached blob
+			cached := Cache(mock)
+
+			// Test size before reading
+			assert.Equal(t, tt.expected, cached.Size())
+
+			// Test size after reading
+			_, err := cached.Data()
+			require.NoError(t, err)
+			if tt.unknownSize {
+				// After reading, size should be known
+				assert.Equal(t, int64(len(tt.data)), cached.Size())
+			} else {
+				assert.Equal(t, tt.expected, cached.Size())
+			}
+		})
+	}
+}
+
+func TestCache_Digest(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        []byte
+		expected    string
+		unknownSize bool
+	}{
+		{
+			name:     "empty blob",
+			data:     []byte{},
+			expected: digest.FromBytes([]byte{}).String(),
+		},
+		{
+			name:     "small blob",
+			data:     []byte("hello"),
+			expected: digest.FromBytes([]byte("hello")).String(),
+		},
+		{
+			name:     "large blob",
+			data:     bytes.Repeat([]byte("x"), 1024*1024), // 1MB
+			expected: digest.FromBytes(bytes.Repeat([]byte("x"), 1024*1024)).String(),
+		},
+		{
+			name:        "unknown size empty blob",
+			data:        []byte{},
+			expected:    digest.FromBytes([]byte{}).String(),
+			unknownSize: true,
+		},
+		{
+			name:        "unknown size small blob",
+			data:        []byte("hello"),
+			expected:    digest.FromBytes([]byte("hello")).String(),
+			unknownSize: true,
+		},
+		{
+			name:        "unknown size large blob",
+			data:        bytes.Repeat([]byte("x"), 1024*1024), // 1MB
+			expected:    digest.FromBytes(bytes.Repeat([]byte("x"), 1024*1024)).String(),
+			unknownSize: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockBlob{
+				data:        tt.data,
+				unknownSize: tt.unknownSize,
+			}
+
+			// Create cached blob
+			cached := Cache(mock)
+
+			// Test digest before reading
+			dig, ok := cached.Digest()
+			require.True(t, ok)
+			assert.Equal(t, tt.expected, dig)
+
+			// Test digest after reading
+			_, err := cached.Data()
+			require.NoError(t, err)
+			dig, ok = cached.Digest()
+			require.True(t, ok)
+			assert.Equal(t, tt.expected, dig)
+		})
+	}
+}
+
+func TestCache_MediaType(t *testing.T) {
+	tests := []struct {
+		name       string
+		data       []byte
+		mediaType  string
+		expected   string
+		shouldKnow bool
+	}{
+		{
+			name:       "no media type",
+			data:       []byte("hello"),
+			mediaType:  "",
+			expected:   "",
+			shouldKnow: false,
+		},
+		{
+			name:       "with media type",
+			data:       []byte("hello"),
+			mediaType:  "text/plain",
+			expected:   "text/plain",
+			shouldKnow: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock blob
+			mock := &mockBlob{
+				data:      tt.data,
+				mediaType: tt.mediaType,
+			}
+
+			// Create cached blob
+			cached := Cache(mock)
+
+			// Test media type
+			mt, known := cached.MediaType()
+			assert.Equal(t, tt.expected, mt)
+			assert.Equal(t, tt.shouldKnow, known)
+		})
+	}
+}
+
+func TestCache_Data(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        []byte
+		mediaType   string
+		unknownSize bool
+	}{
+		{
+			name:      "empty blob",
+			data:      []byte{},
+			mediaType: "",
+		},
+		{
+			name:      "small blob",
+			data:      []byte("hello"),
+			mediaType: "text/plain",
+		},
+		{
+			name:      "large blob",
+			data:      bytes.Repeat([]byte("x"), 1024*1024), // 1MB
+			mediaType: "application/octet-stream",
+		},
+		{
+			name:        "unknown size empty blob",
+			data:        []byte{},
+			mediaType:   "",
+			unknownSize: true,
+		},
+		{
+			name:        "unknown size small blob",
+			data:        []byte("hello"),
+			mediaType:   "text/plain",
+			unknownSize: true,
+		},
+		{
+			name:        "unknown size large blob",
+			data:        bytes.Repeat([]byte("x"), 1024*1024), // 1MB
+			mediaType:   "application/octet-stream",
+			unknownSize: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockBlob{
+				data:        tt.data,
+				mediaType:   tt.mediaType,
+				unknownSize: tt.unknownSize,
+			}
+
+			// Create cached blob
+			cached := Cache(mock)
+
+			// Test first read
+			data, err := cached.Data()
+			require.NoError(t, err)
+			assert.Equal(t, tt.data, data)
+
+			// Test second read (should use cache)
+			data, err = cached.Data()
+			require.NoError(t, err)
+			assert.Equal(t, tt.data, data)
+		})
+	}
+}
+
+func TestCache_ClearCache(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        []byte
+		unknownSize bool
+	}{
+		{
+			name: "known size",
+			data: []byte("hello"),
+		},
+		{
+			name:        "unknown size",
+			data:        []byte("hello"),
+			unknownSize: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockBlob{
+				data:        tt.data,
+				unknownSize: tt.unknownSize,
+			}
+
+			// Create cached blob
+			cached := Cache(mock)
+
+			// Read data to cache it
+			_, err := cached.Data()
+			require.NoError(t, err)
+
+			// Verify data is cached
+			if tt.unknownSize {
+				assert.Equal(t, int64(len(tt.data)), cached.Size())
+			} else {
+				assert.Equal(t, int64(len(tt.data)), cached.Size())
+			}
+
+			// Clear cache
+			cached.ClearCache()
+
+			// Verify cache is cleared
+			if tt.unknownSize {
+				assert.Equal(t, blob.SizeUnknown, cached.Size())
+			} else {
+				assert.Equal(t, int64(len(tt.data)), cached.Size())
+			}
+			_, err = cached.Data()
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestCache_ConcurrentAccess(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        []byte
+		unknownSize bool
+	}{
+		{
+			name: "known size",
+			data: bytes.Repeat([]byte("x"), 1024*1024), // 1MB
+		},
+		{
+			name:        "unknown size",
+			data:        bytes.Repeat([]byte("x"), 1024*1024), // 1MB
+			unknownSize: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockBlob{
+				data:        tt.data,
+				unknownSize: tt.unknownSize,
+			}
+
+			// Create cached blob
+			cached := Cache(mock)
+
+			// Test concurrent access
+			done := make(chan struct{})
+			for i := 0; i < 10; i++ {
+				go func() {
+					defer func() { done <- struct{}{} }()
+
+					// Test ReadCloser
+					reader, err := cached.ReadCloser()
+					require.NoError(t, err)
+					_, err = io.ReadAll(reader)
+					require.NoError(t, err)
+
+					// Test Data
+					_, err = cached.Data()
+					require.NoError(t, err)
+
+					// Test Size
+					_ = cached.Size()
+
+					// Test Digest
+					_, _ = cached.Digest()
+
+					// Test MediaType
+					_, _ = cached.MediaType()
+				}()
+			}
+
+			// Wait for all goroutines to finish
+			for i := 0; i < 10; i++ {
+				<-done
+			}
+		})
+	}
+}

--- a/bindings/go/blob/cache/inmemory/doc.go
+++ b/bindings/go/blob/cache/inmemory/doc.go
@@ -1,0 +1,28 @@
+// Package inmemory provides an in-memory caching implementation for blob storage.
+//
+// The package implements a caching layer for ReadOnlyBlob that stores blob data in memory
+// after the first read, enabling efficient repeated access to the same data. This is
+// particularly useful when:
+//   - The same blob needs to be accessed multiple times
+//   - The underlying blob source is expensive to read from
+//   - The blob data is relatively small and can be kept in memory
+//
+// The implementation is thread-safe and handles both known and unknown blob sizes.
+// When the size is known, it uses exact buffer sizes for optimal memory usage.
+// For unknown sizes, it falls back to dynamic buffer allocation.
+//
+// The cache can be cleared using the ClearCache method to free up memory when the
+// cached data is no longer needed.
+//
+// Note that this is mainly intended for use cases with repeated I/O operations on the same blob.
+// For one-time reads, it may be more efficient to read directly from the underlying blob source.
+// Similarly, when only working with simple Readers, one might want to consider a EagerBufferedReader
+// implementation instead.
+//
+// Example usage:
+//
+//	blob := inmemory.Cache(sourceBlob)
+//	data, err := blob.Data()  // First read caches the data
+//	data, err = blob.Data()   // Subsequent reads use cached data
+//	blob.ClearCache()         // Clear cache when done
+package inmemory


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

see doc.go for details on usage (too long to maintain here)

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This issue allows to wrap arbitrary blobs within an inmemory cache which is very useful whenever dealing with processing of data that has to read from it multiple times
