### PR TITLE
chore: dont use default suffix, so that not setting suffix is equal to no suffix

### DIFF
--- a/.github/workflows/release-go-submodule.yaml
+++ b/.github/workflows/release-go-submodule.yaml
@@ -18,10 +18,9 @@ on:
           - major
           - none
       suffix:
-        description: "Suffix for the tag (e.g. alpha1)"
+        description: "optional suffix for the tag (e.g. alpha1 can lead to v0.0.0-alpha1)"
         required: false
         type: string
-        default: "alpha1"
       dry_run:
         description: "Perform a dry run without pushing tags"
         required: false


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
