### PR TITLE
fix: support for aliases used in OCM CLI V1

### DIFF
--- a/cli/cmd/get/component-version/cmd.go
+++ b/cli/cmd/get/component-version/cmd.go
@@ -25,8 +25,8 @@ const (
 func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:        "component-version {reference}",
-		Aliases:    []string{"cv", "component-versions", "cvs"},
-		SuggestFor: []string{"component", "components", "version", "versions"},
+		Aliases:    []string{"cv", "component-versions", "cvs", "componentversion", "componentversions", "component", "components", "comp", "comps", "c"},
+		SuggestFor: []string{"version", "versions"},
 		Short:      "Get component version(s) from an OCM repository",
 		Args:       cobra.MatchAll(cobra.ExactArgs(1), ComponentReferenceAsFirstPositional),
 		Long: fmt.Sprintf(`Get component version(s) from an OCM repository.


### PR DESCRIPTION
#### What this PR does / why we need it

Do we want to support all aliases `ocm get cv` used in the OCM CLI V1 (for compatibility reasons)? See also:
https://github.com/open-component-model/ocm/blob/main/docs/reference/ocm_get_componentversions.md
