### PR TITLE
fix: flaky manager test sometimes removing something that is not there

### DIFF
--- a/bindings/go/plugin/manager/manager_test.go
+++ b/bindings/go/plugin/manager/manager_test.go
@@ -32,7 +32,8 @@ func TestPluginManager(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, pm.Shutdown(ctx))
-		require.NoError(t, os.Remove("/tmp/test-plugin-plugin.socket"))
+		// make sure it's not there but during a proper shutdown now this is removed by the plugin
+		_ = os.Remove("/tmp/test-plugin-plugin.socket")
 	})
 
 	proto, err := scheme.NewObject(typ)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
