### PR TITLE
fix: make it so that locations without plugins don't generate warning messages

### DIFF
--- a/cli/cmd/setup.go
+++ b/cli/cmd/setup.go
@@ -45,6 +45,7 @@ func setupPluginManager(cmd *cobra.Command) error {
 			)
 			if errors.Is(err, manager.ErrNoPluginsFound) {
 				slog.DebugContext(cmd.Context(), "no plugins found at location", slog.String("location", pluginLocation))
+				continue
 			}
 			if err != nil {
 				return err

--- a/cli/cmd/setup.go
+++ b/cli/cmd/setup.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -39,10 +40,14 @@ func setupPluginManager(cmd *cobra.Command) error {
 			return fmt.Errorf("could not get plugin configuration: %w", err)
 		}
 		for _, pluginLocation := range pluginCfg.Locations {
-			if err := pluginManager.RegisterPlugins(cmd.Context(), pluginLocation,
+			err := pluginManager.RegisterPlugins(cmd.Context(), pluginLocation,
 				manager.WithIdleTimeout(time.Duration(pluginCfg.IdleTimeout)),
-			); err != nil {
-				slog.WarnContext(cmd.Context(), "could not register plugin location", "error", err)
+			)
+			if errors.Is(err, manager.ErrNoPluginsFound) {
+				slog.DebugContext(cmd.Context(), "no plugins found at location", slog.String("location", pluginLocation))
+			}
+			if err != nil {
+				return err
 			}
 		}
 	}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -17,7 +17,7 @@ require (
 	ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20250526130658-2a15446778e5
 	ocm.software/open-component-model/bindings/go/descriptor/v2 v2.0.0-alpha1
 	ocm.software/open-component-model/bindings/go/oci v0.0.0-20250528115839-6767834fc6fe
-	ocm.software/open-component-model/bindings/go/plugin v0.0.0-20250526115132-9c9e145ad14f
+	ocm.software/open-component-model/bindings/go/plugin v0.0.0-20250603203851-b484405ddc31
 	ocm.software/open-component-model/bindings/go/runtime v0.0.1
 	oras.land/oras-go/v2 v2.6.0
 	sigs.k8s.io/yaml v1.4.0

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -84,8 +84,8 @@ ocm.software/open-component-model/bindings/go/descriptor/v2 v2.0.0-alpha1 h1:pUb
 ocm.software/open-component-model/bindings/go/descriptor/v2 v2.0.0-alpha1/go.mod h1:unxxoxXRk5k8PzhLxWPuGOVd7cRL9/QK5xO7enmsJ7s=
 ocm.software/open-component-model/bindings/go/oci v0.0.0-20250528115839-6767834fc6fe h1:cb+qz89I9qOuLys2gPMHdhe+FuwLF2yeiujZG2105TY=
 ocm.software/open-component-model/bindings/go/oci v0.0.0-20250528115839-6767834fc6fe/go.mod h1:fich/kSHz/urfe+orWy1KBJVYcZoS2LEw/15grzw1to=
-ocm.software/open-component-model/bindings/go/plugin v0.0.0-20250526115132-9c9e145ad14f h1:0UeskW31LviW71hUFNCc1cH8hldhzBEwUA7qIjkeXy0=
-ocm.software/open-component-model/bindings/go/plugin v0.0.0-20250526115132-9c9e145ad14f/go.mod h1:1zTXaxHiF0Fg2r6B+qNTlBR1gyzf7l9Lkj0SkklywpI=
+ocm.software/open-component-model/bindings/go/plugin v0.0.0-20250603203851-b484405ddc31 h1:O1xlUzIiGiiDCEDm8LXjRuZJ6EsKofN0Gig9OYr9Us4=
+ocm.software/open-component-model/bindings/go/plugin v0.0.0-20250603203851-b484405ddc31/go.mod h1:GXJh//8KEkxbFxXpf0bqhwsh9vYMDI7UjSb2FdBs71c=
 ocm.software/open-component-model/bindings/go/runtime v0.0.1 h1:QY5pOl6UYIpmOP4GMTTGRCsWjk276vEEc9WtdoHXpCE=
 ocm.software/open-component-model/bindings/go/runtime v0.0.1/go.mod h1:9qeyWvvxkua6NyDVGxeQV6B022WqoAfdU/JnuImm1ws=
 oras.land/oras-go/v2 v2.6.0 h1:X4ELRsiGkrbeox69+9tzTu492FMUu7zJQW6eJU+I2oc=

--- a/cli/internal/plugin/builtin/oci/plugin.go
+++ b/cli/internal/plugin/builtin/oci/plugin.go
@@ -3,6 +3,8 @@ package plugin
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/retry"
@@ -18,6 +20,7 @@ import (
 	"ocm.software/open-component-model/bindings/go/plugin/manager/contracts"
 	contractsv1 "ocm.software/open-component-model/bindings/go/plugin/manager/contracts/ocmrepository/v1"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/componentversionrepository"
+	"ocm.software/open-component-model/bindings/go/plugin/manager/types"
 	"ocm.software/open-component-model/bindings/go/runtime"
 	"ocm.software/open-component-model/cli/internal/plugin/builtin/location"
 )
@@ -97,17 +100,33 @@ func (p *Plugin) AddLocalResource(ctx context.Context, request contractsv1.PostL
 	return newRes, nil
 }
 
-func (p *Plugin) GetLocalResource(ctx context.Context, request contractsv1.GetLocalResourceRequest[*ociv1.Repository], credentials map[string]string) error {
+func (p *Plugin) GetLocalResource(ctx context.Context, request contractsv1.GetLocalResourceRequest[*ociv1.Repository], credentials map[string]string) (contractsv1.GetLocalResourceResponse, error) {
 	repo, err := p.createRepository(request.Repository, credentials)
 	if err != nil {
-		return fmt.Errorf("error creating repository: %w", err)
+		return contractsv1.GetLocalResourceResponse{}, fmt.Errorf("error creating repository: %w", err)
 	}
-	b, _, err := repo.GetLocalResource(ctx, request.Name, request.Version, request.Identity)
+	b, res, err := repo.GetLocalResource(ctx, request.Name, request.Version, request.Identity)
 	if err != nil {
-		return fmt.Errorf("error getting local resource: %w", err)
+		return contractsv1.GetLocalResourceResponse{}, fmt.Errorf("error getting local resource: %w", err)
 	}
 
-	return location.Write(request.TargetLocation, b)
+	path := filepath.Join(os.TempDir(), fmt.Sprintf("ocm-local-resource-%d", res.ToIdentity().CanonicalHashV1()))
+	tmp, err := os.Create(path)
+	if err != nil {
+		return contractsv1.GetLocalResourceResponse{}, fmt.Errorf("error creating buffer file: %w", err)
+	}
+	_ = tmp.Close() // Ensure the file is closed after creation
+
+	loc := types.Location{
+		LocationType: types.LocationTypeLocalFile,
+		Value:        path,
+	}
+
+	if err := location.Write(loc, b); err != nil {
+		return contractsv1.GetLocalResourceResponse{}, fmt.Errorf("error writing blob to location: %w", err)
+	}
+
+	return contractsv1.GetLocalResourceResponse{Location: loc}, nil
 }
 
 var _ contractsv1.ReadWriteOCMRepositoryPluginContract[*ociv1.Repository] = (*Plugin)(nil)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

In the Plugin Manager we can now use a dedicated error message to check this and only log a debug message instead of a warning.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
