### PR TITLE
fix: move locataion ownership from response to request for adding resources

### DIFF
--- a/bindings/go/plugin/manager/contracts/resource/v1/types.go
+++ b/bindings/go/plugin/manager/contracts/resource/v1/types.go
@@ -8,20 +8,23 @@ import (
 
 type GetGlobalResourceRequest struct {
 	// The resource specification to download
-	*v2.Resource `json:"resource"`
+	Resource *v2.Resource `json:"resource"`
 }
 type GetGlobalResourceResponse struct {
+	// Location of the data downloaded based on the GetGlobalResourceRequest.Resource specification.
 	Location types.Location `json:"location"`
 }
 
 type AddGlobalResourceRequest struct {
+	// The ResourceLocation of the Local data to be uploaded under the given Resource specification.
+	ResourceLocation types.Location `json:"resourceLocation"`
+	// Resource specification that describes the resource that should be uploaded.
 	Resource *v2.Resource `json:"resource"`
 }
 
 type AddGlobalResourceResponse struct {
-	// The ResourceLocation of the Local Resource
-	ResourceLocation types.Location `json:"resourceLocation"`
-	Resource         *v2.Resource   `json:"resource"`
+	// Resource specification that describes the resource after it was uploaded.
+	Resource *v2.Resource `json:"resource"`
 }
 
 type GetIdentityRequest[T runtime.Typed] struct {

--- a/bindings/go/plugin/manager/registries/resource/implementations.go
+++ b/bindings/go/plugin/manager/registries/resource/implementations.go
@@ -75,7 +75,7 @@ func (p *RepositoryPlugin) GetIdentity(ctx context.Context, request *v1.GetIdent
 
 // GetGlobalResource retrieves a global resource.
 func (p *RepositoryPlugin) GetGlobalResource(ctx context.Context, req *v1.GetGlobalResourceRequest, credentials map[string]string) (*v1.GetGlobalResourceResponse, error) {
-	if err := p.validateEndpoint(req.Access, p.jsonSchema); err != nil {
+	if err := p.validateEndpoint(req.Resource.Access, p.jsonSchema); err != nil {
 		return nil, fmt.Errorf("failed to validate type %q: %w", p.ID, err)
 	}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

It doesnt make sense that the upload / add of a global resource does not expect a location of the blob data. we should change this 

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
