### PR TITLE
fix: make sure suffix is properly removed

### DIFF
--- a/.github/workflows/release-go-submodule.yaml
+++ b/.github/workflows/release-go-submodule.yaml
@@ -90,9 +90,12 @@ jobs:
         run: |
           version="${{ steps.get_tag.outputs.version }}"
           bump="${{ inputs.bump }}"
-          major=$(echo "$version" | cut -d. -f1)
-          minor=$(echo "$version" | cut -d. -f2)
-          patch=$(echo "$version" | cut -d. -f3)
+          # Strip leading v and everything after the first non-numeric/dot character,
+          # e.g. v1.2.3-alpha1 => 1.2.3
+          clean_version=$(echo "$version" | sed -E 's/^v//' | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')
+          major=$(echo "$clean_version" | cut -d. -f1)
+          minor=$(echo "$clean_version" | cut -d. -f2)
+          patch=$(echo "$clean_version" | cut -d. -f3)
 
           major=${major:-0}
           minor=${minor:-0}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

when we release submodules which had previous releases such as `v2.0.0-alpha1` we need to drop `-alpha1` from the patch interpretation because otherwise tags will be calculated incorrectly.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes the issue we have when releasing a new alpha of the descriptor: https://github.com/open-component-model/open-component-model/actions/runs/15711191727/job/44269443622#step:8:1
