### PR TITLE
chore: add renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,26 @@
+{
+  "extends": [
+    "config:recommended",
+    "config:best-practices",
+    "security:openssf-scorecard",
+    "helpers:pinGitHubActionDigests",
+    ":rebaseStalePrs"
+  ],
+  "git-submodules": {
+    "enabled": true
+  },
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
+  "monorepo": true,
+  "packageRules": [
+    {
+      // Group all internal OCM module updates (e.g. ocm.software/open-component-model/bindings/go/...)
+      "matchPackagePatterns": ["ocm.software/open-component-model/**"],
+      "managers": ["gomod"],
+      "groupName": "OCM Monorepo Go Module Dependencies",
+      "groupSlug": "ocm-monorepo",
+      "automerge": true
+    },
+  ]
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

This adds a custom renovate configuration to help manage our dependency updates within our monorepo

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
