### PR TITLE
feat: component version repository provider

### DIFF
--- a/bindings/go/oci/doc.go
+++ b/bindings/go/oci/doc.go
@@ -100,7 +100,7 @@
 // Configuration and Options:
 //
 // The package supports flexible configuration through RepositoryOptions:
-//   - WithOCIDescriptorCache: Temporary blob storage for OCI Manifests attached to Component Version Index Files
+//   - WithManifestCache: Temporary blob storage for OCI Manifests attached to Component Version Index Files
 //   - WithResolver: Reference resolution strategy
 //   - WithCreator: Component version creator identification
 //

--- a/bindings/go/oci/integration/integration_test.go
+++ b/bindings/go/oci/integration/integration_test.go
@@ -44,6 +44,7 @@ import (
 	ocmoci "ocm.software/open-component-model/bindings/go/oci/spec/access"
 	v1 "ocm.software/open-component-model/bindings/go/oci/spec/access/v1"
 	"ocm.software/open-component-model/bindings/go/oci/spec/layout"
+	ctfrepospecv1 "ocm.software/open-component-model/bindings/go/oci/spec/repository/v1/ctf"
 	ocirepospecv1 "ocm.software/open-component-model/bindings/go/oci/spec/repository/v1/oci"
 	"ocm.software/open-component-model/bindings/go/oci/tar"
 	ocmruntime "ocm.software/open-component-model/bindings/go/runtime"
@@ -126,61 +127,9 @@ func Test_Integration_OCIRepository_BackwardsCompatibility(t *testing.T) {
 	})
 }
 
-func Test_Integration_Specification_based_Repository(t *testing.T) {
-	ctx := t.Context()
-	r := require.New(t)
-
-	t.Logf("Starting OCI integration test")
-
-	// Setup credentials and htpasswd
-	password := generateRandomPassword(t, passwordLength)
-	htpasswd := generateHtpasswd(t, testUsername, password)
-
-	// Start containerized registry
-	t.Logf("Launching test registry (%s)...", distributionRegistryImage)
-	registryContainer, err := registry.Run(ctx, distributionRegistryImage,
-		registry.WithHtpasswd(htpasswd),
-		testcontainers.WithEnv(map[string]string{
-			"REGISTRY_VALIDATION_DISABLED": "true",
-			"REGISTRY_LOG_LEVEL":           "debug",
-		}),
-		testcontainers.WithLogger(log.TestLogger(t)),
-	)
-	r.NoError(err)
-	t.Cleanup(func() {
-		r.NoError(testcontainers.TerminateContainer(registryContainer))
-	})
-	t.Logf("Test registry started")
-
-	registryAddress, err := registryContainer.Address(ctx)
-	r.NoError(err)
-
-	t.Run("basic connectivity and resolution failure", func(t *testing.T) {
-		repoProvider := provider.NewComponentVersionRepositoryProvider()
-		repoSpec := &ocirepospecv1.Repository{BaseUrl: registryAddress}
-		id, err := repoProvider.GetComponentVersionRepositoryCredentialConsumerIdentity(t.Context(), repoSpec)
-		r.NoError(err)
-
-		url, err := ocmruntime.ParseURLAndAllowNoScheme(registryAddress)
-		r.NoError(err)
-		r.Equal(id[ocmruntime.IdentityAttributeHostname], url.Hostname())
-		r.Equal(id[ocmruntime.IdentityAttributePort], url.Port())
-		r.Equal(id[ocmruntime.IdentityAttributeScheme], url.Scheme)
-
-		repo, err := repoProvider.GetComponentVersionRepository(ctx, repoSpec, map[string]string{
-			"username": testUsername,
-			"password": password,
-		})
-		r.NoError(err)
-
-		uploadDownloadBarebonesComponentVersion(t, repo, "test-component", "v1.0.0")
-	})
-}
-
 func Test_Integration_OCIRepository(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	r := require.New(t)
 
 	t.Logf("Starting OCI integration test")
 
@@ -198,50 +147,84 @@ func Test_Integration_OCIRepository(t *testing.T) {
 		}),
 		testcontainers.WithLogger(log.TestLogger(t)),
 	)
+	r := require.New(t)
 	r.NoError(err)
 	t.Cleanup(func() {
 		r.NoError(testcontainers.TerminateContainer(registryContainer))
 	})
 	t.Logf("Test registry started")
 
