### PR TITLE
chore: bump descriptor/v2 runtime to 0.0.1

### DIFF
--- a/bindings/go/descriptor/v2/go.mod
+++ b/bindings/go/descriptor/v2/go.mod
@@ -5,7 +5,7 @@ go 1.24.1
 require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1
 	github.com/stretchr/testify v1.10.0
-	ocm.software/open-component-model/bindings/go/runtime v0.0.0-20250521080551-eb0cbd6529f0
+	ocm.software/open-component-model/bindings/go/runtime v0.0.1
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/bindings/go/descriptor/v2/go.sum
+++ b/bindings/go/descriptor/v2/go.sum
@@ -37,7 +37,7 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-ocm.software/open-component-model/bindings/go/runtime v0.0.0-20250521080551-eb0cbd6529f0 h1:5nwA1hZ5lZbkTsSX4xG0Kla+6jdoIdnSjjgg3FGrRMQ=
-ocm.software/open-component-model/bindings/go/runtime v0.0.0-20250521080551-eb0cbd6529f0/go.mod h1:9qeyWvvxkua6NyDVGxeQV6B022WqoAfdU/JnuImm1ws=
+ocm.software/open-component-model/bindings/go/runtime v0.0.1 h1:QY5pOl6UYIpmOP4GMTTGRCsWjk276vEEc9WtdoHXpCE=
+ocm.software/open-component-model/bindings/go/runtime v0.0.1/go.mod h1:9qeyWvvxkua6NyDVGxeQV6B022WqoAfdU/JnuImm1ws=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
