### PR TITLE
fix: implemented repeated read through ReadSeeker interface and automatic seek back

### DIFF
--- a/bindings/go/blob/buffered_reader_test.go
+++ b/bindings/go/blob/buffered_reader_test.go
@@ -165,3 +165,170 @@ func TestBufferMemory_RepeatedReads(t *testing.T) {
 		r.Equal(data, buf3.Bytes())
 	})
 }
+
+func TestPartialReadCloseDigestError(t *testing.T) {
+	data := []byte("test data")
+	buffered := blob.NewDirectReadOnlyBlob(bytes.NewReader(data))
+
+	r := require.New(t)
+	reader, err := buffered.ReadCloser()
+	r.NoError(err)
+	defer reader.Close()
+
+	partial := make([]byte, 4)
+	n, err := reader.Read(partial)
+	r.NoError(err)
+	r.Equal(4, n)
+	r.Equal(data[:4], partial)
+
+	// Close the reader
+	err = reader.Close()
+	r.NoError(err)
+
+	// make sure the digest returned is the complete content digest and not just the partial read
+	digRaw, ok := buffered.Digest()
+	r.True(ok)
+	dig, err := digest.Parse(digRaw)
+	r.NoError(err)
+
+	r.NotEqual(digest.FromBytes(partial), dig)
+}
+
+func TestBufferedReader_Seek(t *testing.T) {
+	data := "hello world"
+	br := blob.NewEagerBufferedReader(strings.NewReader(data))
+
+	t.Run("SeekStart", func(t *testing.T) {
+		// Seek to start
+		pos, err := br.Seek(0, io.SeekStart)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), pos)
+
+		// Read first character
+		buf := make([]byte, 1)
+		n, err := br.Read(buf)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, n)
+		assert.Equal(t, "h", string(buf))
+
+		// Seek to middle
+		pos, err = br.Seek(5, io.SeekStart)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(5), pos)
+
+		// Read from middle
+		buf = make([]byte, 2)
+		n, err = br.Read(buf)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, n)
+		assert.Equal(t, " w", string(buf))
+	})
+
+	t.Run("SeekCurrent", func(t *testing.T) {
+		// Reset to start
+		_, err := br.Seek(0, io.SeekStart)
+		assert.NoError(t, err)
+
+		// Read first character
+		buf := make([]byte, 1)
+		n, err := br.Read(buf)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, n)
+
+		// Seek forward 2 positions from current
+		pos, err := br.Seek(2, io.SeekCurrent)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(3), pos)
+
+		// Read from new position
+		buf = make([]byte, 2)
+		n, err = br.Read(buf)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, n)
+		assert.Equal(t, "lo", string(buf))
+
+		// Seek backward 1 position
+		pos, err = br.Seek(-1, io.SeekCurrent)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(4), pos)
+
+		// Read from new position
+		buf = make([]byte, 1)
+		n, err = br.Read(buf)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, n)
+		assert.Equal(t, "o", string(buf))
+	})
+
+	t.Run("SeekEnd", func(t *testing.T) {
+		// Seek to end
+		pos, err := br.Seek(0, io.SeekEnd)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(len(data)), pos)
+
+		// Seek back 3 positions from end
+		pos, err = br.Seek(-3, io.SeekEnd)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(len(data)-3), pos)
+
+		// Read from new position
+		buf := make([]byte, 3)
+		n, err := br.Read(buf)
+		assert.NoError(t, err)
+		assert.Equal(t, 3, n)
+		assert.Equal(t, "rld", string(buf))
+	})
+
+	t.Run("Edge Cases", func(t *testing.T) {
+		// Test seeking beyond buffer length
+		pos, err := br.Seek(int64(len(data)+1), io.SeekStart)
+		assert.Error(t, err) // Should return an error
+		assert.Equal(t, io.ErrUnexpectedEOF, err)
+
+		// Test seeking to negative position
+		pos, err = br.Seek(-1, io.SeekStart)
+		assert.Error(t, err)
+		assert.Equal(t, io.ErrUnexpectedEOF, err)
+
+		// Test seeking with invalid whence
+		pos, err = br.Seek(0, 999)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), pos) // Should default to SeekStart
+	})
+
+	t.Run("Seek and Read Sequence", func(t *testing.T) {
+		// Reset to start
+		_, err := br.Seek(0, io.SeekStart)
+		assert.NoError(t, err)
+
+		// Read first 5 bytes
+		buf := make([]byte, 5)
+		n, err := br.Read(buf)
+		assert.NoError(t, err)
+		assert.Equal(t, 5, n)
+		assert.Equal(t, "hello", string(buf))
+
+		// Seek to position 6
+		pos, err := br.Seek(6, io.SeekStart)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(6), pos)
+
+		// Read remaining bytes
+		buf = make([]byte, 5)
+		n, err = br.Read(buf)
+		assert.NoError(t, err)
+		assert.Equal(t, 5, n)
+		assert.Equal(t, "world", string(buf))
+
+		// Seek back to start and verify we can read again
+		pos, err = br.Seek(0, io.SeekStart)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), pos)
+
+		buf = make([]byte, len(data))
+		n, err = br.Read(buf)
+		assert.NoError(t, err)
+		assert.Equal(t, len(data), n)
+		assert.Equal(t, data, string(buf))
+	})
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

this implements a default read / seek on the buffered reader so that everytime the buffer has been fully read, it gets reset fully and can be read from again.

This allows the following flow:

1. Read data from source (e.g. file) in memory
2. Read from memory after first read from file
3. Read again from memory henceforth (this was previously not possible)

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
part of https://github.com/open-component-model/ocm-project/issues/460