### PR TITLE
fix: correct resource contract

### DIFF
--- a/bindings/go/plugin/internal/testplugin-resource/main.go
+++ b/bindings/go/plugin/internal/testplugin-resource/main.go
@@ -21,8 +21,8 @@ import (
 
 type TestPlugin struct{}
 
-func (m *TestPlugin) GetGlobalResource(ctx context.Context, request *v1.GetResourceRequest, credentials map[string]string) (*v1.GetResourceResponse, error) {
-	return &v1.GetResourceResponse{
+func (m *TestPlugin) GetGlobalResource(ctx context.Context, request *v1.GetGlobalResourceRequest, credentials map[string]string) (*v1.GetGlobalResourceResponse, error) {
+	return &v1.GetGlobalResourceResponse{
 		Location: types.Location{
 			LocationType: types.LocationTypeLocalFile,
 			Value:        "/tmp/to/file",
@@ -30,8 +30,8 @@ func (m *TestPlugin) GetGlobalResource(ctx context.Context, request *v1.GetResou
 	}, nil
 }
 
-func (m *TestPlugin) AddGlobalResource(ctx context.Context, request *v1.PostResourceRequest, credentials map[string]string) (*v1.GetGlobalResourceResponse, error) {
-	return &v1.GetGlobalResourceResponse{
+func (m *TestPlugin) AddGlobalResource(ctx context.Context, request *v1.AddGlobalResourceRequest, credentials map[string]string) (*v1.AddGlobalResourceResponse, error) {
+	return &v1.AddGlobalResourceResponse{
 		Resource: &descriptorv2.Resource{
 			ElementMeta: descriptorv2.ElementMeta{
 				ObjectMeta: descriptorv2.ObjectMeta{

--- a/bindings/go/plugin/manager/contracts/resource/v1/contracts.go
+++ b/bindings/go/plugin/manager/contracts/resource/v1/contracts.go
@@ -17,13 +17,13 @@ type IdentityProvider[T runtime.Typed] interface {
 type ReadResourcePluginContract interface {
 	contracts.PluginBase
 	IdentityProvider[runtime.Typed]
-	GetGlobalResource(ctx context.Context, request *GetResourceRequest, credentials map[string]string) (*GetResourceResponse, error)
+	GetGlobalResource(ctx context.Context, request *GetGlobalResourceRequest, credentials map[string]string) (*GetGlobalResourceResponse, error)
 }
 
 type WriteResourcePluginContract interface {
 	contracts.PluginBase
 	IdentityProvider[runtime.Typed]
-	AddGlobalResource(ctx context.Context, request *PostResourceRequest, credentials map[string]string) (*GetGlobalResourceResponse, error)
+	AddGlobalResource(ctx context.Context, request *AddGlobalResourceRequest, credentials map[string]string) (*AddGlobalResourceResponse, error)
 }
 
 // ReadWriteResourcePluginContract is the contract defining Add and Get global resources.

--- a/bindings/go/plugin/manager/contracts/resource/v1/types.go
+++ b/bindings/go/plugin/manager/contracts/resource/v1/types.go
@@ -6,18 +6,19 @@ import (
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
-type GetResourceRequest struct {
-	types.Location
+type GetGlobalResourceRequest struct {
 	// The resource specification to download
 	*v2.Resource `json:"resource"`
 }
-
-type GetResourceResponse struct {
-	// Location where the resource will be downloaded to and can be accessed.
+type GetGlobalResourceResponse struct {
 	Location types.Location `json:"location"`
 }
 
-type PostResourceRequest struct {
+type AddGlobalResourceRequest struct {
+	Resource *v2.Resource `json:"resource"`
+}
+
+type AddGlobalResourceResponse struct {
 	// The ResourceLocation of the Local Resource
 	ResourceLocation types.Location `json:"resourceLocation"`
 	Resource         *v2.Resource   `json:"resource"`
@@ -29,8 +30,4 @@ type GetIdentityRequest[T runtime.Typed] struct {
 
 type GetIdentityResponse struct {
 	Identity map[string]string `json:"identity"`
-}
-
-type GetGlobalResourceResponse struct {
-	Resource *v2.Resource `json:"resource"`
 }

--- a/bindings/go/plugin/manager/manager.go
+++ b/bindings/go/plugin/manager/manager.go
@@ -20,6 +20,7 @@ import (
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialrepository"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/digestprocessor"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/input"
+	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/resource"
 	mtypes "ocm.software/open-component-model/bindings/go/plugin/manager/types"
 )
 
@@ -34,6 +35,7 @@ type PluginManager struct {
 	CredentialRepositoryRegistry       *credentialrepository.RepositoryRegistry
 	InputRegistry                      *input.RepositoryRegistry
 	DigestProcessorRegistry            *digestprocessor.RepositoryRegistry
+	ResourcePluginRegistry             *resource.ResourceRegistry
 
 	mu sync.Mutex
 
@@ -52,6 +54,7 @@ func NewPluginManager(ctx context.Context) *PluginManager {
 		CredentialRepositoryRegistry:       credentialrepository.NewCredentialRepositoryRegistry(ctx),
 		InputRegistry:                      input.NewInputRepositoryRegistry(ctx),
 		DigestProcessorRegistry:            digestprocessor.NewDigestProcessorRegistry(ctx),
+		ResourcePluginRegistry:             resource.NewResourceRegistry(ctx),
 		baseCtx:                            ctx,
 	}
 }
@@ -253,6 +256,11 @@ func (pm *PluginManager) addPlugin(ctx context.Context, ocmConfig *v1.Config, pl
 		case mtypes.DigestProcessorPluginType:
 			slog.DebugContext(ctx, "adding digest processor plugin", "id", plugin.ID)
 			if err := pm.DigestProcessorRegistry.AddPlugin(plugin, typs[0].Type); err != nil {
+				return fmt.Errorf("failed to register plugin %s: %w", plugin.ID, err)
+			}
+		case mtypes.ResourceRepositoryPluginType:
+			slog.DebugContext(ctx, "adding resource repository plugin", "id", plugin.ID)
+			if err := pm.ResourcePluginRegistry.AddPlugin(plugin, typs[0].Type); err != nil {
 				return fmt.Errorf("failed to register plugin %s: %w", plugin.ID, err)
 			}
 		}

--- a/bindings/go/plugin/manager/registries/resource/endpoints_function.go
+++ b/bindings/go/plugin/manager/registries/resource/endpoints_function.go
@@ -55,7 +55,7 @@ func handleGetIdentity(plugin v1.ReadWriteResourcePluginContract) http.HandlerFu
 // handleGetGlobalResource handles the GetGlobalResource endpoint
 func handleGetGlobalResource(plugin v1.ReadWriteResourcePluginContract) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var request v1.GetResourceRequest
+		var request v1.GetGlobalResourceRequest
 		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 			handleError(w, err, http.StatusBadRequest, "failed to unmarshal request")
 			return
@@ -74,7 +74,7 @@ func handleGetGlobalResource(plugin v1.ReadWriteResourcePluginContract) http.Han
 // handleAddGlobalResource handles the AddGlobalResource endpoint
 func handleAddGlobalResource(plugin v1.ReadWriteResourcePluginContract) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var request v1.PostResourceRequest
+		var request v1.AddGlobalResourceRequest
 		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 			handleError(w, err, http.StatusBadRequest, "failed to unmarshal request")
 			return
@@ -128,7 +128,7 @@ func RegisterResourcePlugin[T runtime.Typed](
 	}
 
 	// Add resource type to the plugin's types
-	c.CurrentTypes.Types[types.ResourcePluginType] = append(c.CurrentTypes.Types[types.ResourcePluginType], types.Type{
+	c.CurrentTypes.Types[types.ResourceRepositoryPluginType] = append(c.CurrentTypes.Types[types.ResourceRepositoryPluginType], types.Type{
 		Type:       typ,
 		JSONSchema: schema,
 	})

--- a/bindings/go/plugin/manager/registries/resource/endpoints_function_test.go
+++ b/bindings/go/plugin/manager/registries/resource/endpoints_function_test.go
@@ -19,15 +19,15 @@ type mockPlugin struct {
 	contracts.EmptyBasePlugin
 }
 
-func (m *mockPlugin) GetIdentity(ctx context.Context, request *v1.GetIdentityRequest[runtime.Typed]) (*v1.GetIdentityResponse, error) {
+func (m mockPlugin) GetIdentity(ctx context.Context, request *v1.GetIdentityRequest[runtime.Typed]) (*v1.GetIdentityResponse, error) {
 	return nil, nil
 }
 
-func (m *mockPlugin) GetGlobalResource(ctx context.Context, request *v1.GetResourceRequest, credentials map[string]string) (*v1.GetResourceResponse, error) {
+func (m mockPlugin) GetGlobalResource(ctx context.Context, request *v1.GetGlobalResourceRequest, credentials map[string]string) (*v1.GetGlobalResourceResponse, error) {
 	return nil, nil
 }
 
-func (m *mockPlugin) AddGlobalResource(ctx context.Context, request *v1.PostResourceRequest, credentials map[string]string) (*v1.GetGlobalResourceResponse, error) {
+func (m mockPlugin) AddGlobalResource(ctx context.Context, request *v1.AddGlobalResourceRequest, credentials map[string]string) (*v1.AddGlobalResourceResponse, error) {
 	return nil, nil
 }
 

--- a/bindings/go/plugin/manager/registries/resource/implementations.go
+++ b/bindings/go/plugin/manager/registries/resource/implementations.go
@@ -74,7 +74,7 @@ func (p *RepositoryPlugin) GetIdentity(ctx context.Context, request *v1.GetIdent
 }
 
 // GetGlobalResource retrieves a global resource.
-func (p *RepositoryPlugin) GetGlobalResource(ctx context.Context, req *v1.GetResourceRequest, credentials map[string]string) (*v1.GetResourceResponse, error) {
+func (p *RepositoryPlugin) GetGlobalResource(ctx context.Context, req *v1.GetGlobalResourceRequest, credentials map[string]string) (*v1.GetGlobalResourceResponse, error) {
 	if err := p.validateEndpoint(req.Access, p.jsonSchema); err != nil {
 		return nil, fmt.Errorf("failed to validate type %q: %w", p.ID, err)
 	}
@@ -84,7 +84,7 @@ func (p *RepositoryPlugin) GetGlobalResource(ctx context.Context, req *v1.GetRes
 		return nil, fmt.Errorf("error converting credentials: %w", err)
 	}
 
-	var response v1.GetResourceResponse
+	var response v1.GetGlobalResourceResponse
 	if err := plugins.Call(ctx, p.client, p.config.Type, p.location, GetGlobalResource, http.MethodPost, plugins.WithPayload(req), plugins.WithResult(&response), plugins.WithHeader(credHeader)); err != nil {
 		return nil, fmt.Errorf("failed to get global resource from plugin %q: %w", p.ID, err)
 	}
@@ -92,7 +92,7 @@ func (p *RepositoryPlugin) GetGlobalResource(ctx context.Context, req *v1.GetRes
 }
 
 // AddGlobalResource adds a global resource.
-func (p *RepositoryPlugin) AddGlobalResource(ctx context.Context, req *v1.PostResourceRequest, credentials map[string]string) (*v1.GetGlobalResourceResponse, error) {
+func (p *RepositoryPlugin) AddGlobalResource(ctx context.Context, req *v1.AddGlobalResourceRequest, credentials map[string]string) (*v1.AddGlobalResourceResponse, error) {
 	if err := p.validateEndpoint(req.Resource.Access, p.jsonSchema); err != nil {
 		return nil, fmt.Errorf("failed to validate type %q: %w", p.ID, err)
 	}
@@ -102,7 +102,7 @@ func (p *RepositoryPlugin) AddGlobalResource(ctx context.Context, req *v1.PostRe
 		return nil, fmt.Errorf("error converting credentials: %w", err)
 	}
 
-	var response v1.GetGlobalResourceResponse
+	var response v1.AddGlobalResourceResponse
 	if err := plugins.Call(ctx, p.client, p.config.Type, p.location, AddGlobalResource, http.MethodPost, plugins.WithPayload(req), plugins.WithResult(&response), plugins.WithHeader(credHeader)); err != nil {
 		return nil, fmt.Errorf("failed to add global resource to plugin %q: %w", p.ID, err)
 	}

--- a/bindings/go/plugin/manager/registries/resource/implementations_test.go
+++ b/bindings/go/plugin/manager/registries/resource/implementations_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestGetGlobalResource(t *testing.T) {
 	// Setup test server
-	response := &v1.GetResourceResponse{}
+	response := &v1.GetGlobalResourceRequest{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == GetGlobalResource && r.Method == http.MethodPost {
 			err := json.NewEncoder(w).Encode(response)
@@ -33,11 +33,11 @@ func TestGetGlobalResource(t *testing.T) {
 	plugin := NewResourceRepositoryPlugin(server.Client(), "test-plugin", server.URL, types.Config{
 		ID:         "test-plugin",
 		Type:       types.TCP,
-		PluginType: types.ResourcePluginType,
+		PluginType: types.ResourceRepositoryPluginType,
 	}, server.URL, []byte(`{}`))
 
 	ctx := context.Background()
-	_, err := plugin.GetGlobalResource(ctx, &v1.GetResourceRequest{
+	_, err := plugin.GetGlobalResource(ctx, &v1.GetGlobalResourceRequest{
 		Resource: &descriptorv2.Resource{
 			ElementMeta: descriptorv2.ElementMeta{
 				ObjectMeta: descriptorv2.ObjectMeta{
@@ -77,11 +77,11 @@ func TestAddGlobalResource(t *testing.T) {
 	plugin := NewResourceRepositoryPlugin(server.Client(), "test-plugin", server.URL, types.Config{
 		ID:         "test-plugin",
 		Type:       types.TCP,
-		PluginType: types.ResourcePluginType,
+		PluginType: types.ResourceRepositoryPluginType,
 	}, server.URL, []byte(`{}`))
 
 	ctx := context.Background()
-	_, err := plugin.AddGlobalResource(ctx, &v1.PostResourceRequest{
+	_, err := plugin.AddGlobalResource(ctx, &v1.AddGlobalResourceRequest{
 		Resource: &descriptorv2.Resource{
 			ElementMeta: descriptorv2.ElementMeta{
 				ObjectMeta: descriptorv2.ObjectMeta{
@@ -119,7 +119,7 @@ func TestPing(t *testing.T) {
 	plugin := NewResourceRepositoryPlugin(server.Client(), "test-plugin", server.URL, types.Config{
 		ID:         "test-plugin",
 		Type:       types.TCP,
-		PluginType: types.ResourcePluginType,
+		PluginType: types.ResourceRepositoryPluginType,
 	}, server.URL, []byte(`{}`))
 
 	ctx := context.Background()
@@ -147,7 +147,7 @@ func TestValidateEndpoint(t *testing.T) {
 	plugin := NewResourceRepositoryPlugin(server.Client(), "test-plugin", server.URL, types.Config{
 		ID:         "test-plugin",
 		Type:       types.TCP,
-		PluginType: types.ResourcePluginType,
+		PluginType: types.ResourceRepositoryPluginType,
 	}, server.URL, []byte(validSchema))
 
 	// Test valid object

--- a/bindings/go/plugin/manager/registries/resource/registry_test.go
+++ b/bindings/go/plugin/manager/registries/resource/registry_test.go
@@ -31,7 +31,7 @@ func TestPluginFlow(t *testing.T) {
 	config := mtypes.Config{
 		ID:         "test-plugin-1-resource",
 		Type:       mtypes.Socket,
-		PluginType: mtypes.ResourcePluginType,
+		PluginType: mtypes.ResourceRepositoryPluginType,
 	}
 	serialized, err := json.Marshal(config)
 	require.NoError(t, err)
@@ -56,10 +56,10 @@ func TestPluginFlow(t *testing.T) {
 		Config: mtypes.Config{
 			ID:         "test-plugin-1-resource",
 			Type:       mtypes.Socket,
-			PluginType: mtypes.ResourcePluginType,
+			PluginType: mtypes.ResourceRepositoryPluginType,
 		},
 		Types: map[mtypes.PluginType][]mtypes.Type{
-			mtypes.ResourcePluginType: {
+			mtypes.ResourceRepositoryPluginType: {
 				{
 					Type:       typ,
 					JSONSchema: []byte(`{}`),
@@ -75,7 +75,7 @@ func TestPluginFlow(t *testing.T) {
 	retrievedPlugin, err := registry.GetResourcePlugin(ctx, p)
 	require.NoError(t, err)
 	require.NoError(t, retrievedPlugin.Ping(ctx))
-	resource, err := retrievedPlugin.GetGlobalResource(ctx, &v1.GetResourceRequest{
+	resource, err := retrievedPlugin.GetGlobalResource(ctx, &v1.GetGlobalResourceRequest{
 		Resource: &descriptorv2.Resource{
 			ElementMeta: descriptorv2.ElementMeta{
 				ObjectMeta: descriptorv2.ObjectMeta{
@@ -98,7 +98,7 @@ func TestPluginFlow(t *testing.T) {
 	require.Equal(t, "/tmp/to/file", resource.Location.Value)
 
 	// Test adding a resource
-	addedResource, err := retrievedPlugin.AddGlobalResource(ctx, &v1.PostResourceRequest{
+	addedResource, err := retrievedPlugin.AddGlobalResource(ctx, &v1.AddGlobalResourceRequest{
 		Resource: &descriptorv2.Resource{
 			ElementMeta: descriptorv2.ElementMeta{
 				ObjectMeta: descriptorv2.ObjectMeta{
@@ -153,11 +153,11 @@ func (m *mockResourcePlugin) GetIdentity(ctx context.Context, request *v1.GetIde
 	return nil, nil
 }
 
-func (m *mockResourcePlugin) GetGlobalResource(ctx context.Context, request *v1.GetResourceRequest, creds map[string]string) (*v1.GetResourceResponse, error) {
+func (m *mockResourcePlugin) GetGlobalResource(ctx context.Context, request *v1.GetGlobalResourceRequest, creds map[string]string) (*v1.GetGlobalResourceResponse, error) {
 	return nil, nil
 }
 
-func (m *mockResourcePlugin) AddGlobalResource(ctx context.Context, request *v1.PostResourceRequest, creds map[string]string) (*v1.GetGlobalResourceResponse, error) {
+func (m *mockResourcePlugin) AddGlobalResource(ctx context.Context, request *v1.AddGlobalResourceRequest, creds map[string]string) (*v1.AddGlobalResourceResponse, error) {
 	return nil, nil
 }
 

--- a/bindings/go/plugin/manager/types/types.go
+++ b/bindings/go/plugin/manager/types/types.go
@@ -12,7 +12,7 @@ var (
 	CredentialRepositoryPluginType       PluginType = "credentialRepository" //nolint:gosec // not hardcoded cred
 	InputPluginType                      PluginType = "inputRepository"
 	DigestProcessorPluginType            PluginType = "digestProcessorRepository"
-	ResourcePluginType                   PluginType = "resourceRepository"
+	ResourceRepositoryPluginType         PluginType = "resourceRepository"
 )
 
 type Location struct {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

this corrects the resource contract so that we have the correct typings for global resource downloads

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
