### PR TITLE
docs: add code owner discussion to agenda

### DIFF
--- a/docs/steering/meeting-notes/2025-07-06.md
+++ b/docs/steering/meeting-notes/2025-07-06.md
@@ -32,6 +32,8 @@ Quorum: ✅
 
 - Revisit last action items
 - Discuss project onboarding (possibly NeoNephos Github, TBD)
+- Discuss Github Code Owners "Reset" (Charter states: A Contributor may 
+  become a Code Owners by a majority approval of the existing Code Owners.)
 - Present LFX tools, e.g. for voting
 - Revisit Developer Certificate of Origin (DCO) and mandatory enforcement
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Since we established the TSC members through a majority vote as Code Owners in the last TSC meeting, there was uncertainty whether the other already existing Code Owners should be removed (or at least should also be confirmed through a majority vote). 

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
