### PR TITLE
fix: proper tag listing

### DIFF
--- a/bindings/go/oci/internal/lister/component/component_versions.go
+++ b/bindings/go/oci/internal/lister/component/component_versions.go
@@ -56,7 +56,7 @@ func ReferrerAnnotationVersionResolver(component string) lister.ReferrerVersionR
 // The resolver will:
 //   - Parse the provided reference
 //   - Resolve the tag to a descriptor
-//   - Validate the descriptor's media type.
+//   - Validate the descriptor's media type
 //   - Return the tag if valid, or an error if invalid
 func ReferenceTagVersionResolver(component string, store interface {
 	content.Resolver
@@ -105,8 +105,8 @@ func ReferenceTagVersionResolver(component string, store interface {
 			return "", fmt.Errorf("failed to parse component version annotation: %w", err)
 		}
 
-		if redundantPrefix := path.DefaultComponentDescriptorPath + "/"; strings.HasPrefix(component, redundantPrefix) {
-			component = strings.TrimPrefix(component, redundantPrefix)
+		if strings.HasPrefix(component, path.DefaultComponentDescriptorPath+"/") {
+			component = strings.TrimPrefix(component, path.DefaultComponentDescriptorPath+"/")
 		}
 
 		if candidate != component {

--- a/bindings/go/oci/internal/lister/component/component_versions.go
+++ b/bindings/go/oci/internal/lister/component/component_versions.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -10,7 +11,6 @@ import (
 
 	"ocm.software/open-component-model/bindings/go/oci/internal/lister"
 	"ocm.software/open-component-model/bindings/go/oci/spec/annotations"
-	"ocm.software/open-component-model/bindings/go/oci/spec/descriptor"
 	"ocm.software/open-component-model/bindings/go/oci/spec/repository/path"
 )
 
@@ -54,24 +54,66 @@ func ReferrerAnnotationVersionResolver(component string) lister.ReferrerVersionR
 // legacy and current OCI manifest formats.
 //
 // The resolver will:
-// - Parse the provided reference
-// - Resolve the tag to a descriptor
-// - Validate the descriptor's media type and artifact type
-// - Return the tag if valid, or an error if invalid
-func ReferenceTagVersionResolver(store content.Resolver) lister.TagVersionResolver {
+//   - Parse the provided reference
+//   - Resolve the tag to a descriptor
+//   - Validate the descriptor's media type.
+//   - Return the tag if valid, or an error if invalid
+func ReferenceTagVersionResolver(component string, store interface {
+	content.Resolver
+	content.Fetcher
+},
+) lister.TagVersionResolver {
 	tagResolver := func(ctx context.Context, tag string) (string, error) {
 		desc, err := store.Resolve(ctx, tag)
 		if err != nil {
 			return "", fmt.Errorf("failed to resolve tag %q: %w", tag, err)
 		}
-		legacy := desc.MediaType == ociImageSpecV1.MediaTypeImageManifest && desc.ArtifactType == ""
-		current := desc.MediaType == ociImageSpecV1.MediaTypeImageManifest && desc.ArtifactType == descriptor.MediaTypeComponentDescriptorV2 ||
-			desc.MediaType == ociImageSpecV1.MediaTypeImageIndex && desc.ArtifactType == descriptor.MediaTypeComponentDescriptorV2
-		if !legacy && !current {
-			return "", fmt.Errorf("not recognized as valid top level descriptor type: %w", lister.ErrSkip)
+
+		var manifestAnnotations map[string]string
+		switch desc.MediaType {
+		case ociImageSpecV1.MediaTypeImageManifest:
+			data, err := store.Fetch(ctx, desc)
+			if err != nil {
+				return "", fmt.Errorf("failed to fetch descriptor for tag %q: %w", tag, err)
+			}
+			var manifest ociImageSpecV1.Manifest
+			if err := json.NewDecoder(data).Decode(&manifest); err != nil {
+				return "", fmt.Errorf("failed to decode manifest for tag %q: %w", tag, err)
+			}
+			manifestAnnotations = manifest.Annotations
+		case ociImageSpecV1.MediaTypeImageIndex:
+			data, err := store.Fetch(ctx, desc)
+			if err != nil {
+				return "", fmt.Errorf("failed to fetch descriptor for tag %q: %w", tag, err)
+			}
+			var index ociImageSpecV1.Index
+			if err := json.NewDecoder(data).Decode(&index); err != nil {
+				return "", fmt.Errorf("failed to decode index for tag %q: %w", tag, err)
+			}
+			manifestAnnotations = index.Annotations
+		default:
+			return "", fmt.Errorf("unsupported media type %q for tag %q: %w", desc.MediaType, tag, lister.ErrSkip)
 		}
 
-		return tag, nil
+		annotation, ok := manifestAnnotations[annotations.OCMComponentVersion]
+		if !ok {
+			return "", fmt.Errorf("failed to find %q annotation for tag %q: %w", annotations.OCMComponentVersion, tag, lister.ErrSkip)
+		}
+
+		candidate, version, err := annotations.ParseComponentVersionAnnotation(annotation)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse component version annotation: %w", err)
+		}
+
+		if redundantPrefix := path.DefaultComponentDescriptorPath + "/"; strings.HasPrefix(component, redundantPrefix) {
+			component = strings.TrimPrefix(component, redundantPrefix)
+		}
+
+		if candidate != component {
+			return "", fmt.Errorf("component %q from annotation does not match %q: %w", candidate, component, lister.ErrSkip)
+		}
+
+		return version, nil
 	}
 	return tagResolver
 }

--- a/bindings/go/oci/internal/lister/component/component_versions_test.go
+++ b/bindings/go/oci/internal/lister/component/component_versions_test.go
@@ -1,27 +1,32 @@
 package component_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"testing"
 
 	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/assert"
-	"oras.land/oras-go/v2/content"
 
 	"ocm.software/open-component-model/bindings/go/oci/internal/lister"
 	"ocm.software/open-component-model/bindings/go/oci/internal/lister/component"
 	"ocm.software/open-component-model/bindings/go/oci/spec/annotations"
-	"ocm.software/open-component-model/bindings/go/oci/spec/descriptor"
-	"ocm.software/open-component-model/bindings/go/oci/spec/repository/path"
 )
 
 type mockStore struct {
 	resolveFunc func(ctx context.Context, ref string) (ociImageSpecV1.Descriptor, error)
+	fetchFunc   func(ctx context.Context, desc ociImageSpecV1.Descriptor) (io.ReadCloser, error)
 }
 
 func (m *mockStore) Resolve(ctx context.Context, ref string) (ociImageSpecV1.Descriptor, error) {
 	return m.resolveFunc(ctx, ref)
+}
+
+func (m *mockStore) Fetch(ctx context.Context, desc ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+	return m.fetchFunc(ctx, desc)
 }
 
 func TestReferrerAnnotationVersionResolver(t *testing.T) {
@@ -68,7 +73,7 @@ func TestReferrerAnnotationVersionResolver(t *testing.T) {
 					annotations.OCMComponentVersion: "invalid-format",
 				},
 			},
-			expectedError: fmt.Errorf("failed to parse component version annotation: %q is not considered a valid %q annotation because of a bad prefix, expected %q", "invalid-format", annotations.OCMComponentVersion, path.DefaultComponentDescriptorPath+"/"),
+			expectedError: fmt.Errorf("failed to parse component version annotation: %q is not considered a valid %q annotation, not exactly 2 parts: [%[1]q]", "invalid-format", annotations.OCMComponentVersion),
 		},
 		{
 			name:      "component name mismatch",
@@ -103,12 +108,12 @@ func TestReferenceTagVersionResolver(t *testing.T) {
 		name          string
 		ref           string
 		tag           string
-		store         content.Resolver
+		store         *mockStore
 		expected      string
 		expectedError error
 	}{
 		{
-			name: "valid legacy manifest",
+			name: "valid manifest",
 			ref:  "example.com/repo",
 			tag:  "v1.0.0",
 			store: &mockStore{
@@ -117,33 +122,42 @@ func TestReferenceTagVersionResolver(t *testing.T) {
 						MediaType: ociImageSpecV1.MediaTypeImageManifest,
 					}, nil
 				},
-			},
-			expected: "v1.0.0",
-		},
-		{
-			name: "valid current manifest",
-			ref:  "example.com/repo",
-			tag:  "v1.0.0",
-			store: &mockStore{
-				resolveFunc: func(ctx context.Context, ref string) (ociImageSpecV1.Descriptor, error) {
-					return ociImageSpecV1.Descriptor{
-						MediaType:    ociImageSpecV1.MediaTypeImageManifest,
-						ArtifactType: descriptor.MediaTypeComponentDescriptorV2,
-					}, nil
+				fetchFunc: func(ctx context.Context, desc ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+					data, err := json.Marshal(&ociImageSpecV1.Manifest{
+						MediaType: ociImageSpecV1.MediaTypeImageManifest,
+						Annotations: map[string]string{
+							annotations.OCMComponentVersion: annotations.NewComponentVersionAnnotation("example.com/repo", "v1.0.0"),
+						},
+					})
+					if err != nil {
+						return nil, fmt.Errorf("failed to marshal manifest: %w", err)
+					}
+					return io.NopCloser(bytes.NewReader(data)), nil
 				},
 			},
 			expected: "v1.0.0",
 		},
 		{
-			name: "valid current index",
+			name: "valid index manifest",
 			ref:  "example.com/repo",
 			tag:  "v1.0.0",
 			store: &mockStore{
 				resolveFunc: func(ctx context.Context, ref string) (ociImageSpecV1.Descriptor, error) {
 					return ociImageSpecV1.Descriptor{
-						MediaType:    ociImageSpecV1.MediaTypeImageIndex,
-						ArtifactType: descriptor.MediaTypeComponentDescriptorV2,
+						MediaType: ociImageSpecV1.MediaTypeImageIndex,
 					}, nil
+				},
+				fetchFunc: func(ctx context.Context, desc ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+					data, err := json.Marshal(&ociImageSpecV1.Index{
+						MediaType: ociImageSpecV1.MediaTypeImageIndex,
+						Annotations: map[string]string{
+							annotations.OCMComponentVersion: annotations.NewComponentVersionAnnotation("example.com/repo", "v1.0.0"),
+						},
+					})
+					if err != nil {
+						return nil, fmt.Errorf("failed to marshal manifest: %w", err)
+					}
+					return io.NopCloser(bytes.NewReader(data)), nil
 				},
 			},
 			expected: "v1.0.0",
@@ -155,9 +169,31 @@ func TestReferenceTagVersionResolver(t *testing.T) {
 			store: &mockStore{
 				resolveFunc: func(ctx context.Context, ref string) (ociImageSpecV1.Descriptor, error) {
 					return ociImageSpecV1.Descriptor{
-						MediaType:    "invalid/type",
-						ArtifactType: descriptor.MediaTypeComponentDescriptorV2,
+						MediaType: "invalid/type",
 					}, nil
+				},
+			},
+			expected:      "v1.0.0",
+			expectedError: lister.ErrSkip,
+		},
+		{
+			name: "missing annotation",
+			ref:  "example.com/repo",
+			tag:  "v1.0.0",
+			store: &mockStore{
+				resolveFunc: func(ctx context.Context, ref string) (ociImageSpecV1.Descriptor, error) {
+					return ociImageSpecV1.Descriptor{
+						MediaType: ociImageSpecV1.MediaTypeImageIndex,
+					}, nil
+				},
+				fetchFunc: func(ctx context.Context, desc ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+					data, err := json.Marshal(&ociImageSpecV1.Index{
+						MediaType: ociImageSpecV1.MediaTypeImageIndex,
+					})
+					if err != nil {
+						return nil, fmt.Errorf("failed to marshal manifest: %w", err)
+					}
+					return io.NopCloser(bytes.NewReader(data)), nil
 				},
 			},
 			expected:      "v1.0.0",
@@ -167,7 +203,7 @@ func TestReferenceTagVersionResolver(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resolver := component.ReferenceTagVersionResolver(tt.store)
+			resolver := component.ReferenceTagVersionResolver(tt.ref, tt.store)
 
 			result, err := resolver(t.Context(), tt.tag)
 

--- a/bindings/go/oci/internal/lister/lister.go
+++ b/bindings/go/oci/internal/lister/lister.go
@@ -193,7 +193,7 @@ func listViaReferrrers(ctx context.Context, lister registry.ReferrerLister, opts
 		return nil, errors.New("referrer lister is not available")
 	}
 
-	// every time we get a callback for descriptors (i.e.g from a paginated list),
+	// every time we get a callback for descriptors (i.e. from a paginated list),
 	// we will spawn a goroutine for each descriptor to resolve it to a version
 	wg, ctx := errgroup.WithContext(ctx)
 	wg.SetLimit(runtime.NumCPU())

--- a/bindings/go/oci/internal/lister/lister.go
+++ b/bindings/go/oci/internal/lister/lister.go
@@ -10,8 +10,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"runtime"
 	"slices"
+	"strings"
 	"sync"
 
 	"github.com/Masterminds/semver/v3"
@@ -20,6 +22,7 @@ import (
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/registry"
 
+	"ocm.software/open-component-model/bindings/go/oci/internal/log"
 	indexv1 "ocm.software/open-component-model/bindings/go/oci/spec/index/component/v1"
 )
 
@@ -111,10 +114,12 @@ func (lister *Lister) List(ctx context.Context, opts Options) ([]string, error) 
 	if err != nil {
 		return nil, err
 	}
+	log.Base().Log(ctx, slog.LevelDebug, "listed version candidates", slog.Int("count", len(candidates)))
 	sorted, err := lister.sort(ctx, opts, candidates)
 	if err != nil {
 		return nil, err
 	}
+	log.Base().Log(ctx, slog.LevelDebug, "sorted version candidates")
 
 	return sorted, nil
 }
@@ -188,10 +193,14 @@ func listViaReferrrers(ctx context.Context, lister registry.ReferrerLister, opts
 		return nil, errors.New("referrer lister is not available")
 	}
 
+	// every time we get a callback for descriptors (i.e.g from a paginated list),
+	// we will spawn a goroutine for each descriptor to resolve it to a version
+	wg, ctx := errgroup.WithContext(ctx)
+	wg.SetLimit(runtime.NumCPU())
 	var mu sync.Mutex
+
 	list := func(referrers []ociImageSpecV1.Descriptor) error {
-		wg, ctx := errgroup.WithContext(ctx)
-		wg.SetLimit(runtime.NumCPU())
+		log.Base().Log(ctx, slog.LevelDebug, "listing referrers", slog.Int("count", len(referrers)))
 		for _, referrer := range referrers {
 			wg.Go(func() error {
 				ver, err := opts.VersionResolver(ctx, referrer)
@@ -208,11 +217,15 @@ func listViaReferrrers(ctx context.Context, lister registry.ReferrerLister, opts
 				return nil
 			})
 		}
-		return wg.Wait()
+		return nil
 	}
 
 	if err := lister.Referrers(ctx, indexv1.Descriptor, opts.ArtifactType, list); err != nil {
 		return nil, fmt.Errorf("failed to list referrers: %w", err)
+	}
+
+	if err := wg.Wait(); err != nil {
+		return nil, fmt.Errorf("error while listing referrers: %w", err)
 	}
 
 	return versions, nil
@@ -225,10 +238,14 @@ func listViaTags(ctx context.Context, lister registry.TagLister, opts TagListerO
 		return nil, errors.New("tag lister is not available")
 	}
 
+	wg, ctx := errgroup.WithContext(ctx)
+	wg.SetLimit(runtime.NumCPU())
 	var mu sync.Mutex
+
+	// every time we get a callback for tags (i.e.g from a paginated list),
+	// we will spawn a goroutine for each tag to resolve it to a version
 	list := func(tags []string) error {
-		wg, ctx := errgroup.WithContext(ctx)
-		wg.SetLimit(runtime.NumCPU())
+		log.Base().Log(ctx, slog.LevelDebug, "listing tags", slog.Int("count", len(tags)), slog.String("tags", strings.Join(tags, ",")))
 		for _, tag := range tags {
 			wg.Go(func() error {
 				ver, err := opts.VersionResolver(ctx, tag)
@@ -245,11 +262,15 @@ func listViaTags(ctx context.Context, lister registry.TagLister, opts TagListerO
 				return nil
 			})
 		}
-		return wg.Wait()
+		return nil
 	}
 
 	if err := lister.Tags(ctx, opts.Last, list); err != nil {
 		return nil, fmt.Errorf("failed to list tags: %w", err)
+	}
+
+	if err := wg.Wait(); err != nil {
+		return nil, fmt.Errorf("error while listing tags: %w", err)
 	}
 
 	return versions, nil

--- a/bindings/go/oci/repository.go
+++ b/bindings/go/oci/repository.go
@@ -130,7 +130,7 @@ func (repo *Repository) ListComponentVersions(ctx context.Context, component str
 	opts := lister.Options{
 		SortPolicy: lister.SortPolicyLooseSemverDescending,
 		TagListerOptions: lister.TagListerOptions{
-			VersionResolver: complister.ReferenceTagVersionResolver(store),
+			VersionResolver: complister.ReferenceTagVersionResolver(component, store),
 		},
 		ReferrerListerOptions: lister.ReferrerListerOptions{
 			ArtifactType:    descriptor2.MediaTypeComponentDescriptorV2,

--- a/bindings/go/oci/spec/annotations/annotations.go
+++ b/bindings/go/oci/spec/annotations/annotations.go
@@ -19,21 +19,26 @@ const (
 	// It is usually only a meta information, and has no semantic meaning beyond identifying a creating
 	// process or user agent. as such it CAN be correlated to a user agent header in http.
 	OCMCreator = "software.ocm.creator"
+
+	OCMComponentVersionAnnotationSeparator = ":"
 )
 
 func NewComponentVersionAnnotation(component, version string) string {
 	return fmt.Sprintf("%s/%s:%s", path.DefaultComponentDescriptorPath, component, version)
 }
 
+// ParseComponentVersionAnnotation parses the component version annotation and returns the component name and version.
+// It can identify a possible
 func ParseComponentVersionAnnotation(annotation string) (string, string, error) {
 	prefix := path.DefaultComponentDescriptorPath + "/"
-	if !strings.HasPrefix(annotation, prefix) {
-		return "", "", fmt.Errorf("%q is not considered a valid %q annotation because of a bad prefix, expected %q", annotation, OCMComponentVersion, prefix)
+	if withoutPrefix := strings.TrimPrefix(annotation, prefix); withoutPrefix != annotation {
+		// Remove the prefix if it exists, to allow for both prefixed and non-prefixed annotations.
+		annotation = withoutPrefix
 	}
-	postTrim := strings.TrimPrefix(annotation, prefix)
-	split := strings.Split(postTrim, ":")
+
+	split := strings.SplitN(annotation, OCMComponentVersionAnnotationSeparator, 3)
 	if len(split) != 2 {
-		return "", "", fmt.Errorf("%q is not considered a valid %q annotation", annotation, OCMComponentVersion)
+		return "", "", fmt.Errorf("%q is not considered a valid %q annotation, not exactly 2 parts: %q", annotation, OCMComponentVersion, split)
 	}
 	candidate := split[0]
 	version := split[1]

--- a/bindings/go/oci/spec/annotations/annotations.go
+++ b/bindings/go/oci/spec/annotations/annotations.go
@@ -28,7 +28,8 @@ func NewComponentVersionAnnotation(component, version string) string {
 }
 
 // ParseComponentVersionAnnotation parses the component version annotation and returns the component name and version.
-// It can identify a possible
+// It can identify a possible prefix of the annotation, which is the default component descriptor path and exclude
+// it from the component name. (this can be present in CTFs.)
 func ParseComponentVersionAnnotation(annotation string) (string, string, error) {
 	prefix := path.DefaultComponentDescriptorPath + "/"
 	if withoutPrefix := strings.TrimPrefix(annotation, prefix); withoutPrefix != annotation {

--- a/bindings/go/oci/spec/annotations/annotations_test.go
+++ b/bindings/go/oci/spec/annotations/annotations_test.go
@@ -1,6 +1,7 @@
 package annotations
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,25 +52,47 @@ func TestParseComponentVersionAnnotation(t *testing.T) {
 		expectedError string
 	}{
 		{
-			name:         "valid annotation",
+			name:         "valid annotation (prefixed)",
 			annotation:   "component-descriptors/test-component:1.0.0",
 			expectedComp: "test-component",
 			expectedVer:  "1.0.0",
 		},
 		{
+			name:         "valid annotation",
+			annotation:   "test-component:1.0.0",
+			expectedComp: "test-component",
+			expectedVer:  "1.0.0",
+		},
+		{
+			name:         "valid annotation (name without prefix but with slash)",
+			annotation:   "ocm.software/abc/def/test-component:1.0.0",
+			expectedComp: "ocm.software/abc/def/test-component",
+			expectedVer:  "1.0.0",
+		},
+		{
+			name:         "valid annotation (name without prefix but with slash and prefix)",
+			annotation:   "component-descriptors/ocm.software/abc/def/test-component:1.0.0",
+			expectedComp: "ocm.software/abc/def/test-component",
+			expectedVer:  "1.0.0",
+		},
+		{
 			name:          "invalid format - missing colon",
 			annotation:    "component-descriptors/test-component",
-			expectedError: "\"component-descriptors/test-component\" is not considered a valid \"software.ocm.componentversion\" annotation",
+			expectedError: fmt.Sprintf("%q is not considered a valid %q annotation, not exactly 2 parts: [%[1]q]", "test-component", OCMComponentVersion),
 		},
 		{
 			name:          "invalid format - empty version",
 			annotation:    "component-descriptors/test-component:",
-			expectedError: "version parsed from \"component-descriptors/test-component:\" in \"software.ocm.componentversion\" annotation is empty but should not be",
+			expectedError: "version parsed from \"test-component:\" in \"software.ocm.componentversion\" annotation is empty but should not be",
 		},
 		{
-			name:          "invalid format - wrong prefix",
-			annotation:    "wrong-prefix/test-component:1.0.0",
-			expectedError: "\"wrong-prefix/test-component:1.0.0\" is not considered a valid \"software.ocm.componentversion\" annotation because of a bad prefix, expected \"component-descriptors/\"",
+			name:       "invalid format - multiple separators",
+			annotation: "wrong/test-component:1.0.0:1.0.0",
+			expectedError: fmt.Sprintf("%q is not considered a valid %q annotation, not exactly 2 parts: %q",
+				"wrong/test-component:1.0.0:1.0.0",
+				OCMComponentVersion,
+				[]string{"wrong/test-component", "1.0.0", "1.0.0"},
+			),
 		},
 	}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

previously the lib only used the tags resolve functionality when listing tags. this could cause issues if there were other tagged manifests that were not ocm component versions. also the tagging was not properly concurrent but worked in concurrent blocks equivalent to the tag list page size.


#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

now tag listing works concurrently based on the resolution of the manifest and then the interpretation of the component version annotation on the manifest to differentiate OCM and non OCM versions. While less efficient (a fetch call more per tag), due to the efficiency gains during listing, we should still be good to go.

TLDR: 
- Now we can concurrently fetch all tags, and not just all tags in a page from OCI
- The tag listing actually introspects the discovered tagged manifests, and filters any that do not have our OCM component version annotation as they can not possibly be valid versions
