### PR TITLE
chore: generates history from start of repo instead of head on first version

### DIFF
--- a/.github/workflows/release-go-submodule.yaml
+++ b/.github/workflows/release-go-submodule.yaml
@@ -49,7 +49,7 @@ jobs:
           echo "Latest tag: $latest"
 
           if [ -z "$latest" ]; then
-            latest_commit=HEAD
+            latest_commit=$(git rev-list --max-parents=0 HEAD)  # first commit in history
             version="0.0.0"
           else
             latest_commit=$(git rev-list -n 1 "$latest")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

this uses the first commit of the entire repo for the changelog generation instead of HEAD at the time the first version is generated

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
