### PR TITLE
feat: allow all fs.FS implementations for file blobs

### DIFF
--- a/bindings/go/blob/filesystem/filesystem_test.go
+++ b/bindings/go/blob/filesystem/filesystem_test.go
@@ -15,7 +15,7 @@ func TestNewFS(t *testing.T) {
 
 	fsys, err := filesystem.NewFS(tempDir, os.O_RDWR)
 	require.NoError(t, err)
-	require.Equal(t, tempDir, fsys.Base())
+	require.Equal(t, tempDir, fsys.String())
 }
 
 func TestNewFS_NonExistentPath(t *testing.T) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

this makes it so that file blobs can deal with any fs.FS implementation.

That means that we open the ecosystem for inbuilt types such as mapfs but also for other types from libraries such as tarfs.

This is a prerequisite to CTF support of fs.FS.

Note that by default, compatibility is read-only and write support is based on support of our interface methods.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