-	registryAddress, err := registryContainer.HostAddress(ctx)
-	r.NoError(err)
+	t.Run("direct", func(t *testing.T) {
+		r := require.New(t)
+		registryAddress, err := registryContainer.HostAddress(ctx)
+		r.NoError(err)
 
-	reference := func(ref string) string {
-		return fmt.Sprintf("%s/%s", registryAddress, ref)
-	}
+		reference := func(ref string) string {
+			return fmt.Sprintf("%s/%s", registryAddress, ref)
+		}
 
-	client := createAuthClient(registryAddress, testUsername, password)
+		client := createAuthClient(registryAddress, testUsername, password)
 
-	resolver := urlresolver.New(registryAddress)
-	resolver.SetClient(client)
-	resolver.PlainHTTP = true
+		resolver := urlresolver.New(registryAddress)
+		resolver.SetClient(client)
+		resolver.PlainHTTP = true
 
-	repo, err := oci.NewRepository(oci.WithResolver(resolver))
-	r.NoError(err)
+		repo, err := oci.NewRepository(oci.WithResolver(resolver))
+		r.NoError(err)
 
-	t.Run("basic connectivity and resolution failure", func(t *testing.T) {
-		testResolverConnectivity(t, registryAddress, reference("target:latest"), client)
+		t.Run("basic connectivity and resolution failure", func(t *testing.T) {
+			testResolverConnectivity(t, registryAddress, reference("target:latest"), client)
+		})
+
+		t.Run("basic upload and download of a component version", func(t *testing.T) {
+			uploadDownloadBarebonesComponentVersion(t, repo, "test-component", "v1.0.0")
+		})
+
+		t.Run("basic upload and download of a barebones resource that is compatible with OCI registries", func(t *testing.T) {
+			uploadDownloadBarebonesOCIImage(t, repo, "ghcr.io/test:v1.0.0", reference("new-test:v1.0.0"))
+		})
+
+		t.Run("local resource blob upload and download", func(t *testing.T) {
+			uploadDownloadLocalResource(t, repo, "test-component", "v1.0.0")
+		})
+
+		t.Run("local resource oci layout upload and download", func(t *testing.T) {
+			uploadDownloadLocalResourceOCILayout(t, repo, "test-component", "v1.0.0")
+		})
+
+		t.Run("local source blob upload and download", func(t *testing.T) {
+			uploadDownloadLocalSource(t, repo, "test-component", "v1.0.0")
+		})
 	})
 
-	t.Run("basic upload and download of a component version", func(t *testing.T) {
-		uploadDownloadBarebonesComponentVersion(t, repo, "test-component", "v1.0.0")
-	})
+	t.Run("specification-based", func(t *testing.T) {
+		r := require.New(t)
 
-	t.Run("basic upload and download of a barebones resource that is compatible with OCI registries", func(t *testing.T) {
-		uploadDownloadBarebonesOCIImage(t, repo, "ghcr.io/test:v1.0.0", reference("new-test:v1.0.0"))
-	})
+		registryAddress, err := registryContainer.Address(ctx)
+		r.NoError(err)
 
-	t.Run("local resource blob upload and download", func(t *testing.T) {
-		uploadDownloadLocalResource(t, repo, "test-component", "v1.0.0")
-	})
+		t.Run("basic connectivity and resolution failure", func(t *testing.T) {
+			repoProvider := provider.NewComponentVersionRepositoryProvider()
+			repoSpec := &ocirepospecv1.Repository{BaseUrl: registryAddress}
+			id, err := repoProvider.GetComponentVersionRepositoryCredentialConsumerIdentity(t.Context(), repoSpec)
+			r.NoError(err)
 
-	t.Run("local resource oci layout upload and download", func(t *testing.T) {
-		uploadDownloadLocalResourceOCILayout(t, repo, "test-component", "v1.0.0")
-	})
+			url, err := ocmruntime.ParseURLAndAllowNoScheme(registryAddress)
+			r.NoError(err)
+			r.Equal(id[ocmruntime.IdentityAttributeHostname], url.Hostname())
+			r.Equal(id[ocmruntime.IdentityAttributePort], url.Port())
+			r.Equal(id[ocmruntime.IdentityAttributeScheme], url.Scheme)
 
-	t.Run("local source blob upload and download", func(t *testing.T) {
-		uploadDownloadLocalSource(t, repo, "test-component", "v1.0.0")
+			repo, err := repoProvider.GetComponentVersionRepository(ctx, repoSpec, map[string]string{
+				"username": testUsername,
+				"password": password,
+			})
+			r.NoError(err)
+
+			t.Run("basic upload and download of a component version", func(t *testing.T) {
+				uploadDownloadBarebonesComponentVersion(t, repo, "test-component", "v1.0.0")
+			})
+		})
 	})
 }
 
@@ -249,30 +232,48 @@ func Test_Integration_CTF(t *testing.T) {
 	t.Parallel()
 	fs, err := filesystem.NewFS(t.TempDir(), os.O_RDWR)
 	require.NoError(t, err)
-	archive := ctf.NewFileSystemCTF(fs)
-	store := ocictf.NewFromCTF(archive)
 
-	repo, err := oci.NewRepository(oci.WithResolver(store))
-	require.NoError(t, err)
+	t.Run("direct", func(t *testing.T) {
+		archive := ctf.NewFileSystemCTF(fs)
+		store := ocictf.NewFromCTF(archive)
+		repo, err := oci.NewRepository(oci.WithResolver(store))
+		require.NoError(t, err)
+		t.Run("basic upload and download of a component version", func(t *testing.T) {
+			uploadDownloadBarebonesComponentVersion(t, repo, "test-component", "v1.0.0")
+		})
 
-	t.Run("basic upload and download of a component version", func(t *testing.T) {
-		uploadDownloadBarebonesComponentVersion(t, repo, "test-component", "v1.0.0")
+		t.Run("basic upload and download of a barebones resource that is compatible with OCI registries", func(t *testing.T) {
+			uploadDownloadBarebonesOCIImage(t, repo, "ghcr.io/test:v1.0.0", "new-test:v1.0.0")
+		})
+
+		t.Run("local resource blob upload and download", func(t *testing.T) {
+			uploadDownloadLocalResource(t, repo, "test-component", "v2.0.0")
+		})
+
+		t.Run("local resource oci layout upload and download", func(t *testing.T) {
+			uploadDownloadLocalResourceOCILayout(t, repo, "test-component", "v3.0.0")
+		})
+
+		t.Run("local source blob upload and download", func(t *testing.T) {
+			uploadDownloadLocalSource(t, repo, "test-component", "v4.0.0")
+		})
 	})
 
-	t.Run("basic upload and download of a barebones resource that is compatible with OCI registries", func(t *testing.T) {
-		uploadDownloadBarebonesOCIImage(t, repo, "ghcr.io/test:v1.0.0", "new-test:v1.0.0")
-	})
+	t.Run("specification-based", func(t *testing.T) {
+		r := require.New(t)
+		repoProvider := provider.NewComponentVersionRepositoryProvider()
+		repoSpec := &ctfrepospecv1.Repository{Path: fs.String(), AccessMode: ctfrepospecv1.AccessModeReadWrite}
+		id, err := repoProvider.GetComponentVersionRepositoryCredentialConsumerIdentity(t.Context(), repoSpec)
+		r.NoError(err)
 
-	t.Run("local resource blob upload and download", func(t *testing.T) {
-		uploadDownloadLocalResource(t, repo, "test-component", "v2.0.0")
-	})
+		r.Equal(id[ocmruntime.IdentityAttributePath], fs.String())
 
-	t.Run("local resource oci layout upload and download", func(t *testing.T) {
-		uploadDownloadLocalResourceOCILayout(t, repo, "test-component", "v3.0.0")
-	})
+		repo, err := repoProvider.GetComponentVersionRepository(t.Context(), repoSpec, nil)
+		r.NoError(err)
 
-	t.Run("local source blob upload and download", func(t *testing.T) {
-		uploadDownloadLocalSource(t, repo, "test-component", "v4.0.0")
+		t.Run("basic upload and download of a component version", func(t *testing.T) {
+			uploadDownloadBarebonesComponentVersion(t, repo, "test-component", "v5.0.0")
+		})
 	})
 }
 
@@ -448,8 +449,7 @@ func uploadDownloadBarebonesComponentVersion(t *testing.T, repo oci.ComponentVer
 
 	versions, err := repo.ListComponentVersions(ctx, name)
 	r.NoError(err)
-	r.Len(versions, 1)
-	r.Equal(version, versions[0])
+	r.Contains(versions, version)
 }
 
 func testResolverConnectivity(t *testing.T, address, reference string, client *auth.Client) {

--- a/bindings/go/oci/repository/provider/credential_cache.go
+++ b/bindings/go/oci/repository/provider/credential_cache.go
@@ -1,0 +1,102 @@
+package provider
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"net/url"
+	"sync"
+
+	"oras.land/oras-go/v2/registry/remote/auth"
+
+	ocirepospecv1 "ocm.software/open-component-model/bindings/go/oci/spec/repository/v1/oci"
+	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+type cachedCredential struct {
+	identity   runtime.Identity
+	credential auth.Credential
+}
+type credentialCache struct {
+	mu          sync.RWMutex
+	credentials []cachedCredential
+}
+
+func (cache *credentialCache) get(_ context.Context, hostport string) (auth.Credential, error) {
+	cache.mu.RLock()
+	cache.mu.RUnlock()
+
+	host, port, err := net.SplitHostPort(hostport)
+	if err != nil {
+		return auth.EmptyCredential, err
+	}
+	identity := runtime.Identity{
+		runtime.IdentityAttributeHostname: host,
+		runtime.IdentityAttributePort:     port,
+	}
+
+	for _, entry := range cache.credentials {
+		if identity.Match(entry.identity, runtime.IdentityMatchingChainFn(runtime.IdentitySubset)) {
+			return entry.credential, nil
+		}
+	}
+	return auth.EmptyCredential, nil
+}
+
+func (cache *credentialCache) add(spec *ocirepospecv1.Repository, credentials map[string]string) error {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	parsedBaseURL, err := url.Parse(spec.BaseUrl)
+	if err != nil {
+		return err
+	}
+
+	hostname, port := parsedBaseURL.Hostname(), parsedBaseURL.Port()
+
+	identity := runtime.Identity{
+		runtime.IdentityAttributeHostname: hostname,
+		runtime.IdentityAttributePort:     port,
+	}
+
+	newCredentials := toCredential(credentials)
+
+	for i, entry := range cache.credentials {
+		if identity.Match(entry.identity, runtime.IdentityMatchingChainFn(runtime.IdentitySubset)) && !equalCredentials(entry.credential, newCredentials) {
+			slog.Warn("overwriting existing get for identity", slog.String("identity", identity.String()))
+			cache.credentials[i].credential = newCredentials
+			return nil
+		}
+	}
+
+	cache.credentials = append(cache.credentials, cachedCredential{
+		identity:   identity,
+		credential: newCredentials,
+	})
+
+	return nil
+}
+
+func toCredential(credentials map[string]string) auth.Credential {
+	cred := auth.Credential{}
+	if username, ok := credentials["username"]; ok {
+		cred.Username = username
+	}
+	if password, ok := credentials["password"]; ok {
+		cred.Password = password
+	}
+	if refreshToken, ok := credentials["refresh_token"]; ok {
+		cred.RefreshToken = refreshToken
+	}
+	if accessToken, ok := credentials["access_token"]; ok {
+		cred.AccessToken = accessToken
+	}
+	return cred
+}
+
+func equalCredentials(a, b auth.Credential) bool {
+	return a.Username == b.Username &&
+		a.Password == b.Password &&
+		a.RefreshToken == b.RefreshToken &&
+		a.AccessToken == b.AccessToken
+}

--- a/bindings/go/oci/repository/provider/credential_cache_test.go
+++ b/bindings/go/oci/repository/provider/credential_cache_test.go
@@ -1,0 +1,218 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"oras.land/oras-go/v2/registry/remote/auth"
+
+	ocirepospecv1 "ocm.software/open-component-model/bindings/go/oci/spec/repository/v1/oci"
+	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+func TestCredentialCache_Get(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(*credentialCache)
+		hostport string
+		want     auth.Credential
+		wantErr  bool
+	}{
+		{
+			name: "empty cache returns empty credential",
+			setup: func(c *credentialCache) {
+				// No setup needed
+			},
+			hostport: "example.com:443",
+			want:     auth.EmptyCredential,
+			wantErr:  false,
+		},
+		{
+			name: "returns matching credential",
+			setup: func(c *credentialCache) {
+				spec := &ocirepospecv1.Repository{BaseUrl: "https://example.com:443"}
+				creds := map[string]string{
+					"username": "testuser",
+					"password": "testpass",
+				}
+				err := c.add(spec, creds)
+				require.NoError(t, err)
+			},
+			hostport: "example.com:443",
+			want: auth.Credential{
+				Username: "testuser",
+				Password: "testpass",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid hostport returns error",
+			setup: func(c *credentialCache) {
+				// No setup needed
+			},
+			hostport: "invalid:host:port",
+			want:     auth.EmptyCredential,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := &credentialCache{}
+			tt.setup(cache)
+
+			got, err := cache.get(context.Background(), tt.hostport)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCredentialCache_Add(t *testing.T) {
+	tests := []struct {
+		name        string
+		spec        *ocirepospecv1.Repository
+		credentials map[string]string
+		wantErr     bool
+	}{
+		{
+			name: "add valid credentials",
+			spec: &ocirepospecv1.Repository{
+				BaseUrl: "https://example.com:443",
+			},
+			credentials: map[string]string{
+				"username": "testuser",
+				"password": "testpass",
+			},
+			wantErr: false,
+		},
+		{
+			name: "add credentials with tokens",
+			spec: &ocirepospecv1.Repository{
+				BaseUrl: "https://example.com:443",
+			},
+			credentials: map[string]string{
+				"refresh_token": "refreshtoken123",
+				"access_token":  "accesstoken456",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid base URL",
+			spec: &ocirepospecv1.Repository{
+				BaseUrl: "://invalid-url",
+			},
+			credentials: map[string]string{
+				"username": "testuser",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := &credentialCache{}
+			err := cache.add(tt.spec, tt.credentials)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			// Verify the credentials were added correctly
+			if !tt.wantErr {
+				url, err := runtime.ParseURLAndAllowNoScheme(tt.spec.BaseUrl)
+				assert.NoError(t, err)
+				host, port := url.Hostname(), url.Port()
+				hostport := host + ":" + port
+				got, err := cache.get(context.Background(), hostport)
+				assert.NoError(t, err)
+				assert.Equal(t, toCredential(tt.credentials), got)
+			}
+		})
+	}
+}
+
+func TestCredentialCache_Overwrite(t *testing.T) {
+	cache := &credentialCache{}
+	spec := &ocirepospecv1.Repository{BaseUrl: "https://example.com:443"}
+
+	// Add initial credentials
+	initialCreds := map[string]string{
+		"username": "user1",
+		"password": "pass1",
+	}
+	err := cache.add(spec, initialCreds)
+	require.NoError(t, err)
+
+	// Add new credentials for the same identity
+	newCreds := map[string]string{
+		"username": "user2",
+		"password": "pass2",
+	}
+	err = cache.add(spec, newCreds)
+	require.NoError(t, err)
+
+	// Verify the credentials were overwritten
+	got, err := cache.get(context.Background(), "example.com:443")
+	assert.NoError(t, err)
+	assert.Equal(t, toCredential(newCreds), got)
+}
+
+func TestEqualCredentials(t *testing.T) {
+	tests := []struct {
+		name string
+		a    auth.Credential
+		b    auth.Credential
+		want bool
+	}{
+		{
+			name: "equal credentials",
+			a: auth.Credential{
+				Username:     "user",
+				Password:     "pass",
+				RefreshToken: "refresh",
+				AccessToken:  "access",
+			},
+			b: auth.Credential{
+				Username:     "user",
+				Password:     "pass",
+				RefreshToken: "refresh",
+				AccessToken:  "access",
+			},
+			want: true,
+		},
+		{
+			name: "different credentials",
+			a: auth.Credential{
+				Username: "user1",
+				Password: "pass1",
+			},
+			b: auth.Credential{
+				Username: "user2",
+				Password: "pass2",
+			},
+			want: false,
+		},
+		{
+			name: "empty credentials",
+			a:    auth.EmptyCredential,
+			b:    auth.EmptyCredential,
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := equalCredentials(tt.a, tt.b)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/bindings/go/oci/repository/provider/doc.go
+++ b/bindings/go/oci/repository/provider/doc.go
@@ -1,0 +1,3 @@
+// Package provider supports creating both OCI and CTF (Component Transfer Format) repositories based on specifications,
+// with proper credential management and caching strategies for improved performance.
+package provider

--- a/bindings/go/oci/repository/provider/interface.go
+++ b/bindings/go/oci/repository/provider/interface.go
@@ -7,13 +7,23 @@ import (
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
-// ComponentVersionRepositoryProvider is an interface that provides methods to retrieve component version repositories.
-// It includes methods to get the credential consumer identity and to retrieve the repository itself based on a given specification.
-// The provider can handle different types of repository specifications, such as OCI and CTF repositories.
+// ComponentVersionRepositoryProvider defines the contract for providers that can retrieve
+// and manage component version repositories. It supports different types of repository
+// specifications, including OCI and CTF repositories.
 type ComponentVersionRepositoryProvider interface {
-	// GetComponentVersionRepositoryCredentialConsumerIdentity retrieves the consumer identity for a component version repository based on a given repository specification.
-	// The identity is used to look up credentials for accessing the repository.
+	// GetComponentVersionRepositoryCredentialConsumerIdentity retrieves the consumer identity
+	// for a component version repository based on a given repository specification.
+	//
+	// The identity can be used to look up credentials for accessing the repository and typically
+	// includes information like hostname, port and/or path.
 	GetComponentVersionRepositoryCredentialConsumerIdentity(ctx context.Context, repositorySpecification runtime.Typed) (runtime.Identity, error)
-	// GetComponentVersionRepository retrieves a component version repository based on a given repository specification.
+
+	// GetComponentVersionRepository retrieves a component version repository based on a given
+	// repository specification and credentials.
+	//
+	// This method is responsible for:
+	// - Validating the repository specification
+	// - Setting up the repository with appropriate credentials
+	// - Configuring caching and other repository options
 	GetComponentVersionRepository(ctx context.Context, repositorySpecification runtime.Typed, credentials map[string]string) (oci.ComponentVersionRepository, error)
 }

--- a/bindings/go/oci/repository/provider/interface.go
+++ b/bindings/go/oci/repository/provider/interface.go
@@ -1,0 +1,19 @@
+package provider
+
+import (
+	"context"
+
+	"ocm.software/open-component-model/bindings/go/oci"
+	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+// ComponentVersionRepositoryProvider is an interface that provides methods to retrieve component version repositories.
+// It includes methods to get the credential consumer identity and to retrieve the repository itself based on a given specification.
+// The provider can handle different types of repository specifications, such as OCI and CTF repositories.
+type ComponentVersionRepositoryProvider interface {
+	// GetComponentVersionRepositoryCredentialConsumerIdentity retrieves the consumer identity for a component version repository based on a given repository specification.
+	// The identity is used to look up credentials for accessing the repository.
+	GetComponentVersionRepositoryCredentialConsumerIdentity(ctx context.Context, repositorySpecification runtime.Typed) (runtime.Identity, error)
+	// GetComponentVersionRepository retrieves a component version repository based on a given repository specification.
+	GetComponentVersionRepository(ctx context.Context, repositorySpecification runtime.Typed, credentials map[string]string) (oci.ComponentVersionRepository, error)
+}

--- a/bindings/go/oci/repository/provider/oci_cache.go
+++ b/bindings/go/oci/repository/provider/oci_cache.go
@@ -1,0 +1,48 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"ocm.software/open-component-model/bindings/go/oci/cache"
+	"ocm.software/open-component-model/bindings/go/oci/cache/inmemory"
+	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+type cachedOCIDescriptors struct {
+	identity  runtime.Identity
+	manifests cache.OCIDescriptorCache
+	layers    cache.OCIDescriptorCache
+}
+
+type ociCache struct {
+	mu             sync.RWMutex
+	ociDescriptors []cachedOCIDescriptors
+	scheme         *runtime.Scheme
+}
+
+func (cache *ociCache) get(ctx context.Context, spec runtime.Typed) (manifests cache.OCIDescriptorCache, layers cache.OCIDescriptorCache, err error) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	identity, err := GetComponentVersionRepositoryCredentialConsumerIdentity(ctx, cache.scheme, spec)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get identity from OCI repository: %w", err)
+	}
+
+	for _, entry := range cache.ociDescriptors {
+		if identity.Match(entry.identity, runtime.IdentityMatchingChainFn(runtime.IdentitySubset)) {
+			return entry.manifests, entry.layers, nil
+		}
+	}
+
+	entry := cachedOCIDescriptors{
+		identity:  identity,
+		manifests: inmemory.New(),
+		layers:    inmemory.New(),
+	}
+	cache.ociDescriptors = append(cache.ociDescriptors)
+
+	return entry.manifests, entry.layers, nil
+}

--- a/bindings/go/oci/repository/provider/provider.go
+++ b/bindings/go/oci/repository/provider/provider.go
@@ -1,0 +1,102 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/retry"
+
+	"ocm.software/open-component-model/bindings/go/oci"
+	"ocm.software/open-component-model/bindings/go/oci/repository"
+	v1 "ocm.software/open-component-model/bindings/go/oci/spec/credentials/identity/v1"
+	repoSpec "ocm.software/open-component-model/bindings/go/oci/spec/repository"
+	ctfrepospecv1 "ocm.software/open-component-model/bindings/go/oci/spec/repository/v1/ctf"
+	ocirepospecv1 "ocm.software/open-component-model/bindings/go/oci/spec/repository/v1/oci"
+	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+// CachingComponentVersionRepositoryProvider is a caching implementation of the ComponentVersionRepositoryProvider interface.
+// It uses multiple caches to store credentials, OCI descriptors, and authorization information for multiple repository specifications as well as a shared client.
+type CachingComponentVersionRepositoryProvider struct {
+	scheme *runtime.Scheme
+	*credentialCache
+	*ociCache
+	authorizationCache auth.Cache
+	httpClient         *http.Client
+}
+
+func NewComponentVersionRepositoryProvider() ComponentVersionRepositoryProvider {
+	return &CachingComponentVersionRepositoryProvider{
+		scheme:             repoSpec.Scheme,
+		credentialCache:    &credentialCache{},
+		ociCache:           &ociCache{scheme: repoSpec.Scheme},
+		authorizationCache: auth.NewCache(),
+		httpClient:         retry.DefaultClient,
+	}
+}
+
+func (b *CachingComponentVersionRepositoryProvider) GetComponentVersionRepositoryCredentialConsumerIdentity(ctx context.Context, repositorySpecification runtime.Typed) (runtime.Identity, error) {
+	return GetComponentVersionRepositoryCredentialConsumerIdentity(ctx, b.scheme, repositorySpecification)
+}
+
+func GetComponentVersionRepositoryCredentialConsumerIdentity(_ context.Context, scheme *runtime.Scheme, repositorySpecification runtime.Typed) (runtime.Identity, error) {
+	if _, err := scheme.DefaultType(repositorySpecification); err != nil {
+		return nil, fmt.Errorf("failed to ensure type for repository specification: %w", err)
+	}
+	obj, err := scheme.NewObject(repositorySpecification.GetType())
+	if err != nil {
+		return nil, err
+	}
+	if err := scheme.Convert(repositorySpecification, obj); err != nil {
+		return nil, err
+	}
+	switch obj := obj.(type) {
+	case *ocirepospecv1.Repository:
+		return v1.IdentityFromOCIRepository(obj)
+	case *ctfrepospecv1.Repository:
+		return v1.IdentityFromCTFRepository(obj)
+	default:
+		return nil, fmt.Errorf("unsupported repository specification type for identity generation %T", obj)
+	}
+}
+
+func (b *CachingComponentVersionRepositoryProvider) GetComponentVersionRepository(ctx context.Context, repositorySpecification runtime.Typed, credentials map[string]string) (oci.ComponentVersionRepository, error) {
+	if _, err := b.scheme.DefaultType(repositorySpecification); err != nil {
+		return nil, fmt.Errorf("failed to ensure type for repository specification: %w", err)
+	}
+	obj, err := b.scheme.NewObject(repositorySpecification.GetType())
+	if err != nil {
+		return nil, err
+	}
+	if err := b.scheme.Convert(repositorySpecification, obj); err != nil {
+		return nil, err
+	}
+
+	manifests, layers, err := b.ociCache.get(ctx, obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to getOCIDescriptors from repository cache: %w", err)
+	}
+
+	opts := []oci.RepositoryOption{
+		oci.WithManifestCache(manifests),
+		oci.WithLayerCache(layers),
+	}
+
+	switch obj := obj.(type) {
+	case *ocirepospecv1.Repository:
+		if err := b.credentialCache.add(obj, credentials); err != nil {
+			return nil, fmt.Errorf("failed to add repository get to credentials: %w", err)
+		}
+		return repository.NewFromOCIRepoV1(ctx, obj, &auth.Client{
+			Client:     b.httpClient,
+			Cache:      b.authorizationCache,
+			Credential: b.credentialCache.get,
+		}, opts...)
+	case *ctfrepospecv1.Repository:
+		return repository.NewFromCTFRepoV1(ctx, obj, opts...)
+	default:
+		return nil, fmt.Errorf("unsupported repository specification type %T", obj)
+	}
+}

--- a/bindings/go/oci/repository/provider/provider.go
+++ b/bindings/go/oci/repository/provider/provider.go
@@ -24,9 +24,9 @@ import (
 // - An authorization cache for auth tokens
 // - A shared HTTP client with retry capabilities
 type CachingComponentVersionRepositoryProvider struct {
-	scheme *runtime.Scheme
-	*credentialCache
-	*ociCache
+	scheme             *runtime.Scheme
+	credentialCache    *credentialCache
+	ociCache           *ociCache
 	authorizationCache auth.Cache
 	httpClient         *http.Client
 }

--- a/bindings/go/oci/repository/provider/provider_test.go
+++ b/bindings/go/oci/repository/provider/provider_test.go
@@ -1,0 +1,89 @@
+package provider_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"ocm.software/open-component-model/bindings/go/blob/filesystem"
+	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+	"ocm.software/open-component-model/bindings/go/oci/repository/provider"
+	ctfrepospecv1 "ocm.software/open-component-model/bindings/go/oci/spec/repository/v1/ctf"
+	ocmruntime "ocm.software/open-component-model/bindings/go/runtime"
+)
+
+func Test_Provider_Smoke(t *testing.T) {
+	t.Parallel()
+	fs, err := filesystem.NewFS(t.TempDir(), os.O_RDWR)
+	require.NoError(t, err)
+
+	prov := provider.NewComponentVersionRepositoryProvider()
+
+	r := require.New(t)
+	repoSpec := &ctfrepospecv1.Repository{Path: fs.String(), AccessMode: ctfrepospecv1.AccessModeReadWrite}
+	id, err := prov.GetComponentVersionRepositoryCredentialConsumerIdentity(t.Context(), repoSpec)
+	r.NoError(err)
+
+	r.Equal(id[ocmruntime.IdentityAttributePath], fs.String())
+
+	repo1, err := prov.GetComponentVersionRepository(t.Context(), repoSpec, nil)
+	r.NoError(err)
+	r.NotNil(repo1)
+
+	repo2, err := prov.GetComponentVersionRepository(t.Context(), repoSpec, nil)
+	r.NoError(err)
+	r.NotNil(repo2)
+
+	t.Run("basic upload and download of a component version", func(t *testing.T) {
+		name, version := "test-component", "v1.0.0"
+
+		ctx := t.Context()
+		r := require.New(t)
+
+		desc := descriptor.Descriptor{}
+		desc.Component.Name = name
+		desc.Component.Version = version
+		desc.Component.Labels = append(desc.Component.Labels, descriptor.Label{Name: "foo", Value: "bar"})
+		desc.Component.Provider.Name = "ocm.software/open-component-model/bindings/go/oci/integration/test"
+
+		r.NoError(repo1.AddComponentVersion(ctx, &desc))
+
+		// Verify that the component version can be retrieved
+		retrievedDesc, err := repo1.GetComponentVersion(ctx, name, version)
+		r.NoError(err)
+
+		r.Equal(name, retrievedDesc.Component.Name)
+		r.Equal(version, retrievedDesc.Component.Version)
+		r.ElementsMatch(retrievedDesc.Component.Labels, desc.Component.Labels)
+
+		versions, err := repo1.ListComponentVersions(ctx, name)
+		r.NoError(err)
+		r.Contains(versions, version)
+
+		// Now verify that the same component version can be retrieved from the second repository
+		retrievedDesc2, err := repo2.GetComponentVersion(ctx, name, version)
+		r.NoError(err)
+		r.Equal(name, retrievedDesc2.Component.Name)
+
+		t.Run("concurrent access to the same repository", func(t *testing.T) {
+			r := require.New(t)
+			// Attempt to add the same component version concurrently
+			eg, ctx := errgroup.WithContext(t.Context())
+			for i := 0; i < 10; i++ {
+				eg.Go(func() error {
+					return repo1.AddComponentVersion(ctx, &desc)
+				})
+				eg.Go(func() error {
+					return repo2.AddComponentVersion(ctx, &desc)
+				})
+			}
+			r.NoError(eg.Wait())
+
+			// Verify that the component version still exists and was not corrupted during write
+			_, err := repo1.GetComponentVersion(ctx, name, version)
+			r.NoError(err)
+		})
+	})
+}

--- a/bindings/go/oci/repository_options.go
+++ b/bindings/go/oci/repository_options.go
@@ -49,10 +49,17 @@ func WithScheme(scheme *runtime.Scheme) RepositoryOption {
 	}
 }
 
-// WithOCIDescriptorCache sets the local oci descriptor cache for the repository.
-func WithOCIDescriptorCache(memory cache.OCIDescriptorCache) RepositoryOption {
+// WithManifestCache sets the local oci descriptor cache for manifests.
+func WithManifestCache(memory cache.OCIDescriptorCache) RepositoryOption {
 	return func(o *RepositoryOptions) {
 		o.LocalManifestCache = memory
+	}
+}
+
+// WithLayerCache sets the local oci descriptor cache for the layers.
+func WithLayerCache(memory cache.OCIDescriptorCache) RepositoryOption {
+	return func(o *RepositoryOptions) {
+		o.LocalLayerCache = memory
 	}
 }
 

--- a/bindings/go/oci/spec/credentials/identity/v1/type.go
+++ b/bindings/go/oci/spec/credentials/identity/v1/type.go
@@ -14,8 +14,8 @@ import (
 // used when translating from a repository type into a consumer identity.
 var Type = runtime.NewUnversionedType("OCIRepository")
 
-func IdentityFromOCIRepository(repository oci.Repository) (runtime.Identity, error) {
-	repoURL, err := url.Parse(repository.BaseUrl)
+func IdentityFromOCIRepository(repository *oci.Repository) (runtime.Identity, error) {
+	repoURL, err := runtime.ParseURLAndAllowNoScheme(repository.BaseUrl)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse OCI repository URL: %w", err)
 	}
@@ -50,7 +50,7 @@ func IdentityFromOCIRepository(repository oci.Repository) (runtime.Identity, err
 	return identity, nil
 }
 
-func IdentityFromCTFRepository(repository ctf.Repository) (runtime.Identity, error) {
+func IdentityFromCTFRepository(repository *ctf.Repository) (runtime.Identity, error) {
 	identity := runtime.Identity{
 		runtime.IdentityAttributePath: repository.Path,
 	}

--- a/bindings/go/oci/spec/credentials/identity/v1/type_test.go
+++ b/bindings/go/oci/spec/credentials/identity/v1/type_test.go
@@ -130,7 +130,7 @@ func TestIdentityFromOCIRepository(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "invalid URL - missing scheme (not absolute)",
+			name: "URL - missing scheme (not absolute)",
 			repository: oci.Repository{
 				BaseUrl: "registry.example.com/v2",
 			},
@@ -139,6 +139,20 @@ func TestIdentityFromOCIRepository(t *testing.T) {
 				runtime.IdentityAttributeHostname: "registry.example.com",
 				runtime.IdentityAttributePath:     "/v2",
 				runtime.IdentityAttributePort:     "443",
+				runtime.IdentityAttributeScheme:   "https",
+			},
+			wantErr: false,
+		},
+		{
+			name: "URL - missing scheme (localhost)",
+			repository: oci.Repository{
+				BaseUrl: "localhost:1111/v2",
+			},
+			want: runtime.Identity{
+				runtime.IdentityAttributeType:     Type.String(),
+				runtime.IdentityAttributeHostname: "localhost",
+				runtime.IdentityAttributePath:     "/v2",
+				runtime.IdentityAttributePort:     "1111",
 				runtime.IdentityAttributeScheme:   "https",
 			},
 			wantErr: false,
@@ -163,7 +177,7 @@ func TestIdentityFromOCIRepository(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := IdentityFromOCIRepository(tt.repository)
+			got, err := IdentityFromOCIRepository(&tt.repository)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -195,7 +209,7 @@ func TestIdentityFromCTFRepository(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := IdentityFromCTFRepository(tt.repository)
+			got, err := IdentityFromCTFRepository(&tt.repository)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 			assert.Equal(t, Type, got.GetType())


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

In the current OCI lib there is no implementation that can switch based on the Type on which repository to create / resolve efficiently, leaving it up to users / the CLI.

This implementation provides an efficient and easy way to create component version repositories based on repository specifications.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

This ultimately solves the problem of allowing an implementation that can be used for the plugin manager through the provider interface.