### PR TITLE
fix: ensure that resources by reference have their relation and version defaulted

### DIFF
--- a/bindings/go/constructor/construct.go
+++ b/bindings/go/constructor/construct.go
@@ -236,6 +236,14 @@ func (c *DefaultConstructor) processResource(ctx context.Context, targetRepo Tar
 		logger.Debug("processing resource with input method")
 		res, err = c.processResourceWithInput(ctx, targetRepo, resource, component, version)
 	case resource.HasAccess():
+		if resource.Relation == "" {
+			logger.Debug("defaulting resource relation to external as resource is accessed by reference")
+			resource.Relation = constructor.ExternalRelation
+		}
+		if resource.Version == "" {
+			logger.Debug("defaulting resource version to component version as no resource version was set")
+			resource.Version = version
+		}
 		if byValue := c.opts.ProcessResourceByValue != nil && c.opts.ProcessResourceByValue(resource); byValue {
 			logger.Debug("processing resource by value")
 			res, err = c.processResourceByValue(ctx, targetRepo, resource, component, version)


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

previously resources by reference did not have their version and relation defaulted when they were missing.

This makes it so that resources referenced externally (via accessType instead of input type) get a default of external relation, as they are assumed to be not maintained by the component creator.

At the same time, if the resource is not versioned, we assume that the resource is versioned alongside the component and therefore the component version can be used as defaulting value.


#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
