### PR TITLE
fix: plugin manager test

### DIFF
--- a/bindings/go/plugin/client/sdk/plugin_test.go
+++ b/bindings/go/plugin/client/sdk/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -18,13 +19,14 @@ import (
 )
 
 func TestPluginSDK(t *testing.T) {
+	slog.SetLogLoggerLevel(slog.LevelDebug)
 	r := require.New(t)
 
 	output := bytes.NewBuffer(nil)
-	location := "/tmp/test-plugin-plugin.socket"
+	location := "/tmp/test-plugin-flow-plugin.socket"
 	ctx := context.Background()
 	p := NewPlugin(ctx, types.Config{
-		ID:         "test-plugin",
+		ID:         "test-plugin-flow",
 		Type:       types.Socket,
 		PluginType: types.ComponentVersionRepositoryPluginType,
 	}, output)
@@ -67,11 +69,11 @@ func TestPluginSDKForceShutdownContext(t *testing.T) {
 	r := require.New(t)
 
 	output := bytes.NewBuffer(nil)
-	location := "/tmp/test-plugin-plugin.socket"
+	location := "/tmp/test-plugin-force-plugin.socket"
 	ctx := context.Background()
 	baseCtx := context.Background()
 	p := NewPlugin(baseCtx, types.Config{
-		ID:         "test-plugin",
+		ID:         "test-plugin-force",
 		Type:       types.Socket,
 		PluginType: types.ComponentVersionRepositoryPluginType,
 	}, output)
@@ -125,12 +127,12 @@ func TestPluginSDKForceShutdownContext(t *testing.T) {
 
 func TestIdleChecker(t *testing.T) {
 	r := require.New(t)
-	location := "/tmp/test-plugin-plugin.socket"
+	location := "/tmp/test-plugin-idle-plugin.socket"
 	output := bytes.NewBuffer(nil)
 	timeout := 10 * time.Millisecond
 	ctx := context.Background()
 	p := NewPlugin(ctx, types.Config{
-		ID:          "test-plugin",
+		ID:          "test-plugin-idle",
 		Type:        types.Socket,
 		PluginType:  types.ComponentVersionRepositoryPluginType,
 		IdleTimeout: &timeout,
@@ -161,7 +163,7 @@ func TestIdleChecker(t *testing.T) {
 			return false
 		}
 
-		r.ErrorContains(err, "dial unix /tmp/test-plugin-plugin.socket: connect: no such file or directory")
+		r.ErrorContains(err, "dial unix /tmp/test-plugin-idle-plugin.socket: connect: no such file or directory")
 
 		return true
 	}, 5*time.Second, 20*time.Millisecond)
@@ -169,11 +171,11 @@ func TestIdleChecker(t *testing.T) {
 
 func TestHealthCheckInvalidMethod(t *testing.T) {
 	r := require.New(t)
-	location := "/tmp/test-plugin-plugin.socket"
+	location := "/tmp/test-plugin-invalid-plugin.socket"
 	output := bytes.NewBuffer(nil)
 	ctx := context.Background()
 	p := NewPlugin(ctx, types.Config{
-		ID:         "test-plugin",
+		ID:         "test-plugin-invalid",
 		Type:       types.Socket,
 		PluginType: types.ComponentVersionRepositoryPluginType,
 	}, output)

--- a/bindings/go/plugin/manager/manager_test.go
+++ b/bindings/go/plugin/manager/manager_test.go
@@ -42,7 +42,7 @@ func TestPluginManager(t *testing.T) {
 	desc, err := plugin.GetComponentVersion(ctx, repov1.GetComponentVersionRequest[*v1.OCIRepository]{
 		Repository: &v1.OCIRepository{
 			Type:    typ,
-			BaseUrl: "https://ocm.software/",
+			BaseUrl: "https://ocm.software/test",
 		},
 		Name:    "test-component",
 		Version: "1.0.0",

--- a/bindings/go/plugin/manager/registries/componentversionrepository/registry_test.go
+++ b/bindings/go/plugin/manager/registries/componentversionrepository/registry_test.go
@@ -27,7 +27,7 @@ func TestPluginFlow(t *testing.T) {
 	repository.MustAddToScheme(scheme)
 	registry := NewComponentVersionRepositoryRegistry(ctx)
 	config := mtypes.Config{
-		ID:         "test-plugin",
+		ID:         "test-plugin-1",
 		Type:       mtypes.Socket,
 		PluginType: mtypes.ComponentVersionRepositoryPluginType,
 	}
@@ -41,15 +41,15 @@ func TestPluginFlow(t *testing.T) {
 	pluginCmd := exec.CommandContext(ctx, path, "--config", string(serialized))
 	t.Cleanup(func() {
 		_ = pluginCmd.Process.Kill()
-		_ = os.Remove("/tmp/test-plugin-plugin.socket")
+		_ = os.Remove("/tmp/test-plugin-1-plugin.socket")
 	})
 	pipe, err := pluginCmd.StdoutPipe()
 	require.NoError(t, err)
 	plugin := mtypes.Plugin{
-		ID:   "test-plugin",
+		ID:   "test-plugin-1",
 		Path: path,
 		Config: mtypes.Config{
-			ID:         "test-plugin",
+			ID:         "test-plugin-1",
 			Type:       mtypes.Socket,
 			PluginType: mtypes.ComponentVersionRepositoryPluginType,
 		},


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

The problem was that all tests are using the same name and some didn't properly clean up the socket or the port or something and the next test wasn't able to run.

However, maybe I even need a way to overwrite the name of the socket. 🤔  Right now it's just generated from the name of the file.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
