### PR TITLE
feat: constructor contracts

### DIFF
--- a/bindings/go/plugin/manager/contracts/construction/v1/contracts.go
+++ b/bindings/go/plugin/manager/contracts/construction/v1/contracts.go
@@ -1,0 +1,31 @@
+package v1
+
+import (
+	"context"
+
+	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+	"ocm.software/open-component-model/bindings/go/plugin/manager/contracts"
+	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+type IdentityProvider[T runtime.Typed] interface {
+	contracts.PluginBase
+	GetIdentity(ctx context.Context, typ GetIdentityRequest[T]) (runtime.Identity, error)
+}
+
+type ResourceInputPluginContract interface {
+	contracts.PluginBase
+	IdentityProvider[runtime.Typed]
+	ProcessResource(ctx context.Context, request *ProcessResourceRequest, credentials map[string]string) (*ProcessResourceResponse, error)
+}
+
+type SourceInputPluginContract interface {
+	contracts.PluginBase
+	IdentityProvider[runtime.Typed]
+	ProcessSource(ctx context.Context, request *ProcessSourceRequest, credentials map[string]string) (*ProcessSourceResponse, error)
+}
+
+type ResourceDigestProcessorPlugin interface {
+	contracts.PluginBase
+	ProcessResourceDigest(ctx context.Context, resource *descriptor.Resource) (*descriptor.Resource, error)
+}

--- a/bindings/go/plugin/manager/contracts/construction/v1/types.go
+++ b/bindings/go/plugin/manager/contracts/construction/v1/types.go
@@ -1,0 +1,29 @@
+package v1
+
+import (
+	constructorv1 "ocm.software/open-component-model/bindings/go/constructor/spec/v1"
+	"ocm.software/open-component-model/bindings/go/plugin/manager/types"
+	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+type GetIdentityRequest[T runtime.Typed] struct {
+	Typ T `json:"type"`
+}
+
+type ProcessResourceRequest struct {
+	Resource *constructorv1.Resource `json:"resource"`
+}
+
+type ProcessResourceResponse struct {
+	Resource *constructorv1.Resource `json:"resource,omitempty"`
+	Location *types.Location         `json:"location,omitempty"`
+}
+
+type ProcessSourceRequest struct {
+	Source *constructorv1.Source `json:"source"`
+}
+
+type ProcessSourceResponse struct {
+	Source   *constructorv1.Source `json:"source,omitempty"`
+	Location *types.Location       `json:"location,omitempty"`
+}

--- a/bindings/go/plugin/manager/contracts/ocmrepository/v1/contracts.go
+++ b/bindings/go/plugin/manager/contracts/ocmrepository/v1/contracts.go
@@ -8,6 +8,11 @@ import (
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
+type IdentityProvider[T runtime.Typed] interface {
+	contracts.PluginBase
+	GetIdentity(ctx context.Context, typ GetIdentityRequest[T]) (runtime.Identity, error)
+}
+
 // ReadOCMRepositoryPluginContract is a plugin type that can deal with repositories
 // These provide type safety for all implementations. The Type defines the repository on which these requests work on.
 type ReadOCMRepositoryPluginContract[T runtime.Typed] interface {
@@ -15,7 +20,7 @@ type ReadOCMRepositoryPluginContract[T runtime.Typed] interface {
 	IdentityProvider[T]
 	GetComponentVersion(ctx context.Context, request GetComponentVersionRequest[T], credentials map[string]string) (*descriptor.Descriptor, error)
 	ListComponentVersions(ctx context.Context, request ListComponentVersionsRequest[T], credentials map[string]string) ([]string, error)
-	GetLocalResource(ctx context.Context, request GetLocalResourceRequest[T], credentials map[string]string) error
+	GetLocalResource(ctx context.Context, request GetLocalResourceRequest[T], credentials map[string]string) (GetLocalResourceResponse, error)
 }
 
 // WriteOCMRepositoryPluginContract defines the ability to upload ComponentVersions to a repository with a given Type.
@@ -32,24 +37,20 @@ type ReadWriteOCMRepositoryPluginContract[T runtime.Typed] interface {
 	WriteOCMRepositoryPluginContract[T]
 }
 
-// ResourcePluginContract is the contract defining Add and Get global resources.
-type ResourcePluginContract interface {
-	contracts.PluginBase
-	AddGlobalResource(ctx context.Context, request PostResourceRequest, credentials map[string]string) (*descriptor.Resource, error)
-	GetGlobalResource(ctx context.Context, request GetResourceRequest, credentials map[string]string) error
-}
-
 type ReadResourcePluginContract interface {
 	contracts.PluginBase
-	GetGlobalResource(ctx context.Context, request GetResourceRequest, credentials map[string]string) error
+	IdentityProvider[runtime.Typed]
+	GetGlobalResource(ctx context.Context, request GetResourceRequest, credentials map[string]string) (GetResourceResponse, error)
 }
 
 type WriteResourcePluginContract interface {
 	contracts.PluginBase
+	IdentityProvider[runtime.Typed]
 	AddGlobalResource(ctx context.Context, request PostResourceRequest, credentials map[string]string) (*descriptor.Resource, error)
 }
 
-type IdentityProvider[T runtime.Typed] interface {
-	contracts.PluginBase
-	GetIdentity(ctx context.Context, typ GetIdentityRequest[T]) (runtime.Identity, error)
+// ReadWriteResourcePluginContract is the contract defining Add and Get global resources.
+type ReadWriteResourcePluginContract interface {
+	ReadResourcePluginContract
+	WriteResourcePluginContract
 }

--- a/bindings/go/plugin/manager/contracts/ocmrepository/v1/types.go
+++ b/bindings/go/plugin/manager/contracts/ocmrepository/v1/types.go
@@ -37,9 +37,11 @@ type GetLocalResourceRequest[T runtime.Typed] struct {
 
 	// Identity of the local resource
 	Identity map[string]string `json:"identity,omitempty"`
+}
 
-	// The Location of the Local Resource to download to
-	TargetLocation types.Location `json:"targetLocation"`
+type GetLocalResourceResponse struct {
+	// Location where the local resource will be downloaded to and can be accessed.
+	Location types.Location `json:"location"`
 }
 
 type PostLocalResourceRequest[T runtime.Typed] struct {
@@ -59,9 +61,11 @@ type GetResourceRequest struct {
 	types.Location
 	// The resource specification to download
 	*v2.Resource `json:"resource"`
+}
 
-	// The Location of the Local Resource to download to
-	TargetLocation types.Location `json:"targetLocation"`
+type GetResourceResponse struct {
+	// Location where the resource will be downloaded to and can be accessed.
+	Location types.Location `json:"location"`
 }
 
 type PostResourceRequest struct {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

this adds the plugin contracts for the component constructor inputs and processor plugins so that we can start building registries

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
