### PR TITLE
fix!: size was originally never an attribute, lets remove it

### DIFF
--- a/bindings/go/descriptor/v2/descriptor.go
+++ b/bindings/go/descriptor/v2/descriptor.go
@@ -94,8 +94,6 @@ type Resource struct {
 	Access *runtime.Raw `json:"access"`
 	// Digest is the optional digest of the referenced resource.
 	Digest *Digest `json:"digest,omitempty"`
-	// Size of the resource blob.
-	Size int64 `json:"size,omitempty"`
 	// CreationTime of the resource.
 	CreationTime *Timestamp `json:"creationTime,omitempty"`
 }

--- a/bindings/go/descriptor/v2/descriptor_test.go
+++ b/bindings/go/descriptor/v2/descriptor_test.go
@@ -474,7 +474,6 @@ func TestResource_Struct(t *testing.T) {
 			NormalisationAlgorithm: "OciArtifactDigest",
 			Value:                  "abcdef1234567890",
 		},
-		Size: 1024,
 	}
 
 	// Test
@@ -488,7 +487,6 @@ func TestResource_Struct(t *testing.T) {
 	assert.Contains(t, string(jsonData), `"relation":"local"`)
 	assert.Contains(t, string(jsonData), `"access":{"type":"ociArtifact","imageReference":"test/image:1.0"}`)
 	assert.Contains(t, string(jsonData), `"digest":{"hashAlgorithm":"SHA-256","normalisationAlgorithm":"OciArtifactDigest","value":"abcdef1234567890"}`)
-	assert.Contains(t, string(jsonData), `"size":1024`)
 }
 
 func TestSource_Struct(t *testing.T) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

this is the removal of the size attribute in the resource, which we prototyped with extensively. however resource sizes are not feasible for a lot of types and should rather be access-specific.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
