### PR TITLE
fix: fixup non-deterministic registry behavior

### DIFF
--- a/bindings/go/runtime/registry.go
+++ b/bindings/go/runtime/registry.go
@@ -19,13 +19,15 @@ type Scheme struct {
 	// if the constructors cannot determine a match,
 	// this will trigger the creation of an unstructured.Unstructured with NewScheme instead of failing.
 	allowUnknown bool
-	types        map[Type]Typed
+	aliases      map[Type][]Type
+	defaults     map[Type]Typed
 }
 
 // NewScheme creates a new registry.
 func NewScheme(opts ...SchemeOption) *Scheme {
 	reg := &Scheme{
-		types: make(map[Type]Typed),
+		defaults: make(map[Type]Typed),
+		aliases:  make(map[Type][]Type),
 	}
 	for _, opt := range opts {
 		opt(reg)
@@ -47,19 +49,33 @@ func (r *Scheme) Clone() *Scheme {
 	defer r.mu.RUnlock()
 	clone := NewScheme()
 	clone.allowUnknown = r.allowUnknown
-	maps.Copy(clone.types, r.types)
+	maps.Copy(clone.defaults, r.defaults)
+	maps.Copy(clone.aliases, r.aliases)
 	return clone
 }
 
+// RegisterWithAlias registers a new type with the registry.
+// The first type is the default type and all other types are aliases.
+// Note that if Scheme.RegisterWithAlias or Scheme.MustRegister were called before,
+// even the first type will be counted as an alias.
 func (r *Scheme) RegisterWithAlias(prototype Typed, types ...Type) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	for _, typ := range types {
-		if _, exists := r.types[typ]; exists {
-			return fmt.Errorf("type %q is already registered", typ)
+	for i, typ := range types {
+		if prototype, exists := r.defaults[typ]; exists {
+			return fmt.Errorf("type %q is already registered as default for %T", typ, prototype)
 		}
-		r.types[typ] = prototype
+		if def, alias := r.aliases[typ]; alias {
+			return fmt.Errorf("type %q is already registered as alias for %q", typ, def)
+		}
+		if i == 0 && r.defaults[typ] == nil {
+			// first type is the defaults type
+			r.defaults[typ] = prototype
+		} else {
+			// all other types are aliases
+			r.aliases[typ] = append(r.aliases[typ], types[0])
+		}
 	}
 	return nil
 }
@@ -77,7 +93,7 @@ func (r *Scheme) TypeForPrototype(prototype any) (Type, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	for typ, proto := range r.types {
+	for typ, proto := range r.defaults {
 		// if there is an unversioned type registered, do not use it
 		// TODO find a way to avoid this or to fallback to the fully qualified type instead of unqualified ones
 		if !typ.HasVersion() {
@@ -103,7 +119,14 @@ func (r *Scheme) IsRegistered(typ Type) bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	_, exists := r.types[typ]
+	_, exists := r.defaults[typ]
+	if exists {
+		return true
+	}
+
+	// check if the type is an alias
+	_, exists = r.aliases[typ]
+
 	return exists
 }
 
@@ -120,7 +143,7 @@ func (r *Scheme) NewObject(typ Type) (Typed, error) {
 
 	var object any
 	// construct by full type
-	proto, exists := r.types[typ]
+	proto, exists := r.defaults[typ]
 	if exists {
 		t := reflect.TypeOf(proto)
 		for t.Kind() == reflect.Ptr {

--- a/bindings/go/runtime/registry_test.go
+++ b/bindings/go/runtime/registry_test.go
@@ -246,6 +246,21 @@ func TestRegistry_Default_DifferentRegisteredType(t *testing.T) {
 	r.Equal(typed.Type, typ2)
 }
 
+func TestRegistry_Default_MultipleRegisteredTypesWithoutTypeSet(t *testing.T) {
+	r := require.New(t)
+	typ1 := NewVersionedType("test1", "v1")
+	typ2 := NewVersionedType("test2", "v1")
+	registry := NewScheme()
+	registry.MustRegisterWithAlias(&TestType{}, typ1, typ2)
+
+	// Test defaulting a typed object with different registered type
+	typed := &TestType{}
+	updated, err := registry.DefaultType(typed)
+	r.NoError(err)
+	r.True(updated) // Type should not be updated since it's already a valid registered type
+	r.Equal(typed.Type, typ1)
+}
+
 func TestRegistry_Default_UnregisteredType(t *testing.T) {
 	r := require.New(t)
 	typ1 := NewVersionedType("test1", "v1")
@@ -258,4 +273,14 @@ func TestRegistry_Default_UnregisteredType(t *testing.T) {
 	updated, err := registry.DefaultType(typed)
 	r.NoError(err)
 	r.True(updated) // Type should be updated since it was unregistered
+}
+
+func TestRegistry_MultipleTypes_With_Alias(t *testing.T) {
+	r := require.New(t)
+	def := NewVersionedType("test1", "v1")
+	alias := NewVersionedType("test2", "v1")
+	registry := NewScheme()
+	registry.MustRegisterWithAlias(&TestType{}, def, alias)
+	r.ErrorContains(registry.RegisterWithAlias(&TestType{}, def), "already registered as default")
+	r.ErrorContains(registry.RegisterWithAlias(&TestType{}, alias), "already registered as alias")
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

This fixes up the registration order of typings to be deterministic so that only the first type registration causes a defaulting, whereas all following type definitions are aliases

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
