### PR TITLE
chore: bump CTF lib to blob 0.0.3

### DIFF
--- a/bindings/go/ctf/ctf_test.go
+++ b/bindings/go/ctf/ctf_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"ocm.software/open-component-model/bindings/go/blob"
+	"ocm.software/open-component-model/bindings/go/blob/inmemory"
 
 	"ocm.software/open-component-model/bindings/go/ctf"
 	v1 "ocm.software/open-component-model/bindings/go/ctf/index/v1"
@@ -32,7 +32,7 @@ func Test_CTF_ReadWrite(t *testing.T) {
 			}[format]
 			path := filepath.Join(t.TempDir(), name)
 
-			testBlob := blob.NewDirectReadOnlyBlob(bytes.NewReader([]byte("test")))
+			testBlob := inmemory.New(bytes.NewReader([]byte("test")))
 			digest, _ := testBlob.Digest()
 
 			err := ctf.WorkWithinCTF(ctx, path, ctf.O_CREATE|ctf.O_RDWR, func(ctx context.Context, ctf ctf.CTF) error {

--- a/bindings/go/ctf/filesystem_ctf_test.go
+++ b/bindings/go/ctf/filesystem_ctf_test.go
@@ -18,6 +18,7 @@ import (
 
 	"ocm.software/open-component-model/bindings/go/blob"
 	"ocm.software/open-component-model/bindings/go/blob/filesystem"
+	"ocm.software/open-component-model/bindings/go/blob/inmemory"
 	"ocm.software/open-component-model/bindings/go/ctf"
 	v1 "ocm.software/open-component-model/bindings/go/ctf/index/v1"
 )
@@ -46,7 +47,7 @@ func Test_FileSystemCTF_BasicOperations(t *testing.T) {
 
 	// Test SaveBlob
 	testData := []byte("test blob data")
-	testBlob := blob.NewDirectReadOnlyBlob(bytes.NewReader(testData))
+	testBlob := inmemory.New(bytes.NewReader(testData))
 	err = fs.SaveBlob(ctx, testBlob)
 	r.NoError(err)
 
@@ -178,7 +179,7 @@ func Test_FileSystemCTF_ConcurrentOperations(t *testing.T) {
 	blobs := make([]blob.ReadOnlyBlob, 10)
 	for i := 0; i < 10; i++ {
 		data := []byte(fmt.Sprintf("test blob %d", i))
-		blobs[i] = blob.NewDirectReadOnlyBlob(bytes.NewReader(data))
+		blobs[i] = inmemory.New(bytes.NewReader(data))
 	}
 
 	// Save blobs concurrently
@@ -208,7 +209,7 @@ func Test_FileSystemCTF_IndexOperations(t *testing.T) {
 
 	// Create and set an index with artifacts
 	idx := v1.NewIndex()
-	testBlob := blob.NewDirectReadOnlyBlob(bytes.NewReader([]byte("test")))
+	testBlob := inmemory.New(bytes.NewReader([]byte("test")))
 	digest, _ := testBlob.Digest()
 	err = fs.SaveBlob(ctx, testBlob)
 	r.NoError(err)

--- a/bindings/go/ctf/go.mod
+++ b/bindings/go/ctf/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/sync v0.15.0
-	ocm.software/open-component-model/bindings/go/blob v0.0.2
+	ocm.software/open-component-model/bindings/go/blob v0.0.3
 )
 
 require (

--- a/bindings/go/ctf/go.sum
+++ b/bindings/go/ctf/go.sum
@@ -28,5 +28,5 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-ocm.software/open-component-model/bindings/go/blob v0.0.2 h1:YBAXJ1m8PE/WiXNqGggCBwb48rlMKAsF7/x51gBvEGI=
-ocm.software/open-component-model/bindings/go/blob v0.0.2/go.mod h1:XHcaZ3WihLLswm+dNDs7QrAHu4M0zaNTy2nErUkZNLU=
+ocm.software/open-component-model/bindings/go/blob v0.0.3 h1:gd33Yt3ZuVgP/ysp7DqcNgiFazWEdwdXSUtBbmWyaGg=
+ocm.software/open-component-model/bindings/go/blob v0.0.3/go.mod h1:XHcaZ3WihLLswm+dNDs7QrAHu4M0zaNTy2nErUkZNLU=

--- a/bindings/go/ctf/tar_test.go
+++ b/bindings/go/ctf/tar_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"ocm.software/open-component-model/bindings/go/blob"
+	"ocm.software/open-component-model/bindings/go/blob/inmemory"
 	"ocm.software/open-component-model/bindings/go/ctf"
 )
 
@@ -19,7 +19,7 @@ func Test_Archive(t *testing.T) {
 	archive, err := ctf.OpenCTF(ctx, path, ctf.FormatDirectory, ctf.O_RDWR)
 	r.NoError(err)
 
-	testBlob := blob.NewDirectReadOnlyBlob(bytes.NewReader([]byte("test")))
+	testBlob := inmemory.New(bytes.NewReader([]byte("test")))
 
 	r.NoError(archive.SaveBlob(ctx, testBlob))
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

bumps the blob lib in the ctf lib because we had a breaking change with the inmemory blob interface design

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
