### PR TITLE
fix: return `ErrNoPluginsFound` if plugin folder does not exist

### DIFF
--- a/bindings/go/plugin/manager/manager.go
+++ b/bindings/go/plugin/manager/manager.go
@@ -145,6 +145,10 @@ func (pm *PluginManager) Shutdown(ctx context.Context) error {
 func (pm *PluginManager) fetchPlugins(ctx context.Context, conf *mtypes.Config, dir string) ([]*mtypes.Plugin, error) {
 	var plugins []*mtypes.Plugin
 	if err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if os.IsNotExist(err) {
+			return ErrNoPluginsFound
+		}
+
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
#### What this PR does / why we need it

This PR fixes this problem:

```console
Error: could not setup plugin manager: could not fetch plugins: failed to discover plugins: lstat ~/.config/ocm/plugins: no such file or directory
```

The error happens if you call the CLI, but the plugin folder does not exist.
