### PR TITLE
chore: parallelize lint tasks when run on whole repo

### DIFF
--- a/tools.Taskfile.yml
+++ b/tools.Taskfile.yml
@@ -31,19 +31,27 @@ tasks:
 
   golangci-lint/run:
     desc: "Run golangci-lint on all go modules"
-    deps: [golangci-lint/install]
+    deps:
+        - for: { var: GO_MODULES }
+          task: 'golangci-lint/module'
+          vars:
+            ITEM: '{{ .ITEM }}'
     aliases:
       - "lint"
-    cmds:
-      - for: { var: GO_MODULES }
-        cmd: |
-          cd {{.ITEM}} && 
-          {{ .ROOT_DIR }}/tmp/bin/golangci-lint run \
-            --timeout 10m \
-            --config={{ .ROOT_DIR }}/.github/config/golangci.yml \
-            --path-prefix {{.ITEM}} \
-            {{ .CLI_ARGS }} ./...          
-            
+
+  golangci-lint/module:
+    desc: "Run golangci-lint on a single go module specified by ITEM"
+    internal: true
+    deps: [golangci-lint/install]
+    cmd: |
+      cd {{.ITEM}} && 
+        {{ .ROOT_DIR }}/tmp/bin/golangci-lint run \
+          --timeout 10m \
+          --config={{ .ROOT_DIR }}/.github/config/golangci.yml \
+          --path-prefix {{.ITEM}} \
+          {{ .CLI_ARGS }} ./...   
+  
+  
 
   golangci-lint/install:
     desc: "Install golangci-lint at {{ .GOLANGCI_LINT_TARGET_VERSION }} into tmp ({{ .ROOT_DIR }}/tmp/bin) if not already present"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

this parallelizes the lint execution so that each linter is run concurrently. Makes the lint significantly faster when run on the whole repo

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
