### PR TITLE
chore: add retaining log levels from plugins

### DIFF
--- a/bindings/go/plugin/client/sdk/plugin_test.go
+++ b/bindings/go/plugin/client/sdk/plugin_test.go
@@ -25,7 +25,7 @@ func TestPluginSDK(t *testing.T) {
 	output := bytes.NewBuffer(nil)
 	location := "/tmp/test-plugin-flow-plugin.socket"
 	ctx := context.Background()
-	p := NewPlugin(ctx, types.Config{
+	p := NewPlugin(ctx, slog.Default(), types.Config{
 		ID:         "test-plugin-flow",
 		Type:       types.Socket,
 		PluginType: types.ComponentVersionRepositoryPluginType,
@@ -72,7 +72,7 @@ func TestPluginSDKForceShutdownContext(t *testing.T) {
 	location := "/tmp/test-plugin-force-plugin.socket"
 	ctx := context.Background()
 	baseCtx := context.Background()
-	p := NewPlugin(baseCtx, types.Config{
+	p := NewPlugin(baseCtx, slog.Default(), types.Config{
 		ID:         "test-plugin-force",
 		Type:       types.Socket,
 		PluginType: types.ComponentVersionRepositoryPluginType,
@@ -131,7 +131,7 @@ func TestIdleChecker(t *testing.T) {
 	output := bytes.NewBuffer(nil)
 	timeout := 10 * time.Millisecond
 	ctx := context.Background()
-	p := NewPlugin(ctx, types.Config{
+	p := NewPlugin(ctx, slog.Default(), types.Config{
 		ID:          "test-plugin-idle",
 		Type:        types.Socket,
 		PluginType:  types.ComponentVersionRepositoryPluginType,
@@ -174,7 +174,7 @@ func TestHealthCheckInvalidMethod(t *testing.T) {
 	location := "/tmp/test-plugin-invalid-plugin.socket"
 	output := bytes.NewBuffer(nil)
 	ctx := context.Background()
-	p := NewPlugin(ctx, types.Config{
+	p := NewPlugin(ctx, slog.Default(), types.Config{
 		ID:         "test-plugin-invalid",
 		Type:       types.Socket,
 		PluginType: types.ComponentVersionRepositoryPluginType,

--- a/bindings/go/plugin/manager/manager_test.go
+++ b/bindings/go/plugin/manager/manager_test.go
@@ -12,9 +12,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
 	"ocm.software/open-component-model/bindings/go/plugin/internal/dummytype"
 	dummyv1 "ocm.software/open-component-model/bindings/go/plugin/internal/dummytype/v1"
-
 	repov1 "ocm.software/open-component-model/bindings/go/plugin/manager/contracts/ocmrepository/v1"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/componentversionrepository"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/types"
@@ -115,7 +115,7 @@ func TestPluginManagerShutdownPlugin(t *testing.T) {
 func TestPluginManagerShutdownWithoutWait(t *testing.T) {
 	writer := bytes.NewBuffer(nil)
 	slog.SetDefault(slog.New(slog.NewTextHandler(writer, &slog.HandlerOptions{
-		Level: slog.LevelDebug,
+		Level: slog.LevelInfo,
 	})))
 	ctx, cancel := context.WithCancel(context.Background())
 	baseContext := context.Background() // a different context
@@ -147,7 +147,7 @@ func TestPluginManagerShutdownWithoutWait(t *testing.T) {
 
 	content, err := io.ReadAll(writer)
 	require.NoError(t, err)
-	require.Contains(t, string(content), "Gracefully shutting down plugin id=test-plugin")
+	require.Contains(t, string(content), "Gracefully shutting down plugin")
 }
 
 func TestPluginManagerMultiplePluginsForSameType(t *testing.T) {

--- a/bindings/go/plugin/manager/registries/componentversionrepository/endpoints_function_test.go
+++ b/bindings/go/plugin/manager/registries/componentversionrepository/endpoints_function_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"ocm.software/open-component-model/bindings/go/plugin/internal/dummytype"
-	dummyv1 "ocm.software/open-component-model/bindings/go/plugin/internal/dummytype/v1"
 
 	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+	"ocm.software/open-component-model/bindings/go/plugin/internal/dummytype"
+	dummyv1 "ocm.software/open-component-model/bindings/go/plugin/internal/dummytype/v1"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/contracts"
 	repov1 "ocm.software/open-component-model/bindings/go/plugin/manager/contracts/ocmrepository/v1"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/endpoints"

--- a/bindings/go/plugin/manager/registries/plugins/log_streamer_test.go
+++ b/bindings/go/plugin/manager/registries/plugins/log_streamer_test.go
@@ -1,0 +1,87 @@
+package plugins
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"ocm.software/open-component-model/bindings/go/plugin/manager/types"
+)
+
+// TestParseLine tests the parseLine function
+func TestParseLine(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    record
+		wantErr bool
+	}{
+		{
+			name:  "valid log line",
+			input: `{"level":"info","msg":"test message","key1":"value1","key2":42}`,
+			want: record{
+				level: "info",
+				msg:   "test message",
+				args:  []any{"key1", "value1", "key2", float64(42)},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "invalid JSON",
+			input:   `{"level":"info","msg":"test message"`,
+			want:    record{},
+			wantErr: true,
+		},
+		{
+			name:    "missing msg field",
+			input:   `{"level":"info","key1":"value1"}`,
+			want:    record{},
+			wantErr: true,
+		},
+		{
+			name:    "missing level field",
+			input:   `{"msg":"test message","key1":"value1"}`,
+			want:    record{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseLine(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseLine() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if got.level != tt.want.level {
+				t.Errorf("parseLine() level = %v, want %v", got.level, tt.want.level)
+			}
+			if got.msg != tt.want.msg {
+				t.Errorf("parseLine() msg = %v, want %v", got.msg, tt.want.msg)
+			}
+
+			assert.Equal(t, tt.want.level, got.level)
+			assert.Equal(t, tt.want.msg, got.msg)
+			assert.Equal(t, tt.want.args, got.args)
+		})
+	}
+}
+
+// TestStartLogStreamerNilStderr tests the StartLogStreamer function with nil stderr
+func TestStartLogStreamerNilStderr(t *testing.T) {
+	// Create a plugin with nil stderr
+	plugin := &types.Plugin{
+		ID:     "test-plugin",
+		Stderr: nil,
+	}
+
+	// Create a context with timeout to ensure test doesn't hang
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	// This should return immediately without error
+	StartLogStreamer(ctx, plugin)
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Keep log levels from plugins at the level that the plugin defined and relog them with a plugin ID on the level they defined.

Also, harden the log streamer so that if the plugin quits or the context is cancelled, the streaming attempts stop completely.

#### Which issue(s) this PR fixes

Closes https://github.com/open-component-model/ocm-project/issues/489
