### PR TITLE
feat: allow creating CTFs from any fs.FS implementation

### DIFF
--- a/bindings/go/ctf/cas_file_blob.go
+++ b/bindings/go/ctf/cas_file_blob.go
@@ -2,6 +2,7 @@ package ctf
 
 import (
 	"io"
+	"io/fs"
 	"sync"
 
 	"ocm.software/open-component-model/bindings/go/blob"
@@ -24,7 +25,7 @@ var (
 )
 
 // NewCASFileBlob creates a new CASFileBlob instance.
-func NewCASFileBlob(fs filesystem.FileSystem, path string) *CASFileBlob {
+func NewCASFileBlob(fs fs.FS, path string) *CASFileBlob {
 	return &CASFileBlob{blob: filesystem.NewFileBlob(fs, path)}
 }
 

--- a/bindings/go/ctf/go.mod
+++ b/bindings/go/ctf/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/sync v0.14.0
-	ocm.software/open-component-model/bindings/go/blob v0.0.1
+	ocm.software/open-component-model/bindings/go/blob v0.0.2
 )
 
 require (

--- a/bindings/go/ctf/go.sum
+++ b/bindings/go/ctf/go.sum
@@ -28,5 +28,5 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-ocm.software/open-component-model/bindings/go/blob v0.0.1 h1:GPHjAJZYxyM6z1cI0IVckM3IsQFC9SzJCSawPmoEqac=
-ocm.software/open-component-model/bindings/go/blob v0.0.1/go.mod h1:XHcaZ3WihLLswm+dNDs7QrAHu4M0zaNTy2nErUkZNLU=
+ocm.software/open-component-model/bindings/go/blob v0.0.2 h1:YBAXJ1m8PE/WiXNqGggCBwb48rlMKAsF7/x51gBvEGI=
+ocm.software/open-component-model/bindings/go/blob v0.0.2/go.mod h1:XHcaZ3WihLLswm+dNDs7QrAHu4M0zaNTy2nErUkZNLU=

--- a/bindings/go/ctf/tar.go
+++ b/bindings/go/ctf/tar.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"ocm.software/open-component-model/bindings/go/blob"
+	"ocm.software/open-component-model/bindings/go/blob/filesystem"
 	"ocm.software/open-component-model/bindings/go/ctf/index/v1"
 )
 
@@ -71,7 +72,9 @@ func ExtractTAR(ctx context.Context, base, path string, format FileFormat, flag 
 	// if we have an original flag, we will now respect the flag and set the FS to read-only if O_RDONLY is set
 	// this makes sure that even though we just extracted the tar, it can only be read from.
 	if flag&O_RDONLY != 0 || (flag&os.O_WRONLY == 0 && flag&os.O_RDWR == 0) {
-		ctf.FS().ForceReadOnly()
+		if roFS, ok := ctf.FS().(filesystem.ReadOnlyFS); ok {
+			roFS.ForceReadOnly()
+		}
 	}
 
 	return ctf, nil


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

this uses the recent leniency of the blob filesystem to allow any arbitrary go fs.FS implementation for use in CTFs

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
