### PR TITLE
fix: introduce support for provider labels in runtime

### DIFF
--- a/bindings/go/descriptor/runtime/descriptor.go
+++ b/bindings/go/descriptor/runtime/descriptor.go
@@ -52,13 +52,19 @@ type Component struct {
 	// See https://github.com/open-component-model/ocm-spec/blob/main/doc/01-model/03-elements-sub.md#repository-contexts
 	RepositoryContexts []runtime.Typed `json:"-"`
 	// Provider describes the provider type of component in the origin's context.
-	Provider runtime.Identity `json:"-"`
+	Provider Provider `json:"-"`
 	// Resources defines all resources that are created by the component and by a third party.
 	Resources []Resource `json:"-"`
 	// Sources defines sources that produced the component.
 	Sources []Source `json:"-"`
 	// References component dependencies that can be resolved in the current context.
 	References []Reference `json:"-"`
+}
+
+// Provider describes the provider of the component.
+type Provider struct {
+	Name   string  `json:"-"`
+	Labels []Label `json:"-"`
 }
 
 // ResourceRelation describes whether the component is created by a third party or internally.

--- a/bindings/go/descriptor/runtime/descriptor_test.go
+++ b/bindings/go/descriptor/runtime/descriptor_test.go
@@ -167,30 +167,30 @@ func TestConvertFromV2Provider(t *testing.T) {
 	tests := []struct {
 		name     string
 		provider string
-		want     runtime.Identity
+		want     descriptorRuntime.Provider
 		wantErr  bool
 	}{
 		{
 			name:     "simple provider name",
 			provider: "test-provider",
-			want: runtime.Identity{
-				v2.IdentityAttributeName: "test-provider",
+			want: descriptorRuntime.Provider{
+				Name: "test-provider",
 			},
 			wantErr: false,
 		},
 		{
 			name:     "json provider",
-			provider: `{"name": "test-provider", "type": "org"}`,
-			want: runtime.Identity{
-				"name": "test-provider",
-				"type": "org",
+			provider: `{"name": "test-provider", "labels": [{"name": "label1", "value": "value1"}]}`,
+			want: descriptorRuntime.Provider{
+				Name:   "test-provider",
+				Labels: []descriptorRuntime.Label{{Name: "label1", Value: "value1"}},
 			},
 			wantErr: false,
 		},
 		{
 			name:     "invalid json",
 			provider: `{invalid json}`,
-			want:     nil,
+			want:     descriptorRuntime.Provider{},
 			wantErr:  true,
 		},
 	}
@@ -496,31 +496,39 @@ func TestConvertFromV2Signatures(t *testing.T) {
 func TestConvertToV2Provider(t *testing.T) {
 	tests := []struct {
 		name     string
-		provider runtime.Identity
+		provider descriptorRuntime.Provider
 		want     string
 		wantErr  bool
 	}{
 		{
 			name:     "nil provider",
-			provider: nil,
+			provider: descriptorRuntime.Provider{},
 			want:     "",
-			wantErr:  false,
+			wantErr:  true,
 		},
 		{
 			name: "simple provider",
-			provider: runtime.Identity{
-				v2.IdentityAttributeName: "test-provider",
+			provider: descriptorRuntime.Provider{
+				Name: "test-provider",
 			},
 			want:    "test-provider",
 			wantErr: false,
 		},
 		{
 			name: "provider without name",
-			provider: runtime.Identity{
-				"other": "value",
+			provider: descriptorRuntime.Provider{
+				Labels: []descriptorRuntime.Label{{Name: "test", Value: "value"}},
 			},
 			want:    "",
 			wantErr: true,
+		},
+		{
+			name: "provider with name and labels",
+			provider: descriptorRuntime.Provider{
+				Name:   "test-provider",
+				Labels: []descriptorRuntime.Label{{Name: "test", Value: "value"}},
+			},
+			want: `{"name":"test-provider","labels":[{"name":"test","value":"value"}]}`,
 		},
 	}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

the provider in the runtime should be able to support labels just like the current OCM v1 lib (this was originally introduced as part of the schema v3alpha1 but is now also part of the v2 contract)

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
