### PR TITLE
fix: fixup conflict resolution strategy for component constructors

### DIFF
--- a/bindings/go/constructor/construct.go
+++ b/bindings/go/constructor/construct.go
@@ -14,7 +14,12 @@ import (
 	constructor "ocm.software/open-component-model/bindings/go/constructor/runtime"
 	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
 	"ocm.software/open-component-model/bindings/go/oci"
+	ocmruntime "ocm.software/open-component-model/bindings/go/runtime"
 )
+
+// ErrShouldSkipConstruction is an error that indicates that the construction of a component should be skipped,
+// e.g. because the component version already exists in the target repository.
+var ErrShouldSkipConstruction = errors.New("should skip construction")
 
 type Constructor interface {
 	// Construct processes a component constructor specification and creates the corresponding component descriptors.
@@ -97,7 +102,12 @@ func (c *DefaultConstructor) construct(ctx context.Context, component *construct
 
 	// decide how to handle existing component versions in the target repository
 	// based on the configured conflict policy.
-	if err := c.processConflictStrategy(ctx, repo, component); err != nil {
+	conflictingDescriptor, err := ProcessConflictStrategy(ctx, repo, component, c.opts.ComponentVersionConflictPolicy)
+	switch {
+	case errors.Is(err, ErrShouldSkipConstruction):
+		// skip construction if the policy is to skip existing versions, and return the existing descriptor
+		return conflictingDescriptor, nil
+	case err != nil:
 		return nil, err
 	}
 
@@ -112,27 +122,31 @@ func (c *DefaultConstructor) construct(ctx context.Context, component *construct
 	return desc, nil
 }
 
-func (c *DefaultConstructor) processConflictStrategy(ctx context.Context, repo TargetRepository, component *constructor.Component) error {
+// ProcessConflictStrategy checks for existing component versions in the target repository
+// and applies the configured conflict resolution strategy.
+// It returns an error if the policy is to abort and fail, or skips construction by returning ErrShouldSkipConstruction.
+// If the policy is to replace, it logs a warning and does not return a possible existing descriptor for conflict resolution.
+func ProcessConflictStrategy(ctx context.Context, repo TargetRepository, component *constructor.Component, policy ComponentVersionConflictPolicy) (*descriptor.Descriptor, error) {
 	logger := log.Base().With("component", component.Name, "version", component.Version)
-	switch c.opts.ComponentVersionConflictPolicy {
+	switch policy {
 	case ComponentVersionConflictAbortAndFail, ComponentVersionConflictSkip:
 		logger.DebugContext(ctx, "checking for existing component version in target repository", "component", component.Name, "version", component.Version)
-		switch _, err := repo.GetComponentVersion(ctx, component.Name, component.Version); {
+		switch desc, err := repo.GetComponentVersion(ctx, component.Name, component.Version); {
 		case err == nil:
-			if c.opts.ComponentVersionConflictPolicy == ComponentVersionConflictAbortAndFail {
-				return fmt.Errorf("component version %q already exists in target repository", component.ToIdentity())
+			if policy == ComponentVersionConflictAbortAndFail {
+				return desc, fmt.Errorf("component version %q already exists in target repository", component.ToIdentity())
 			}
 			logger.WarnContext(ctx, "component version already exists in target repository, skipping construction", "component", component.Name, "version", component.Version)
-			return nil
+			return desc, ErrShouldSkipConstruction
 		case !errors.Is(err, oci.ErrNotFound):
-			return fmt.Errorf("error checking for existing component version in target repository: %w", err)
+			return nil, fmt.Errorf("error checking for existing component version in target repository: %w", err)
 		default:
 			logger.DebugContext(ctx, "no existing component version found in target repository, continuing with construction", "component", component.Name, "version", component.Version)
 		}
 	case ComponentVersionConflictReplace:
 		logger.WarnContext(ctx, "REPLACING component version in target repository, old component version will no longer be available if it was present before.")
 	}
-	return nil
+	return nil, nil
 }
 
 // createBaseDescriptor initializes a new descriptor with the basic component metadata.
@@ -272,19 +286,16 @@ func (c *DefaultConstructor) processResourceByValue(ctx context.Context, targetR
 		return nil, err
 	}
 
-	var creds map[string]string
-	if c.opts.CredentialProvider != nil {
-		identity, err := repository.GetResourceCredentialConsumerIdentity(ctx, resource)
-		if err != nil {
-			return nil, fmt.Errorf("error getting credential consumer identity of access type %q: %w", resource.Access.GetType(), err)
-		}
+	converted := constructor.ConvertToDescriptorResource(resource)
 
-		if creds, err = c.opts.Resolve(ctx, identity); err != nil {
-			return nil, fmt.Errorf("error resolving credentials for input method of access type %q: %w", resource.Access.GetType(), err)
+	// best effort to resolve credentials for by value resource download.
+	// if no identity is resolved, we assume resolution is simply skipped.
+	var creds map[string]string
+	if identity, err := repository.GetResourceCredentialConsumerIdentity(ctx, resource); err == nil {
+		if creds, err = resolveCredentials(ctx, c.opts.CredentialProvider, identity); err != nil {
+			return nil, fmt.Errorf("error resolving credentials for resource by-value processing %w", err)
 		}
 	}
-
-	converted := constructor.ConvertToDescriptorResource(resource)
 
 	data, err := repository.DownloadResource(ctx, converted, creds)
 	if err != nil {
@@ -333,15 +344,12 @@ func (c *DefaultConstructor) processSourceWithInput(ctx context.Context, targetR
 		return nil, fmt.Errorf("no input method resolvable for input specification of type %q: %w", src.Input.GetType(), err)
 	}
 
+	// best effort to resolve credentials for the input method.
+	// if no identity is resolved, we assume resolution is simply skipped.
 	var creds map[string]string
-	if c.opts.CredentialProvider != nil {
-		identity, err := method.GetSourceCredentialConsumerIdentity(ctx, src)
-		if err != nil {
-			return nil, fmt.Errorf("error getting credential consumer identity of type %q: %w", src.Input.GetType(), err)
-		}
-
-		if creds, err = c.opts.Resolve(ctx, identity); err != nil {
-			return nil, fmt.Errorf("error resolving credentials for input method of type %q: %w", src.Input.GetType(), err)
+	if identity, err := method.GetSourceCredentialConsumerIdentity(ctx, src); err == nil {
+		if creds, err = resolveCredentials(ctx, c.opts.CredentialProvider, identity); err != nil {
+			return nil, fmt.Errorf("error resolving credentials for source input method: %w", err)
 		}
 	}
 
@@ -377,15 +385,12 @@ func (c *DefaultConstructor) processResourceWithInput(ctx context.Context, targe
 		return nil, fmt.Errorf("no input method resolvable for input specification of type %q: %w", resource.Input.GetType(), err)
 	}
 
+	// best effort to resolve credentials for the input method.
+	// if no identity is resolved, we assume resolution is simply skipped.
 	var creds map[string]string
-	if c.opts.CredentialProvider != nil {
-		identity, err := method.GetResourceCredentialConsumerIdentity(ctx, resource)
-		if err != nil {
-			return nil, fmt.Errorf("error getting credential consumer identity of type %q: %w", resource.Input.GetType(), err)
-		}
-
-		if creds, err = c.opts.Resolve(ctx, identity); err != nil {
-			return nil, fmt.Errorf("error resolving credentials for input method of type %q: %w", resource.Input.GetType(), err)
+	if identity, err := method.GetResourceCredentialConsumerIdentity(ctx, resource); err == nil {
+		if creds, err = resolveCredentials(ctx, c.opts.CredentialProvider, identity); err != nil {
+			return nil, fmt.Errorf("error resolving credentials for resource input method: %w", err)
 		}
 	}
 
@@ -509,4 +514,23 @@ func newConcurrencyGroup(ctx context.Context, limit int) (*errgroup.Group, conte
 		eg.SetLimit(cores)
 	}
 	return eg, egctx
+}
+
+// resolveCredentials attempts to resolve credentials for a given credential consumerIdentity.
+// It returns the resolved credentials and any error that occurred during resolution.
+// If no credentials are needed or available, it returns nil credentials and no error.
+func resolveCredentials(ctx context.Context, provider CredentialProvider, consumerIdentity ocmruntime.Identity) (map[string]string, error) {
+	logger := log.Base().With("identity", consumerIdentity)
+
+	if provider == nil {
+		logger.DebugContext(ctx, "no credential provider configured, skipping credential resolution")
+		return nil, nil
+	}
+
+	if consumerIdentity == nil {
+		logger.DebugContext(ctx, "no credential consumer identity found, proceeding without credentials")
+		return nil, nil
+	}
+
+	return provider.Resolve(ctx, consumerIdentity)
 }

--- a/bindings/go/constructor/construct_resource_test.go
+++ b/bindings/go/constructor/construct_resource_test.go
@@ -645,7 +645,7 @@ func TestConstructWithCredentialResolutionFailure(t *testing.T) {
 	// Process the constructor and expect an error
 	_, err := constructorInstance.Construct(t.Context(), constructor)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "error resolving credentials for input method")
+	assert.Contains(t, err.Error(), "error resolving credentials for resource input method")
 }
 
 func TestConstructWithResourceByValueFailure(t *testing.T) {

--- a/bindings/go/constructor/construct_source_test.go
+++ b/bindings/go/constructor/construct_source_test.go
@@ -455,7 +455,7 @@ func TestConstructWithSourceCredentialResolutionError(t *testing.T) {
 	// Process the constructor and expect an error
 	_, err := ctor.Construct(t.Context(), constructor)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "error resolving credentials for input method")
+	assert.Contains(t, err.Error(), "error resolving credentials for source input method")
 }
 
 func TestConstructWithMultipleSources(t *testing.T) {

--- a/bindings/go/constructor/construct_test.go
+++ b/bindings/go/constructor/construct_test.go
@@ -236,6 +236,7 @@ func TestComponentVersionConflictPolicies(t *testing.T) {
 		existing       bool
 		expectError    bool
 		expectReplaced bool
+		components     []*constructorruntime.Component
 	}{
 		{
 			name:           "AbortAndFail with existing component",
@@ -243,6 +244,16 @@ func TestComponentVersionConflictPolicies(t *testing.T) {
 			existing:       true,
 			expectError:    true,
 			expectReplaced: false,
+			components: []*constructorruntime.Component{
+				{
+					ComponentMeta: constructorruntime.ComponentMeta{
+						ObjectMeta: constructorruntime.ObjectMeta{
+							Name:    "test-component",
+							Version: "1.0.0",
+						},
+					},
+				},
+			},
 		},
 		{
 			name:           "AbortAndFail with no existing component",
@@ -250,6 +261,16 @@ func TestComponentVersionConflictPolicies(t *testing.T) {
 			existing:       false,
 			expectError:    false,
 			expectReplaced: false,
+			components: []*constructorruntime.Component{
+				{
+					ComponentMeta: constructorruntime.ComponentMeta{
+						ObjectMeta: constructorruntime.ObjectMeta{
+							Name:    "test-component",
+							Version: "1.0.0",
+						},
+					},
+				},
+			},
 		},
 		{
 			name:           "Skip with existing component",
@@ -257,6 +278,16 @@ func TestComponentVersionConflictPolicies(t *testing.T) {
 			existing:       true,
 			expectError:    false,
 			expectReplaced: false,
+			components: []*constructorruntime.Component{
+				{
+					ComponentMeta: constructorruntime.ComponentMeta{
+						ObjectMeta: constructorruntime.ObjectMeta{
+							Name:    "test-component",
+							Version: "1.0.0",
+						},
+					},
+				},
+			},
 		},
 		{
 			name:           "Skip with no existing component",
@@ -264,6 +295,16 @@ func TestComponentVersionConflictPolicies(t *testing.T) {
 			existing:       false,
 			expectError:    false,
 			expectReplaced: false,
+			components: []*constructorruntime.Component{
+				{
+					ComponentMeta: constructorruntime.ComponentMeta{
+						ObjectMeta: constructorruntime.ObjectMeta{
+							Name:    "test-component",
+							Version: "1.0.0",
+						},
+					},
+				},
+			},
 		},
 		{
 			name:           "Replace with existing component",
@@ -271,6 +312,16 @@ func TestComponentVersionConflictPolicies(t *testing.T) {
 			existing:       true,
 			expectError:    false,
 			expectReplaced: true,
+			components: []*constructorruntime.Component{
+				{
+					ComponentMeta: constructorruntime.ComponentMeta{
+						ObjectMeta: constructorruntime.ObjectMeta{
+							Name:    "test-component",
+							Version: "1.0.0",
+						},
+					},
+				},
+			},
 		},
 		{
 			name:           "Replace with no existing component",
@@ -278,6 +329,116 @@ func TestComponentVersionConflictPolicies(t *testing.T) {
 			existing:       false,
 			expectError:    false,
 			expectReplaced: false,
+			components: []*constructorruntime.Component{
+				{
+					ComponentMeta: constructorruntime.ComponentMeta{
+						ObjectMeta: constructorruntime.ObjectMeta{
+							Name:    "test-component",
+							Version: "1.0.0",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "Multiple components with different versions",
+			policy:         ComponentVersionConflictReplace,
+			existing:       true,
+			expectError:    false,
+			expectReplaced: true,
+			components: []*constructorruntime.Component{
+				{
+					ComponentMeta: constructorruntime.ComponentMeta{
+						ObjectMeta: constructorruntime.ObjectMeta{
+							Name:    "test-component-1",
+							Version: "1.0.0",
+						},
+					},
+				},
+				{
+					ComponentMeta: constructorruntime.ComponentMeta{
+						ObjectMeta: constructorruntime.ObjectMeta{
+							Name:    "test-component-2",
+							Version: "2.0.0",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "Same component different versions",
+			policy:         ComponentVersionConflictReplace,
+			existing:       true,
+			expectError:    false,
+			expectReplaced: true,
+			components: []*constructorruntime.Component{
+				{
+					ComponentMeta: constructorruntime.ComponentMeta{
+						ObjectMeta: constructorruntime.ObjectMeta{
+							Name:    "test-component",
+							Version: "1.0.0",
+						},
+					},
+				},
+				{
+					ComponentMeta: constructorruntime.ComponentMeta{
+						ObjectMeta: constructorruntime.ObjectMeta{
+							Name:    "test-component",
+							Version: "2.0.0",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "Empty component list",
+			policy:         ComponentVersionConflictReplace,
+			existing:       false,
+			expectError:    false,
+			expectReplaced: false,
+			components:     []*constructorruntime.Component{},
+		},
+		{
+			name:           "Invalid component version",
+			policy:         ComponentVersionConflictReplace,
+			existing:       false,
+			expectError:    false,
+			expectReplaced: false,
+			components: []*constructorruntime.Component{
+				{
+					ComponentMeta: constructorruntime.ComponentMeta{
+						ObjectMeta: constructorruntime.ObjectMeta{
+							Name:    "test-component",
+							Version: "", // Empty version
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "Multiple components with mixed policies",
+			policy:         ComponentVersionConflictReplace,
+			existing:       true,
+			expectError:    false,
+			expectReplaced: true,
+			components: []*constructorruntime.Component{
+				{
+					ComponentMeta: constructorruntime.ComponentMeta{
+						ObjectMeta: constructorruntime.ObjectMeta{
+							Name:    "test-component-1",
+							Version: "1.0.0",
+						},
+					},
+				},
+				{
+					ComponentMeta: constructorruntime.ComponentMeta{
+						ObjectMeta: constructorruntime.ObjectMeta{
+							Name:    "test-component-2",
+							Version: "1.0.0",
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -289,55 +450,55 @@ func TestComponentVersionConflictPolicies(t *testing.T) {
 				TargetRepositoryProvider:       &mockTargetRepositoryProvider{repo: repo},
 			}
 
-			component := &constructorruntime.Component{
-				ComponentMeta: constructorruntime.ComponentMeta{
-					ObjectMeta: constructorruntime.ObjectMeta{
-						Name:    "test-component",
-						Version: "1.0.0",
-					},
-				},
-			}
-
 			if tt.existing {
-				existingDesc := &descriptor.Descriptor{
-					Component: descriptor.Component{
-						ComponentMeta: descriptor.ComponentMeta{
-							ObjectMeta: descriptor.ObjectMeta{
-								Name:    component.Name,
-								Version: component.Version,
+				for _, component := range tt.components {
+					existingDesc := &descriptor.Descriptor{
+						Component: descriptor.Component{
+							ComponentMeta: descriptor.ComponentMeta{
+								ObjectMeta: descriptor.ObjectMeta{
+									Name:    component.Name,
+									Version: component.Version,
+								},
 							},
 						},
-					},
+					}
+					err := repo.AddComponentVersion(t.Context(), existingDesc)
+					require.NoError(t, err)
 				}
-				err := repo.AddComponentVersion(context.Background(), existingDesc)
-				require.NoError(t, err)
 			}
 
 			constructor := NewDefaultConstructor(opts)
 			compConstructor := &constructorruntime.ComponentConstructor{
-				Components: []constructorruntime.Component{*component},
+				Components: make([]constructorruntime.Component, len(tt.components)),
+			}
+			for i, comp := range tt.components {
+				compConstructor.Components[i] = *comp
 			}
 
-			descriptors, err := constructor.Construct(context.Background(), compConstructor)
+			descriptors, err := constructor.Construct(t.Context(), compConstructor)
 
 			if tt.expectError {
 				assert.Error(t, err)
 				assert.Nil(t, descriptors)
 			} else {
 				assert.NoError(t, err)
-				assert.Len(t, descriptors, 1)
-				assert.Equal(t, component.Name, descriptors[0].Component.Name)
-				assert.Equal(t, component.Version, descriptors[0].Component.Version)
+				if len(tt.components) > 0 {
+					assert.Len(t, descriptors, len(tt.components))
+					for i, component := range tt.components {
+						assert.Equal(t, component.Name, descriptors[i].Component.Name)
+						assert.Equal(t, component.Version, descriptors[i].Component.Version)
+					}
+				} else {
+					assert.Empty(t, descriptors)
+				}
 			}
 
-			if tt.expectReplaced {
-				desc, err := repo.GetComponentVersion(context.Background(), component.Name, component.Version)
-				require.NoError(t, err)
-				assert.NotNil(t, desc)
-			} else if tt.existing && tt.policy == ComponentVersionConflictSkip {
-				desc, err := repo.GetComponentVersion(context.Background(), component.Name, component.Version)
-				require.NoError(t, err)
-				assert.NotNil(t, desc)
+			if tt.expectReplaced || tt.existing && tt.policy == ComponentVersionConflictSkip {
+				for _, component := range tt.components {
+					desc, err := repo.GetComponentVersion(t.Context(), component.Name, component.Version)
+					require.NoError(t, err)
+					assert.NotNil(t, desc)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

currently the constructor conflict resolution strategy did not properly abort and return the conflicting descriptors, this has been fixed.

additionally, the consumer identity will now not cause a failing construction if construction is still possible without credentials (failed resolution of an identity is logged with debug)


#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
