### PR TITLE
feat: constructor callbacks

### DIFF
--- a/bindings/go/constructor/construct.go
+++ b/bindings/go/constructor/construct.go
@@ -56,7 +56,7 @@ func (c *DefaultConstructor) Construct(ctx context.Context, constructor *constru
 
 	for i, component := range constructor.Components {
 		componentLogger := logger.With("component", component.Name, "version", component.Version)
-		componentLogger.Info("constructing component")
+		componentLogger.Debug("constructing component")
 
 		eg.Go(func() error {
 			if c.opts.OnStartComponentConstruct != nil {
@@ -87,7 +87,7 @@ func (c *DefaultConstructor) Construct(ctx context.Context, constructor *constru
 		return nil, fmt.Errorf("error constructing components: %w", err)
 	}
 
-	logger.Info("component construction completed successfully", "num_components", len(descriptors))
+	logger.Debug("component construction completed successfully", "num_components", len(descriptors))
 	return descriptors, nil
 }
 
@@ -187,7 +187,7 @@ func (c *DefaultConstructor) processDescriptor(
 
 	for i, resource := range component.Resources {
 		resourceLogger := logger.With("resource", resource.ToIdentity())
-		resourceLogger.Info("processing resource")
+		resourceLogger.Debug("processing resource")
 
 		eg.Go(func() error {
 			if c.opts.OnStartResourceConstruct != nil {
@@ -214,7 +214,7 @@ func (c *DefaultConstructor) processDescriptor(
 
 	for i, source := range component.Sources {
 		sourceLogger := logger.With("source", source.ToIdentity())
-		sourceLogger.Info("processing source")
+		sourceLogger.Debug("processing source")
 
 		eg.Go(func() error {
 			if c.opts.OnStartSourceConstruct != nil {

--- a/bindings/go/constructor/construct.go
+++ b/bindings/go/constructor/construct.go
@@ -59,7 +59,17 @@ func (c *DefaultConstructor) Construct(ctx context.Context, constructor *constru
 		componentLogger.Info("constructing component")
 
 		eg.Go(func() error {
+			if c.opts.OnStartComponentConstruct != nil {
+				if err := c.opts.OnStartComponentConstruct(egctx, &component); err != nil {
+					return fmt.Errorf("error starting component construction for %q: %w", component.ToIdentity(), err)
+				}
+			}
 			desc, err := c.construct(egctx, &component)
+			if c.opts.OnEndComponentConstruct != nil {
+				if err := c.opts.OnEndComponentConstruct(egctx, desc, err); err != nil {
+					return fmt.Errorf("error ending component construction for %q: %w", component.ToIdentity(), err)
+				}
+			}
 			if err != nil {
 				return err
 			}
@@ -180,7 +190,17 @@ func (c *DefaultConstructor) processDescriptor(
 		resourceLogger.Info("processing resource")
 
 		eg.Go(func() error {
+			if c.opts.OnStartResourceConstruct != nil {
+				if err := c.opts.OnStartResourceConstruct(egctx, &resource); err != nil {
+					return fmt.Errorf("error starting resource construction for %q: %w", resource.ToIdentity(), err)
+				}
+			}
 			res, err := c.processResource(egctx, targetRepo, &resource, component.Name, component.Version)
+			if c.opts.OnEndResourceConstruct != nil {
+				if err := c.opts.OnEndResourceConstruct(egctx, res, err); err != nil {
+					return fmt.Errorf("error ending resource construction for %q: %w", resource.ToIdentity(), err)
+				}
+			}
 			if err != nil {
 				return fmt.Errorf("error processing resource %q at index %d: %w", resource.ToIdentity(), i, err)
 			}
@@ -197,7 +217,17 @@ func (c *DefaultConstructor) processDescriptor(
 		sourceLogger.Info("processing source")
 
 		eg.Go(func() error {
+			if c.opts.OnStartSourceConstruct != nil {
+				if err := c.opts.OnStartSourceConstruct(egctx, &source); err != nil {
+					return fmt.Errorf("error starting source construction for %q: %w", source.ToIdentity(), err)
+				}
+			}
 			src, err := c.processSource(egctx, targetRepo, &source, component.Name, component.Version)
+			if c.opts.OnEndSourceConstruct != nil {
+				if err := c.opts.OnEndSourceConstruct(egctx, src, err); err != nil {
+					return fmt.Errorf("error ending source construction for %q: %w", source.ToIdentity(), err)
+				}
+			}
 			if err != nil {
 				return fmt.Errorf("error processing source %q at index %d: %w", source.ToIdentity(), i, err)
 			}

--- a/bindings/go/constructor/construct_callbacks_test.go
+++ b/bindings/go/constructor/construct_callbacks_test.go
@@ -1,0 +1,218 @@
+package constructor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	constructorruntime "ocm.software/open-component-model/bindings/go/constructor/runtime"
+	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+// mockInputType implements runtime.Typed for testing
+type mockInputType struct {
+	Type runtime.Type
+}
+
+func (m *mockInputType) GetType() runtime.Type {
+	return m.Type
+}
+
+func (m *mockInputType) SetType(typ runtime.Type) {
+	m.Type = typ
+}
+
+func (m *mockInputType) DeepCopyTyped() runtime.Typed {
+	return &mockInputType{
+		Type: m.Type,
+	}
+}
+
+// mockCallbackTracker helps track which callbacks were called and in what order
+type mockCallbackTracker struct {
+	startComponentCalled bool
+	endComponentCalled   bool
+	startResourceCalled  bool
+	endResourceCalled    bool
+	startSourceCalled    bool
+	endSourceCalled      bool
+	component            *constructorruntime.Component
+	resource             *constructorruntime.Resource
+	source               *constructorruntime.Source
+	descriptor           *descriptor.Descriptor
+	err                  error
+}
+
+func (m *mockCallbackTracker) reset() {
+	m.startComponentCalled = false
+	m.endComponentCalled = false
+	m.startResourceCalled = false
+	m.endResourceCalled = false
+	m.startSourceCalled = false
+	m.endSourceCalled = false
+	m.component = nil
+	m.resource = nil
+	m.source = nil
+	m.descriptor = nil
+	m.err = nil
+}
+
+func TestConstructionCallbacks(t *testing.T) {
+	tracker := &mockCallbackTracker{}
+	mockRepo := newMockTargetRepository()
+
+	// Create a simple component with one resource and one source
+	component := &constructorruntime.Component{
+		ComponentMeta: constructorruntime.ComponentMeta{
+			ObjectMeta: constructorruntime.ObjectMeta{
+				Name:    "test-component",
+				Version: "v1.0.0",
+			},
+		},
+		Resources: []constructorruntime.Resource{
+			{
+				ElementMeta: constructorruntime.ElementMeta{
+					ObjectMeta: constructorruntime.ObjectMeta{
+						Name:    "test-resource",
+						Version: "v1.0.0",
+					},
+				},
+				Type: "test",
+				AccessOrInput: constructorruntime.AccessOrInput{
+					Input: &mockInputType{
+						Type: runtime.NewVersionedType("mock", "v1"),
+					},
+				},
+			},
+		},
+		Sources: []constructorruntime.Source{
+			{
+				ElementMeta: constructorruntime.ElementMeta{
+					ObjectMeta: constructorruntime.ObjectMeta{
+						Name:    "test-source",
+						Version: "v1.0.0",
+					},
+				},
+				Type: "test",
+				AccessOrInput: constructorruntime.AccessOrInput{
+					Input: &mockInputType{
+						Type: runtime.NewVersionedType("mock", "v1"),
+					},
+				},
+			},
+		},
+	}
+
+	constructor := &constructorruntime.ComponentConstructor{
+		Components: []constructorruntime.Component{*component},
+	}
+
+	// Create mock input methods
+	mockSourceInput := &mockSourceInputMethod{
+		processedSource: &descriptor.Source{
+			ElementMeta: descriptor.ElementMeta{
+				ObjectMeta: descriptor.ObjectMeta{
+					Name:    "test-source",
+					Version: "v1.0.0",
+				},
+			},
+			Access: &descriptor.LocalBlob{
+				MediaType: "application/octet-stream",
+			},
+		},
+	}
+	mockResourceInput := &mockInputMethod{
+		processedResource: &descriptor.Resource{
+			ElementMeta: descriptor.ElementMeta{
+				ObjectMeta: descriptor.ObjectMeta{
+					Name:    "test-resource",
+					Version: "v1.0.0",
+				},
+			},
+			Access: &descriptor.LocalBlob{
+				MediaType: "application/octet-stream",
+			},
+		},
+	}
+
+	// Create the constructor with our callback tracker
+	opts := Options{
+		TargetRepositoryProvider: &mockTargetRepositoryProvider{repo: mockRepo},
+		ResourceInputMethodProvider: &mockInputMethodProvider{
+			methods: map[runtime.Type]ResourceInputMethod{
+				runtime.NewVersionedType("mock", "v1"): mockResourceInput,
+			},
+		},
+		SourceInputMethodProvider: &mockSourceInputMethodProvider{
+			methods: map[runtime.Type]SourceInputMethod{
+				runtime.NewVersionedType("mock", "v1"): mockSourceInput,
+			},
+		},
+		ComponentConstructionCallbacks: ComponentConstructionCallbacks{
+			OnStartComponentConstruct: func(ctx context.Context, component *constructorruntime.Component) error {
+				tracker.startComponentCalled = true
+				tracker.component = component
+				return nil
+			},
+			OnEndComponentConstruct: func(ctx context.Context, desc *descriptor.Descriptor, err error) error {
+				tracker.endComponentCalled = true
+				tracker.descriptor = desc
+				tracker.err = err
+				return nil
+			},
+			OnStartResourceConstruct: func(ctx context.Context, resource *constructorruntime.Resource) error {
+				tracker.startResourceCalled = true
+				tracker.resource = resource
+				return nil
+			},
+			OnEndResourceConstruct: func(ctx context.Context, resource *descriptor.Resource, err error) error {
+				tracker.endResourceCalled = true
+				return nil
+			},
+			OnStartSourceConstruct: func(ctx context.Context, source *constructorruntime.Source) error {
+				tracker.startSourceCalled = true
+				tracker.source = source
+				return nil
+			},
+			OnEndSourceConstruct: func(ctx context.Context, source *descriptor.Source, err error) error {
+				tracker.endSourceCalled = true
+				return nil
+			},
+		},
+	}
+
+	constructorInstance := NewDefaultConstructor(opts)
+
+	// Process the constructor
+	descriptors, err := constructorInstance.Construct(context.Background(), constructor)
+	require.NoError(t, err)
+	require.Len(t, descriptors, 1)
+
+	// Verify all callbacks were called
+	assert.True(t, tracker.startComponentCalled, "OnStartComponentConstruct should have been called")
+	assert.True(t, tracker.endComponentCalled, "OnEndComponentConstruct should have been called")
+	assert.True(t, tracker.startResourceCalled, "OnStartResourceConstruct should have been called")
+	assert.True(t, tracker.endResourceCalled, "OnEndResourceConstruct should have been called")
+	assert.True(t, tracker.startSourceCalled, "OnStartSourceConstruct should have been called")
+	assert.True(t, tracker.endSourceCalled, "OnEndSourceConstruct should have been called")
+
+	// Verify the component passed to callbacks
+	assert.Equal(t, component.Name, tracker.component.Name)
+	assert.Equal(t, component.Version, tracker.component.Version)
+
+	// Verify the resource passed to callbacks
+	assert.Equal(t, component.Resources[0].Name, tracker.resource.Name)
+	assert.Equal(t, component.Resources[0].Version, tracker.resource.Version)
+
+	// Verify the source passed to callbacks
+	assert.Equal(t, component.Sources[0].Name, tracker.source.Name)
+	assert.Equal(t, component.Sources[0].Version, tracker.source.Version)
+
+	// Verify the descriptor passed to end component callback
+	assert.Equal(t, component.Name, tracker.descriptor.Component.Name)
+	assert.Equal(t, component.Version, tracker.descriptor.Component.Version)
+	assert.Nil(t, tracker.err, "No error should have been passed to OnEndComponentConstruct")
+}

--- a/bindings/go/constructor/options.go
+++ b/bindings/go/constructor/options.go
@@ -1,7 +1,10 @@
 package constructor
 
 import (
+	"context"
+
 	constructor "ocm.software/open-component-model/bindings/go/constructor/runtime"
+	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
 )
 
 // Options are the options for construction based on a *constructor.Constructor.
@@ -50,6 +53,30 @@ type Options struct {
 	// While constructing a component version, the constructor library will use the policy to determine how to handle conflicts
 	// of component versions when interacting with the target repository.
 	ComponentVersionConflictPolicy
+
+	// While constructing a component version, the constructor library will use the given callbacks to notify about
+	// the construction process. This can be used to implement custom logging or other actions such as progress trackers.
+	ComponentConstructionCallbacks
+}
+
+type ComponentConstructionCallbacks struct {
+	// OnStartComponentConstruct is called before the construction of a component version starts.
+	OnStartComponentConstruct func(ctx context.Context, component *constructor.Component) error
+	// OnEndComponentConstruct is called after the construction of a component version ends.
+	// If an error occurs during the construction, the error is passed as a parameter.
+	OnEndComponentConstruct func(ctx context.Context, descriptor *descriptor.Descriptor, err error) error
+
+	// OnStartResourceConstruct is called before the construction of a resource starts.
+	OnStartResourceConstruct func(ctx context.Context, resource *constructor.Resource) error
+	// OnEndResourceConstruct is called after the construction of a resource ends.
+	// If an error occurs during the construction, the error is passed as a parameter.
+	OnEndResourceConstruct func(ctx context.Context, resource *descriptor.Resource, err error) error
+
+	// OnStartSourceConstruct is called before the construction of a source starts.
+	OnStartSourceConstruct func(ctx context.Context, source *constructor.Source) error
+	// OnEndSourceConstruct is called after the construction of a source ends.
+	// If an error occurs during the construction, the error is passed as a parameter.
+	OnEndSourceConstruct func(ctx context.Context, source *descriptor.Source, err error) error
 }
 
 // ComponentVersionConflictPolicy defines the policy for handling component version conflicts


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

This adds optional lifecycle callbacks to the constructor 

```
type ComponentConstructionCallbacks struct {
	// OnStartComponentConstruct is called before the construction of a component version starts.
	OnStartComponentConstruct func(ctx context.Context, component *constructor.Component) error
	// OnEndComponentConstruct is called after the construction of a component version ends.
	// If an error occurs during the construction, the error is passed as a parameter.
	OnEndComponentConstruct func(ctx context.Context, descriptor *descriptor.Descriptor, err error) error

	// OnStartResourceConstruct is called before the construction of a resource starts.
	OnStartResourceConstruct func(ctx context.Context, resource *constructor.Resource) error
	// OnEndResourceConstruct is called after the construction of a resource ends.
	// If an error occurs during the construction, the error is passed as a parameter.
	OnEndResourceConstruct func(ctx context.Context, resource *descriptor.Resource, err error) error

	// OnStartSourceConstruct is called before the construction of a source starts.
	OnStartSourceConstruct func(ctx context.Context, source *constructor.Source) error
	// OnEndSourceConstruct is called after the construction of a source ends.
	// If an error occurs during the construction, the error is passed as a parameter.
	OnEndSourceConstruct func(ctx context.Context, source *descriptor.Source, err error) error
}
```

this allows plugging in progress trackers for tools like the CLI

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
