### PR TITLE
feat!: make referrer indexes and lookup optional and disable by default

### DIFF
--- a/bindings/go/oci/integration/integration_test.go
+++ b/bindings/go/oci/integration/integration_test.go
@@ -185,7 +185,7 @@ func Test_Integration_OCIRepository(t *testing.T) {
 			uploadDownloadBarebonesComponentVersion(t, repo, "test-component", "v1.0.0")
 		})
 
-		t.Run("basic upload and download of a component version", func(t *testing.T) {
+		t.Run("basic upload and download of a component version (with index based referrer tracking)", func(t *testing.T) {
 			repo, err := oci.NewRepository(oci.WithResolver(resolver), oci.WithReferrerTrackingPolicy(oci.ReferrerTrackingPolicyByIndexAndSubject))
 			r.NoError(err)
 			uploadDownloadBarebonesComponentVersion(t, repo, "test-component", "v1.0.0")

--- a/bindings/go/oci/integration/integration_test.go
+++ b/bindings/go/oci/integration/integration_test.go
@@ -73,7 +73,8 @@ func Test_Integration_OCIRepository_BackwardsCompatibility(t *testing.T) {
 
 	reg := "ghcr.io/open-component-model/ocm"
 
-	resolver := urlresolver.New(reg)
+	resolver, err := urlresolver.New(urlresolver.WithBaseURL(reg))
+	r.NoError(err)
 	resolver.SetClient(createAuthClient(reg, user, password))
 
 	scheme := ocmruntime.NewScheme()
@@ -166,9 +167,12 @@ func Test_Integration_OCIRepository(t *testing.T) {
 
 		client := createAuthClient(registryAddress, testUsername, password)
 
-		resolver := urlresolver.New(registryAddress)
-		resolver.SetClient(client)
-		resolver.PlainHTTP = true
+		resolver, err := urlresolver.New(
+			urlresolver.WithBaseURL(registryAddress),
+			urlresolver.WithPlainHTTP(true),
+			urlresolver.WithBaseClient(client),
+		)
+		r.NoError(err)
 
 		repo, err := oci.NewRepository(oci.WithResolver(resolver))
 		r.NoError(err)
@@ -178,6 +182,12 @@ func Test_Integration_OCIRepository(t *testing.T) {
 		})
 
 		t.Run("basic upload and download of a component version", func(t *testing.T) {
+			uploadDownloadBarebonesComponentVersion(t, repo, "test-component", "v1.0.0")
+		})
+
+		t.Run("basic upload and download of a component version", func(t *testing.T) {
+			repo, err := oci.NewRepository(oci.WithResolver(resolver), oci.WithReferrerTrackingPolicy(oci.ReferrerTrackingPolicyByIndexAndSubject))
+			r.NoError(err)
 			uploadDownloadBarebonesComponentVersion(t, repo, "test-component", "v1.0.0")
 		})
 
@@ -457,9 +467,12 @@ func testResolverConnectivity(t *testing.T, address, reference string, client *a
 	ctx := t.Context()
 	r := require.New(t)
 
-	resolver := urlresolver.New(address)
-	resolver.SetClient(client)
-	resolver.PlainHTTP = true
+	resolver, err := urlresolver.New(
+		urlresolver.WithBaseURL(address),
+		urlresolver.WithPlainHTTP(true),
+		urlresolver.WithBaseClient(client),
+	)
+	r.NoError(err)
 
 	store, err := resolver.StoreForReference(ctx, reference)
 	r.NoError(err)

--- a/bindings/go/oci/internal/lister/lister.go
+++ b/bindings/go/oci/internal/lister/lister.go
@@ -35,6 +35,8 @@ const (
 	// LookupPolicyReferrerWithTagFallback first attempts to find versions using referrers,
 	// and falls back to tag-based listing if no referrers are found or an error occurred.
 	LookupPolicyReferrerWithTagFallback LookupPolicy = iota
+	// LookupPolicyTagOnly only uses tag-based listing, ignoring referrers, even if they are available.
+	LookupPolicyTagOnly // LookupPolicyTagOnly only uses tag-based listing, ignoring referrers.
 )
 
 // SortPolicy defines how discovered versions should be sorted.
@@ -133,6 +135,13 @@ func (lister *Lister) listUnsorted(ctx context.Context, opts Options) ([]string,
 		tags, terr := listViaTags(ctx, lister.tagLister, opts.TagListerOptions)
 		if terr != nil {
 			return nil, fmt.Errorf("could not list versions via referrers or tags: %w", errors.Join(err, terr))
+		}
+
+		return tags, nil
+	case LookupPolicyTagOnly:
+		tags, err := listViaTags(ctx, lister.tagLister, opts.TagListerOptions)
+		if err != nil {
+			return nil, fmt.Errorf("could not list versions via tags alone: %w", err)
 		}
 
 		return tags, nil

--- a/bindings/go/oci/internal/lister/lister.go
+++ b/bindings/go/oci/internal/lister/lister.go
@@ -36,7 +36,7 @@ const (
 	// and falls back to tag-based listing if no referrers are found or an error occurred.
 	LookupPolicyReferrerWithTagFallback LookupPolicy = iota
 	// LookupPolicyTagOnly only uses tag-based listing, ignoring referrers, even if they are available.
-	LookupPolicyTagOnly // LookupPolicyTagOnly only uses tag-based listing, ignoring referrers.
+	LookupPolicyTagOnly
 )
 
 // SortPolicy defines how discovered versions should be sorted.

--- a/bindings/go/oci/repository_options.go
+++ b/bindings/go/oci/repository_options.go
@@ -37,7 +37,32 @@ type RepositoryOptions struct {
 
 	// CopyOptions are the options for copying resources between sources and targets
 	ResourceCopyOptions *oras.CopyOptions
+
+	// ReferrerTrackingPolicy defines how OCI referrers are used to track component versions.
+	ReferrerTrackingPolicy ReferrerTrackingPolicy
 }
+
+// ReferrerTrackingPolicy defines how OCI referrers are used in the repository.
+// see https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers
+type ReferrerTrackingPolicy int
+
+const (
+	// ReferrerTrackingPolicyNone means that no referrers are tracked.
+	// This is the default policy and means that no referrers are used to track component versions.
+	//
+	// This is generally less accurate and efficient, but will work with any OCI repository that only
+	// contains OCM component versions as tags.
+	ReferrerTrackingPolicyNone ReferrerTrackingPolicy = iota
+	// ReferrerTrackingPolicyByIndexAndSubject
+	// means that added manifests are tracked using a static index and referencing that in the subject.
+	//
+	// If the index / subject can be stored via OCI referrers API, it will be used.
+	//
+	// If not, a new manifest with the index will be created and tagged with the digest of the index.
+	// see https://github.com/opencontainers/distribution-spec/blob/main/spec.md#backwards-compatibility
+	// for details on backwards-compatibility and behavior.
+	ReferrerTrackingPolicyByIndexAndSubject ReferrerTrackingPolicy = iota
+)
 
 // RepositoryOption is a function that modifies RepositoryOptions.
 type RepositoryOption func(*RepositoryOptions)
@@ -74,6 +99,13 @@ func WithCreator(creator string) RepositoryOption {
 func WithResolver(resolver Resolver) RepositoryOption {
 	return func(o *RepositoryOptions) {
 		o.Resolver = resolver
+	}
+}
+
+// WithReferrerTrackingPolicy sets the ReferrerTrackingPolicy for the repository.
+func WithReferrerTrackingPolicy(policy ReferrerTrackingPolicy) RepositoryOption {
+	return func(o *RepositoryOptions) {
+		o.ReferrerTrackingPolicy = policy
 	}
 }
 
@@ -132,5 +164,6 @@ func NewRepository(opts ...RepositoryOption) (*Repository, error) {
 		resolver:                   options.Resolver,
 		creatorAnnotation:          options.Creator,
 		resourceCopyOptions:        *options.ResourceCopyOptions,
+		referrerTrackingPolicy:     options.ReferrerTrackingPolicy,
 	}, nil
 }

--- a/bindings/go/oci/resolver/url/options.go
+++ b/bindings/go/oci/resolver/url/options.go
@@ -1,0 +1,40 @@
+package url
+
+import (
+	"oras.land/oras-go/v2/registry/remote"
+)
+
+// Option is an interface for configuring the CachingResolver.
+type Option interface {
+	Apply(*CachingResolver)
+}
+
+// OptionFunc is a function type that implements the Option interface.
+type OptionFunc func(*CachingResolver)
+
+func (f OptionFunc) Apply(resolver *CachingResolver) {
+	f(resolver)
+}
+
+// WithBaseURL sets the base URL for the registry resolver.
+// All references resolved will be under this base URL.
+func WithBaseURL(baseURL string) Option {
+	return OptionFunc(func(resolver *CachingResolver) {
+		resolver.baseURL = baseURL
+	})
+}
+
+// WithBaseClient sets the base client to use for making requests to the registry.
+// this also contains HTTP configuration.
+func WithBaseClient(client remote.Client) Option {
+	return OptionFunc(func(resolver *CachingResolver) {
+		resolver.baseClient = client
+	})
+}
+
+// WithPlainHTTP sets whether to use plain HTTP instead of HTTPS for any repository clients
+func WithPlainHTTP(plainHTTP bool) Option {
+	return OptionFunc(func(resolver *CachingResolver) {
+		resolver.plainHTTP = plainHTTP
+	})
+}

--- a/bindings/go/oci/resolver/url/resolver_test.go
+++ b/bindings/go/oci/resolver/url/resolver_test.go
@@ -12,13 +12,14 @@ import (
 
 func TestNewURLPathResolver(t *testing.T) {
 	baseURL := "http://example.com"
-	resolver := url.New(baseURL)
+	resolver, err := url.New(url.WithBaseURL(baseURL))
+	assert.NoError(t, err)
 	assert.NotNil(t, resolver)
-	assert.Equal(t, baseURL, resolver.BaseURL)
 }
 
 func TestURLPathResolver_SetClient(t *testing.T) {
-	resolver := url.New("http://example.com")
+	resolver, err := url.New(url.WithBaseURL("http://example.com"))
+	assert.NoError(t, err)
 	repo, err := remote.NewRepository("example.com/test")
 	assert.NoError(t, err)
 
@@ -31,7 +32,8 @@ func TestURLPathResolver_SetClient(t *testing.T) {
 	assert.NotNil(t, store)
 }
 func TestURLPathResolver_ComponentVersionReference(t *testing.T) {
-	resolver := url.New("http://example.com")
+	resolver, err := url.New(url.WithBaseURL("http://example.com"))
+	assert.NoError(t, err)
 	component := "test-component"
 	version := "v1.0.0"
 	expected := "http://example.com/component-descriptors/test-component:v1.0.0"
@@ -59,7 +61,8 @@ func TestURLPathResolver_StoreForReference(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resolver := url.New("http://example.com")
+			resolver, err := url.New(url.WithBaseURL("http://example.com"))
+			assert.NoError(t, err)
 			store, err := resolver.StoreForReference(context.Background(), tt.reference)
 
 			if tt.expectError {

--- a/bindings/go/oci/spec/index/component/v1/index.go
+++ b/bindings/go/oci/spec/index/component/v1/index.go
@@ -23,6 +23,8 @@ const MediaType = "application/vnd.ocm.software.component-index.v1+json"
 
 // Manifest defines the OCI manifest structure for the Component Index.
 // It is an empty JSON manifest that serves as a referrer for OCM component descriptors.
+// Manifest is hard-coded against Descriptor and MUST never change.
+// This is because the Index for the Referrer API must remain stable.
 var Manifest = ociImageSpecV1.Manifest{
 	Versioned: specs.Versioned{
 		SchemaVersion: 2,
@@ -47,8 +49,10 @@ var Manifest = ociImageSpecV1.Manifest{
 var Descriptor = ociImageSpecV1.Descriptor{
 	MediaType:    Manifest.MediaType,
 	ArtifactType: Manifest.ArtifactType,
-	Digest:       "sha256:9717cda41c478af11cba7ed29f4aa3e4882bab769d006788169cbccafc0fcd05",
-	Size:         837,
+	// Digest is calculated from the Manifest JSON representation and MUST never change.
+	Digest: "sha256:9717cda41c478af11cba7ed29f4aa3e4882bab769d006788169cbccafc0fcd05",
+	// Size is calculated from the Manifest JSON representation and MUST never change.
+	Size: 837,
 }
 
 // Store defines the interface for interacting with the OCI content store.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

this makes the referrer index, the index creation, subject reference on the index, as well as the listing via referrer API optional and hidden behind a configurable policy that is by default disabled. (this is the expected behavior if moving from a legacy OCM repository, as we didnt have referrer support before)

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
