### PR TITLE
feat: introduce oci backed resource digest processor

### DIFF
--- a/bindings/go/oci/ctf/store.go
+++ b/bindings/go/oci/ctf/store.go
@@ -137,6 +137,8 @@ func (s *Repository) Push(ctx context.Context, expected ociImageSpecV1.Descripto
 
 // Resolve resolves a reference string to its corresponding descriptor in the CTF archive.
 // The reference should be in the format "repository:tag" so it will be resolved against the index.
+// The reference can also be just a tag or a digest, in which case the repository is based on the base repository.
+// Alternatively, it is also possible to provide a digest directly, e.g., "sha256:abc123...".
 // If a full reference is given, it will be resolved against the blob Repository immediately.
 // Returns the descriptor if found, or an error if the reference is invalid or not found.
 func (s *Repository) Resolve(ctx context.Context, reference string) (ociImageSpecV1.Descriptor, error) {
@@ -152,11 +154,15 @@ func (s *Repository) Resolve(ctx context.Context, reference string) (ociImageSpe
 
 	repo := s.repo
 
-	if prefix := wellKnownRegistryCTF + "/"; strings.HasPrefix(reference, prefix) {
-		reference = strings.TrimPrefix(reference, prefix)
-	}
-	if prefix := repo + ":"; strings.HasPrefix(reference, prefix) {
-		reference = strings.TrimPrefix(reference, prefix)
+	// if we do not have a pure digest, we need to parse the reference
+	// loosely because it could be that registry/repository information is prefixed to the actual reference.
+	if _, err := digest.Parse(reference); err != nil {
+		if idx := strings.Index(reference, ":"); idx != -1 {
+			reference = reference[idx+1:]
+		}
+		if idx := strings.Index(reference, "@"); idx != -1 {
+			reference = reference[:idx]
+		}
 	}
 
 	for _, artifact := range idx.GetArtifacts() {
@@ -202,7 +208,7 @@ func (s *Repository) Resolve(ctx context.Context, reference string) (ociImageSpe
 }
 
 // Tag associates a descriptor with a reference in the CTF archive's index.
-// The reference should be in the format "repository:tag".
+// The reference should be in the format "repository:tag", but can also be just a tag or digest.
 // This operation updates the index to maintain the mapping between references and their corresponding descriptors.
 func (s *Repository) Tag(ctx context.Context, desc ociImageSpecV1.Descriptor, reference string) error {
 	s.indexMu.Lock()
@@ -215,24 +221,50 @@ func (s *Repository) Tag(ctx context.Context, desc ociImageSpecV1.Descriptor, re
 
 	repo := s.repo
 
-	ref := registry.Reference{Reference: reference}
-
 	var meta v1.ArtifactMetadata
-	if err := ref.ValidateReferenceAsTag(); err == nil {
-		meta = v1.ArtifactMetadata{
-			Repository: repo,
-			Tag:        reference,
-			Digest:     desc.Digest.String(),
-			MediaType:  desc.MediaType,
+
+	if ref, err := looseref.ParseReference(reference); err == nil {
+		if err := ref.ValidateReferenceAsTag(); err == nil {
+			meta = v1.ArtifactMetadata{
+				Repository: repo,
+				Tag:        reference,
+				Digest:     desc.Digest.String(),
+				MediaType:  desc.MediaType,
+			}
+		} else if err := ref.ValidateReferenceAsDigest(); err == nil {
+			meta = v1.ArtifactMetadata{
+				Repository: repo,
+				Digest:     desc.Digest.String(),
+				MediaType:  desc.MediaType,
+			}
+		} else {
+			ref := registry.Reference{Reference: reference}
+			if err := ref.ValidateReferenceAsTag(); err == nil {
+				meta = v1.ArtifactMetadata{
+					Repository: repo,
+					Tag:        reference,
+					Digest:     desc.Digest.String(),
+					MediaType:  desc.MediaType,
+				}
+			} else if err := ref.ValidateReferenceAsDigest(); err == nil {
+				meta = v1.ArtifactMetadata{
+					Repository: repo,
+					Digest:     desc.Digest.String(),
+					MediaType:  desc.MediaType,
+				}
+			} else {
+				return fmt.Errorf("invalid raw reference %q: %w", reference, err)
+			}
 		}
-	} else if err := ref.ValidateReferenceAsDigest(); err == nil {
-		meta = v1.ArtifactMetadata{
-			Repository: repo,
-			Digest:     desc.Digest.String(),
-			MediaType:  desc.MediaType,
-		}
-	} else {
-		return fmt.Errorf("invalid reference %q: %w", reference, err)
+	}
+
+	ok, err := s.Exists(ctx, desc)
+	if err != nil {
+		return fmt.Errorf("unable to check if descriptor exists: %w", err)
+	}
+	if !ok {
+		// if the descriptor does not exist, we cannot tag it
+		return fmt.Errorf("descriptor %s does not exist in the archive", desc.Digest)
 	}
 
 	slog.Info("adding artifact to index", "meta", meta)

--- a/bindings/go/oci/ctf/store.go
+++ b/bindings/go/oci/ctf/store.go
@@ -157,11 +157,12 @@ func (s *Repository) Resolve(ctx context.Context, reference string) (ociImageSpe
 	// if we do not have a pure digest, we need to parse the reference
 	// loosely because it could be that registry/repository information is prefixed to the actual reference.
 	if _, err := digest.Parse(reference); err != nil {
-		if idx := strings.Index(reference, ":"); idx != -1 {
-			reference = reference[idx+1:]
-		}
+		// if we have an encoded digest, prefer to use that one only,
+		// else if we have a tag, use that one.
 		if idx := strings.Index(reference, "@"); idx != -1 {
-			reference = reference[:idx]
+			reference = reference[idx+1:]
+		} else if idx := strings.Index(reference, ":"); idx != -1 {
+			reference = reference[idx+1:]
 		}
 	}
 

--- a/bindings/go/oci/ctf/store_test.go
+++ b/bindings/go/oci/ctf/store_test.go
@@ -148,7 +148,7 @@ func TestPush(t *testing.T) {
 func TestResolve(t *testing.T) {
 	ctf := setupTestCTF(t)
 	provider := NewFromCTF(ctf)
-	store, err := provider.StoreForReference(t.Context(), "test-repo:v1.0.0")
+	store, err := provider.StoreForReference(t.Context(), "localhost:5000/test-repo:v1.0.0")
 	require.NoError(t, err)
 
 	ctx := t.Context()
@@ -174,6 +174,8 @@ func TestResolve(t *testing.T) {
 		digestStr,
 		"test-repo@" + digestStr,
 		"test-repo:v1.0.0@" + digestStr,
+		"localhost:5000/test-repo:v1.0.0",
+		"localhost:5000/test-repo:v1.0.0@" + digestStr,
 	}
 
 	for _, tc := range expectedOkResolves {

--- a/bindings/go/oci/ctf/store_test.go
+++ b/bindings/go/oci/ctf/store_test.go
@@ -168,26 +168,22 @@ func TestResolve(t *testing.T) {
 	})
 	require.NoError(t, ctf.SetIndex(ctx, index))
 
-	t.Run("successful resolve", func(t *testing.T) {
-		desc, err := store.Resolve(ctx, "v1.0.0")
-		assert.NoError(t, err)
-		assert.Equal(t, ociImageSpecV1.MediaTypeImageManifest, desc.MediaType)
-		assert.Equal(t, digest.Digest(digestStr), desc.Digest)
-	})
+	expectedOkResolves := []string{
+		"v1.0.0",
+		"test-repo:v1.0.0",
+		digestStr,
+		"test-repo@" + digestStr,
+		"test-repo:v1.0.0@" + digestStr,
+	}
 
-	t.Run("successful resolve with full repo", func(t *testing.T) {
-		desc, err := store.Resolve(ctx, "test-repo:v1.0.0")
-		assert.NoError(t, err)
-		assert.Equal(t, ociImageSpecV1.MediaTypeImageManifest, desc.MediaType)
-		assert.Equal(t, digest.Digest(digestStr), desc.Digest)
-	})
-
-	t.Run("successful resolve with digest", func(t *testing.T) {
-		desc, err := store.Resolve(ctx, digestStr)
-		assert.NoError(t, err)
-		assert.Equal(t, ociImageSpecV1.MediaTypeImageManifest, desc.MediaType)
-		assert.Equal(t, digest.Digest(digestStr), desc.Digest)
-	})
+	for _, tc := range expectedOkResolves {
+		t.Run(fmt.Sprintf("%s", tc), func(t *testing.T) {
+			desc, err := store.Resolve(ctx, tc)
+			assert.NoError(t, err)
+			assert.Equal(t, ociImageSpecV1.MediaTypeImageManifest, desc.MediaType)
+			assert.Equal(t, digest.Digest(digestStr), desc.Digest)
+		})
+	}
 
 	t.Run("invalid reference", func(t *testing.T) {
 		desc, err := store.Resolve(ctx, "invalid")

--- a/bindings/go/oci/integration/integration_test.go
+++ b/bindings/go/oci/integration/integration_test.go
@@ -196,6 +196,10 @@ func Test_Integration_OCIRepository(t *testing.T) {
 		t.Run("local source blob upload and download", func(t *testing.T) {
 			uploadDownloadLocalSource(t, repo, "test-component", "v1.0.0")
 		})
+
+		t.Run("oci image digest processing", func(t *testing.T) {
+			processResourceDigest(t, repo, "ghcr.io/test:v1.0.0", reference("new-test:v1.0.0"))
+		})
 	})
 
 	t.Run("specification-based", func(t *testing.T) {
@@ -257,6 +261,10 @@ func Test_Integration_CTF(t *testing.T) {
 
 		t.Run("local source blob upload and download", func(t *testing.T) {
 			uploadDownloadLocalSource(t, repo, "test-component", "v4.0.0")
+		})
+
+		t.Run("oci image digest processing", func(t *testing.T) {
+			processResourceDigest(t, repo, "ghcr.io/test:v1.0.0", "new-test:v1.0.0")
 		})
 	})
 
@@ -426,6 +434,53 @@ func uploadDownloadBarebonesOCIImage(t *testing.T, repo oci.ResourceRepository, 
 	r.NoError(err)
 
 	r.Equal(originalData, dataFromBlob)
+}
+
+func processResourceDigest(t *testing.T, repo *oci.Repository, from, to string) {
+	ctx := t.Context()
+	r := require.New(t)
+
+	originalData := []byte("foobar")
+
+	data, access := createSingleLayerOCIImage(t, originalData, from, to)
+
+	blob := inmemory.New(bytes.NewReader(data))
+
+	resource := descriptor.Resource{
+		ElementMeta: descriptor.ElementMeta{
+			ObjectMeta: descriptor.ObjectMeta{
+				Name:    "test-resource",
+				Version: "v1.0.0",
+			},
+		},
+		Type:         "some-arbitrary-type-packed-in-image",
+		Access:       access,
+		Size:         int64(len(data)),
+		CreationTime: descriptor.CreationTime(time.Now()),
+	}
+
+	targetAccess := resource.Access.DeepCopyTyped()
+	targetAccess.(*v1.OCIImage).ImageReference = to
+
+	newRes, err := repo.UploadResource(ctx, targetAccess, &resource, blob)
+	r.NoError(err)
+	resource = *newRes
+
+	r.NotNil(resource.Digest)
+
+	resource.Digest = nil
+
+	newRes, err = repo.ProcessResourceDigest(ctx, &resource)
+	r.NoError(err)
+	resource = *newRes
+
+	r.Contains(resource.Access.(*v1.OCIImage).ImageReference, "test:v1.0.0@sha256:0aa67467eee1b66c5e549e6b67226e226778f689ccdb46c39fe706b6428c98a5")
+
+	r.Equal(resource.Digest.Value, "0aa67467eee1b66c5e549e6b67226e226778f689ccdb46c39fe706b6428c98a5")
+	r.Equal(resource.Digest.HashAlgorithm, "SHA-256")
+	r.Equal(resource.Digest.NormalisationAlgorithm, "genericBlobDigest/v1")
+
+	r.NotNil(resource.Digest)
 }
 
 func uploadDownloadBarebonesComponentVersion(t *testing.T, repo oci.ComponentVersionRepository, name, version string) {

--- a/bindings/go/oci/interface.go
+++ b/bindings/go/oci/interface.go
@@ -49,6 +49,7 @@ type ComponentVersionRepository interface {
 
 	LocalResourceRepository
 	LocalSourceRepository
+	ResourceDigestProcessor
 }
 
 type LocalResourceRepository interface {
@@ -129,6 +130,15 @@ type SourceRepository interface {
 	// The blob.ReadOnlyBlob returned will always be an OCI Layout, readable by [tar.ReadOCILayout].
 	// For more information on the download procedure, see [tar.NewOCILayoutWriter].
 	DownloadSource(ctx context.Context, res *descriptor.Source) (content blob.ReadOnlyBlob, err error)
+}
+
+type ResourceDigestProcessor interface {
+	// ProcessResourceDigest processes, verifies and appends the [*descriptor.Resource.Digest] with information fetched
+	// from the repository.
+	// Under certain circumstances, it can also process the [*descriptor.Resource.Access] of the resource,
+	// e.g. to ensure that the digest is pinned after digest information was appended.
+	// As a result, after processing, the access MUST always reference the content described by the digest and cannot be mutated.
+	ProcessResourceDigest(ctx context.Context, res *descriptor.Resource) (*descriptor.Resource, error)
 }
 
 // Resolver defines the interface for resolving references to OCI stores.

--- a/bindings/go/oci/internal/digest/digest.go
+++ b/bindings/go/oci/internal/digest/digest.go
@@ -35,6 +35,22 @@ func Apply(target *runtime.Digest, digest digest.Digest) error {
 	return nil
 }
 
+// Verify checks if the target digest matches the provided digest.
+// It compares the Value and HashAlgorithm fields of the target
+// with the encoded value and algorithm of the provided digest.
+func Verify(target *runtime.Digest, digest digest.Digest) error {
+	if target == nil {
+		return fmt.Errorf("target digest is nil")
+	}
+	if target.Value != digest.Encoded() {
+		return fmt.Errorf("digest value mismatch: expected %s, got %s", target.Value, digest.Encoded())
+	}
+	if target.HashAlgorithm != ReverseSHAMapping[digest.Algorithm()] {
+		return fmt.Errorf("hash algorithm mismatch: expected %s, got %s", target.HashAlgorithm, ReverseSHAMapping[digest.Algorithm()])
+	}
+	return nil
+}
+
 func reverseMap[K, V comparable](m map[K]V) map[V]K {
 	reversed := make(map[V]K)
 	for k, v := range m {

--- a/bindings/go/oci/internal/digest/digest.go
+++ b/bindings/go/oci/internal/digest/digest.go
@@ -45,7 +45,11 @@ func Verify(target *runtime.Digest, digest digest.Digest) error {
 	if target.Value != digest.Encoded() {
 		return fmt.Errorf("digest value mismatch: expected %s, got %s", target.Value, digest.Encoded())
 	}
-	if target.HashAlgorithm != ReverseSHAMapping[digest.Algorithm()] {
+	algo, ok := ReverseSHAMapping[digest.Algorithm()]
+	if !ok {
+		return fmt.Errorf("unknown algorithm in digest: %s", digest.Algorithm())
+	}
+	if target.HashAlgorithm != algo {
 		return fmt.Errorf("hash algorithm mismatch: expected %s, got %s", target.HashAlgorithm, ReverseSHAMapping[digest.Algorithm()])
 	}
 	return nil

--- a/bindings/go/oci/repository.go
+++ b/bindings/go/oci/repository.go
@@ -259,15 +259,8 @@ func (repo *Repository) processOCIImageDigest(ctx context.Context, res *descript
 	}
 
 	var desc ociImageSpecV1.Descriptor
-
-	if pinnedDigest == "" {
-		if desc, err = src.Resolve(ctx, fqdn); err != nil {
-			return nil, fmt.Errorf("failed to resolve reference to process digest %q: %w", typed.ImageReference, err)
-		}
-	} else {
-		if desc, err = src.Resolve(ctx, fqdn); err != nil {
-			return nil, fmt.Errorf("failed to resolve reference to process digest %q: %w", typed.ImageReference, err)
-		}
+	if desc, err = src.Resolve(ctx, fqdn); err != nil {
+		return nil, fmt.Errorf("failed to resolve reference to process digest %q: %w", typed.ImageReference, err)
 	}
 
 	// if the resource did not have a digest, we apply the digest from the descriptor

--- a/bindings/go/oci/repository.go
+++ b/bindings/go/oci/repository.go
@@ -197,6 +197,101 @@ func (repo *Repository) AddLocalSource(ctx context.Context, component, version s
 	return source, nil
 }
 
+func (repo *Repository) ProcessResourceDigest(ctx context.Context, res *descriptor.Resource) (_ *descriptor.Resource, err error) {
+	done := log.Operation(ctx, "process resource digest",
+		log.IdentityLogAttr("resource", res.ToIdentity()))
+	defer func() {
+		done(err)
+	}()
+	res = res.DeepCopy()
+	access := res.Access
+	if _, err = repo.scheme.DefaultType(access); err != nil {
+		return nil, fmt.Errorf("error defaulting resource access type: %w", err)
+	}
+	typed, err := repo.scheme.NewObject(access.GetType())
+	if err != nil {
+		return nil, fmt.Errorf("error creating resource access: %w", err)
+	}
+	if err := repo.scheme.Convert(access, typed); err != nil {
+		return nil, fmt.Errorf("error converting resource access: %w", err)
+	}
+
+	switch typed := typed.(type) {
+	case *v2.LocalBlob:
+		if typed.GlobalAccess == nil {
+			return nil, fmt.Errorf("local blob access does not have a global access and cannot be used")
+		}
+		globalAccess, err := repo.scheme.NewObject(typed.GlobalAccess.GetType())
+		if err != nil {
+			return nil, fmt.Errorf("error creating typed global blob access with help of scheme: %w", err)
+		}
+		if err := repo.scheme.Convert(typed.GlobalAccess, globalAccess); err != nil {
+			return nil, fmt.Errorf("error converting global blob access: %w", err)
+		}
+		res.Access = globalAccess
+		return repo.ProcessResourceDigest(ctx, res)
+	case *accessv1.OCIImage:
+		return repo.processOCIImageDigest(ctx, res, typed)
+	default:
+		return nil, fmt.Errorf("unsupported resource access type: %T", typed)
+	}
+}
+
+func (repo *Repository) processOCIImageDigest(ctx context.Context, res *descriptor.Resource, typed *accessv1.OCIImage) (*descriptor.Resource, error) {
+	src, err := repo.resolver.StoreForReference(ctx, typed.ImageReference)
+	if err != nil {
+		return nil, err
+	}
+
+	resolved, err := repo.resolver.Reference(typed.ImageReference)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing image reference %q: %w", typed.ImageReference, err)
+	}
+
+	reference := resolved.String()
+
+	// reference is not a FQDN because it can be pinned, for resolving, use the FQDN part of the reference
+	fqdn := reference
+	pinnedDigest := ""
+	if index := strings.IndexByte(reference, '@'); index != -1 {
+		fqdn = reference[:index]
+		pinnedDigest = reference[index+1:]
+	}
+
+	var desc ociImageSpecV1.Descriptor
+
+	if pinnedDigest == "" {
+		if desc, err = src.Resolve(ctx, fqdn); err != nil {
+			return nil, fmt.Errorf("failed to resolve reference to process digest %q: %w", typed.ImageReference, err)
+		}
+	} else {
+		if desc, err = src.Resolve(ctx, fqdn); err != nil {
+			return nil, fmt.Errorf("failed to resolve reference to process digest %q: %w", typed.ImageReference, err)
+		}
+	}
+
+	// if the resource did not have a digest, we apply the digest from the descriptor
+	// if it did, we verify it against the received descriptor.
+	if res.Digest == nil {
+		res.Digest = &descriptor.Digest{}
+		if err := internaldigest.Apply(res.Digest, desc.Digest); err != nil {
+			return nil, fmt.Errorf("failed to apply digest to resource: %w", err)
+		}
+	} else if err := internaldigest.Verify(res.Digest, desc.Digest); err != nil {
+		return nil, fmt.Errorf("failed to verify digest of resource %q: %w", res.ToIdentity(), err)
+	}
+
+	if pinnedDigest != "" && pinnedDigest != desc.Digest.String() {
+		return nil, fmt.Errorf("expected pinned digest %q (derived from %q) but got %q", pinnedDigest, reference, desc.Digest)
+	}
+
+	// in any case, after successful processing, we can pin the access
+	typed.ImageReference = fqdn + "@" + desc.Digest.String()
+	res.Access = typed
+
+	return res, nil
+}
+
 func (repo *Repository) uploadAndUpdateLocalArtifact(ctx context.Context, component string, version string, artifact descriptor.Artifact, b blob.ReadOnlyBlob) error {
 	reference, store, err := repo.getStore(ctx, component, version)
 	if err != nil {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

add a method / interface that allows us to process and append / pin digests to resources backed by OCI Images efficiently via resolve calls.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

This allows the component constructor to efficiently construct OCI based blob digests.