### PR TITLE
feat: allow checking for types that have already been registered

### DIFF
--- a/bindings/go/runtime/registry.go
+++ b/bindings/go/runtime/registry.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -121,7 +122,7 @@ func (r *Scheme) RegisterSchemeType(scheme *Scheme, typ Type) error {
 	}
 
 	if _, exists := r.defaults[typ]; exists {
-		return fmt.Errorf("type %q already registered", typ)
+		return TypeAlreadyRegisteredError(typ)
 	}
 
 	prototype, ok := scheme.defaults[typ]
@@ -135,13 +136,31 @@ func (r *Scheme) RegisterSchemeType(scheme *Scheme, typ Type) error {
 	for alias, forTyp := range scheme.aliases {
 		if forTyp.Equal(typ) {
 			if _, exists := r.aliases[alias]; exists {
-				return fmt.Errorf("alias %q already registered, cannot register for type %q", alias, typ)
+				return fmt.Errorf("%w: cannot register for type %q", TypeAlreadyRegisteredError(alias), typ)
 			}
 			r.aliases[alias] = typ
 		}
 	}
 
 	return nil
+}
+
+// TypeAlreadyRegisteredError is returned when a type is already registered in the scheme.
+// It contains the type that was attempted to be registered.
+//
+// Use IsTypeAlreadyRegisteredError to check for this error type.
+type TypeAlreadyRegisteredError Type
+
+func (e TypeAlreadyRegisteredError) Error() string {
+	return fmt.Sprintf("type %q is already registered", Type(e))
+}
+
+// IsTypeAlreadyRegisteredError checks if the error is of type TypeAlreadyRegisteredError.
+func IsTypeAlreadyRegisteredError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.As(err, new(TypeAlreadyRegisteredError))
 }
 
 // RegisterWithAlias registers a new type with the registry.
@@ -154,10 +173,10 @@ func (r *Scheme) RegisterWithAlias(prototype Typed, types ...Type) error {
 
 	for i, typ := range types {
 		if prototype, exists := r.defaults[typ]; exists {
-			return fmt.Errorf("type %q is already registered as default for %T", typ, prototype)
+			return fmt.Errorf("%w: as default for %T", TypeAlreadyRegisteredError(typ), prototype)
 		}
 		if def, ok := r.aliases[typ]; ok {
-			return fmt.Errorf("type %q is already registered as alias for %q", typ, def)
+			return fmt.Errorf("%w: as alias for %q", TypeAlreadyRegisteredError(typ), def)
 		}
 		if i == 0 {
 			// first type is the def type


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

this introduces an error that returns which type was already registered in a scheme if there was a conflict during registration

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
