### PR TITLE
chore!: make sure that OCI lib expects only already converted accesses

### DIFF
--- a/bindings/go/oci/internal/pack/pack_test.go
+++ b/bindings/go/oci/internal/pack/pack_test.go
@@ -250,7 +250,7 @@ func TestResourceBlob(t *testing.T) {
 			},
 		},
 		{
-			name: "error on empty access type",
+			name: "empty type but typed access",
 			blob: &testBlob{
 				content:   content,
 				mediaType: "application/vnd.test",
@@ -258,28 +258,14 @@ func TestResourceBlob(t *testing.T) {
 			},
 			resource: &descriptor.Resource{
 				Access: &v2.LocalBlob{
-					Type: runtime.NewVersionedType("", ""),
+					LocalReference: digest.String(),
+					MediaType:      "application/vnd.test",
 				},
 			},
 			opts: Options{
-				AccessScheme: runtime.NewScheme(),
+				AccessScheme:  runtime.NewScheme(),
+				BaseReference: "test-ref",
 			},
-			expectedError: "resource access or access type is empty",
-		},
-		{
-			name: "error on nil access",
-			blob: &testBlob{
-				content:   content,
-				mediaType: "application/vnd.test",
-				digest:    digest,
-			},
-			resource: &descriptor.Resource{
-				Access: nil,
-			},
-			opts: Options{
-				AccessScheme: runtime.NewScheme(),
-			},
-			expectedError: "resource access or access type is empty",
 		},
 		{
 			name: "error on unsupported access type",
@@ -289,14 +275,14 @@ func TestResourceBlob(t *testing.T) {
 				digest:    digest,
 			},
 			resource: &descriptor.Resource{
-				Access: &v2.LocalBlob{
+				Access: &runtime.Raw{
 					Type: runtime.NewVersionedType("unsupported", "v1"),
 				},
 			},
 			opts: Options{
 				AccessScheme: runtime.NewScheme(),
 			},
-			expectedError: "error creating resource access: unsupported type: unsupported/v1",
+			expectedError: "artifact access is not a local blob access",
 		},
 	}
 
@@ -354,7 +340,7 @@ func TestResourceLocalBlob(t *testing.T) {
 		name          string
 		blob          *testBlob
 		resource      *descriptor.Resource
-		access        *descriptor.LocalBlob
+		access        *v2.LocalBlob
 		opts          Options
 		expectedError string
 	}{
@@ -366,7 +352,7 @@ func TestResourceLocalBlob(t *testing.T) {
 				digest:    dig,
 			},
 			resource: &descriptor.Resource{},
-			access: &descriptor.LocalBlob{
+			access: &v2.LocalBlob{
 				MediaType: "application/vnd.oci.image.layout.v1+tar",
 			},
 			opts: Options{
@@ -382,7 +368,7 @@ func TestResourceLocalBlob(t *testing.T) {
 				digest:    dig,
 			},
 			resource: &descriptor.Resource{},
-			access: &descriptor.LocalBlob{
+			access: &v2.LocalBlob{
 				MediaType: "application/vnd.test",
 			},
 			opts: Options{
@@ -436,7 +422,7 @@ func TestResourceLocalBlobOCISingleLayerArtifact(t *testing.T) {
 		name          string
 		blob          *testBlob
 		resource      *descriptor.Resource
-		access        *descriptor.LocalBlob
+		access        *v2.LocalBlob
 		opts          Options
 		expectedError string
 	}{
@@ -448,7 +434,7 @@ func TestResourceLocalBlobOCISingleLayerArtifact(t *testing.T) {
 				digest:    digest,
 			},
 			resource: &descriptor.Resource{},
-			access: &descriptor.LocalBlob{
+			access: &v2.LocalBlob{
 				MediaType:      "application/vnd.test",
 				LocalReference: digest.String(),
 			},
@@ -465,7 +451,7 @@ func TestResourceLocalBlobOCISingleLayerArtifact(t *testing.T) {
 				digest:    digest,
 			},
 			resource: &descriptor.Resource{},
-			access: &descriptor.LocalBlob{
+			access: &v2.LocalBlob{
 				MediaType:      "application/vnd.test",
 				LocalReference: digest.String(),
 			},
@@ -483,7 +469,7 @@ func TestResourceLocalBlobOCISingleLayerArtifact(t *testing.T) {
 				digest:    digest,
 			},
 			resource: &descriptor.Resource{},
-			access: &descriptor.LocalBlob{
+			access: &v2.LocalBlob{
 				MediaType:      "application/vnd.test",
 				LocalReference: digest.String(),
 			},

--- a/bindings/go/oci/repository.go
+++ b/bindings/go/oci/repository.go
@@ -215,19 +215,7 @@ func (repo *Repository) ProcessResourceDigest(ctx context.Context, res *descript
 		done(err)
 	}()
 	res = res.DeepCopy()
-	access := res.Access
-	if _, err = repo.scheme.DefaultType(access); err != nil {
-		return nil, fmt.Errorf("error defaulting resource access type: %w", err)
-	}
-	typed, err := repo.scheme.NewObject(access.GetType())
-	if err != nil {
-		return nil, fmt.Errorf("error creating resource access: %w", err)
-	}
-	if err := repo.scheme.Convert(access, typed); err != nil {
-		return nil, fmt.Errorf("error converting resource access: %w", err)
-	}
-
-	switch typed := typed.(type) {
+	switch typed := res.Access.(type) {
 	case *v2.LocalBlob:
 		if typed.GlobalAccess == nil {
 			return nil, fmt.Errorf("local blob access does not have a global access and cannot be used")

--- a/bindings/go/oci/repository_options.go
+++ b/bindings/go/oci/repository_options.go
@@ -16,6 +16,13 @@ import (
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
+var DefaultRepositoryScheme = runtime.NewScheme()
+
+func init() {
+	ocmoci.MustAddToScheme(DefaultRepositoryScheme)
+	v2.MustAddToScheme(DefaultRepositoryScheme)
+}
+
 // RepositoryOptions defines the options for creating a new Repository.
 type RepositoryOptions struct {
 	// Scheme is the runtime scheme used for type conversion.
@@ -121,9 +128,7 @@ func NewRepository(opts ...RepositoryOption) (*Repository, error) {
 	}
 
 	if options.Scheme == nil {
-		options.Scheme = runtime.NewScheme()
-		ocmoci.MustAddToScheme(options.Scheme)
-		v2.MustAddToScheme(options.Scheme)
+		options.Scheme = DefaultRepositoryScheme
 	}
 
 	if options.LocalManifestCache == nil {

--- a/bindings/go/oci/repository_test.go
+++ b/bindings/go/oci/repository_test.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -152,11 +151,9 @@ func TestRepository_GetLocalResource(t *testing.T) {
 					},
 				},
 				Type: "test-type",
-				Access: &runtime.Raw{
-					Type: runtime.Type{
-						Name: "localBlob",
-					},
-					Data: []byte(`{"localReference":"sha256:1234567890","mediaType":"application/octet-stream"}`),
+				Access: &v2.LocalBlob{
+					LocalReference: "sha256:1234567890",
+					MediaType:      "application/octet-stream",
 				},
 			},
 			identity: map[string]string{
@@ -179,13 +176,9 @@ func TestRepository_GetLocalResource(t *testing.T) {
 					},
 				},
 				Type: "test-type",
-				Access: &runtime.Raw{
-					Type: runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-					Data: []byte(fmt.Sprintf(
-						`{"type":"%s","localReference":"%s","mediaType":"application/octet-stream"}`,
-						runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-						digest.FromString("test content").String(),
-					)),
+				Access: &v2.LocalBlob{
+					LocalReference: digest.FromString("test content").String(),
+					MediaType:      "application/octet-stream",
 				},
 			},
 			identity: map[string]string{
@@ -211,13 +204,9 @@ func TestRepository_GetLocalResource(t *testing.T) {
 					},
 				},
 				Type: "test-type",
-				Access: &runtime.Raw{
-					Type: runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-					Data: []byte(fmt.Sprintf(
-						`{"type":"%s","localReference":"%s","mediaType":"application/octet-stream"}`,
-						runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-						digest.FromString("platform specific content").String(),
-					)),
+				Access: &v2.LocalBlob{
+					LocalReference: digest.FromString("platform specific content").String(),
+					MediaType:      "application/octet-stream",
 				},
 			},
 			content: []byte("platform specific content"),
@@ -242,13 +231,9 @@ func TestRepository_GetLocalResource(t *testing.T) {
 					},
 				},
 				Type: "test-type",
-				Access: &runtime.Raw{
-					Type: runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-					Data: []byte(fmt.Sprintf(
-						`{"type":"%s","localReference":"%s","mediaType":"application/octet-stream"}`,
-						runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-						digest.FromString("legacy content").String(),
-					)),
+				Access: &v2.LocalBlob{
+					LocalReference: digest.FromString("legacy content").String(),
+					MediaType:      "application/octet-stream",
 				},
 			},
 			content: []byte("legacy content"),
@@ -275,13 +260,9 @@ func TestRepository_GetLocalResource(t *testing.T) {
 					},
 				},
 				Type: "test-type",
-				Access: &runtime.Raw{
-					Type: runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-					Data: []byte(fmt.Sprintf(
-						`{"type":"%s","localReference":"%s","mediaType":"application/octet-stream"}`,
-						runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-						digest.FromString("platform specific content").String(),
-					)),
+				Access: &v2.LocalBlob{
+					LocalReference: digest.FromString("platform specific content").String(),
+					MediaType:      "application/octet-stream",
 				},
 			},
 			identity: map[string]string{
@@ -302,14 +283,9 @@ func TestRepository_GetLocalResource(t *testing.T) {
 					},
 				},
 				Type: "test-type",
-				Access: &runtime.Raw{
-					Type: runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-					Data: []byte(fmt.Sprintf(
-						`{"type":"%s","localReference":"%s","mediaType":"%s"}`,
-						runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-						digest.FromString("single layer manifest content").String(),
-						ociImageSpecV1.MediaTypeImageManifest,
-					)),
+				Access: &v2.LocalBlob{
+					LocalReference: digest.FromString("single layer manifest content").String(),
+					MediaType:      ociImageSpecV1.MediaTypeImageManifest,
 				},
 			},
 			content: []byte("single layer manifest content"),
@@ -332,14 +308,9 @@ func TestRepository_GetLocalResource(t *testing.T) {
 					},
 				},
 				Type: "test-type",
-				Access: &runtime.Raw{
-					Type: runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-					Data: []byte(fmt.Sprintf(
-						`{"type":"%s","localReference":"%s","mediaType":"%s"}`,
-						runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-						digest.FromString("oci layout content").String(),
-						layout.MediaTypeOCIImageLayoutV1+"+tar+gzip",
-					)),
+				Access: &v2.LocalBlob{
+					LocalReference: digest.FromString("oci layout content").String(),
+					MediaType:      layout.MediaTypeOCIImageLayoutV1 + "+tar+gzip",
 				},
 			},
 			content: func(t *testing.T) []byte {
@@ -506,14 +477,9 @@ func TestRepository_DownloadUploadResource(t *testing.T) {
 					},
 				},
 				Type: "ociImageLayer",
-				Access: &runtime.Raw{
-					Type: runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-					Data: []byte(fmt.Sprintf(
-						`{"type":"%s","localReference":"%s","mediaType":"%s"}`,
-						runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-						digest.FromString("test layer content").String(),
-						artifactMediaType,
-					)),
+				Access: &v2.LocalBlob{
+					LocalReference: digest.FromString("test layer content").String(),
+					MediaType:      artifactMediaType,
 				},
 			},
 			content:        []byte("test layer content"),
@@ -693,14 +659,9 @@ func TestRepository_DownloadUploadSource(t *testing.T) {
 					},
 				},
 				Type: "ociImageLayer",
-				Access: &runtime.Raw{
-					Type: runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-					Data: []byte(fmt.Sprintf(
-						`{"type":"%s","localReference":"%s","mediaType":"%s"}`,
-						runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-						digest.FromString("test layer content").String(),
-						artifactMediaType,
-					)),
+				Access: &v2.LocalBlob{
+					LocalReference: digest.FromString("test layer content").String(),
+					MediaType:      artifactMediaType,
 				},
 			},
 			content:        []byte("test layer content"),
@@ -877,14 +838,9 @@ func TestRepository_AddLocalResourceOCILayout(t *testing.T) {
 			},
 		},
 		Type: "test-type",
-		Access: &runtime.Raw{
-			Type: runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-			Data: []byte(fmt.Sprintf(
-				`{"type":"%s","localReference":"%s","mediaType":"%s"}`,
-				runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-				digest.FromBytes(data).String(),
-				layout.MediaTypeOCIImageLayoutV1+"+tar",
-			)),
+		Access: &v2.LocalBlob{
+			LocalReference: digest.FromBytes(data).String(),
+			MediaType:      layout.MediaTypeOCIImageLayoutV1 + "+tar",
 		},
 	}
 
@@ -953,14 +909,9 @@ func TestRepository_AddLocalResourceOCIImageLayer(t *testing.T) {
 			},
 		},
 		Type: "ociImageLayer",
-		Access: &runtime.Raw{
-			Type: runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-			Data: []byte(fmt.Sprintf(
-				`{"type":"%s","localReference":"%s","mediaType":"%s"}`,
-				runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-				contentDigest.String(),
-				ociImageSpecV1.MediaTypeImageLayer,
-			)),
+		Access: &v2.LocalBlob{
+			LocalReference: contentDigest.String(),
+			MediaType:      ociImageSpecV1.MediaTypeImageLayer,
 		},
 	}
 
@@ -1097,6 +1048,7 @@ func setupLegacyComponentVersion(t *testing.T, store *ocictf.Store, ctx context.
 	r.NoError(repoStore.Push(ctx, layerDesc, bytes.NewReader(content)))
 
 	topDesc, err := oci.AddDescriptorToStore(ctx, repoStore, desc, oci.AddDescriptorOptions{
+		Scheme:           oci.DefaultRepositoryScheme,
 		Author:           "OLD OCM",
 		AdditionalLayers: []ociImageSpecV1.Descriptor{layerDesc},
 	})
@@ -1168,11 +1120,9 @@ func TestRepository_GetLocalSource(t *testing.T) {
 					},
 				},
 				Type: "test-type",
-				Access: &runtime.Raw{
-					Type: runtime.Type{
-						Name: "localBlob",
-					},
-					Data: []byte(`{"localReference":"sha256:1234567890","mediaType":"application/octet-stream"}`),
+				Access: &v2.LocalBlob{
+					LocalReference: "sha256:1234567890",
+					MediaType:      "application/octet-stream",
 				},
 			},
 			identity: map[string]string{
@@ -1195,13 +1145,8 @@ func TestRepository_GetLocalSource(t *testing.T) {
 					},
 				},
 				Type: "test-type",
-				Access: &runtime.Raw{
-					Type: runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-					Data: []byte(fmt.Sprintf(
-						`{"type":"%s","localReference":"%s","mediaType":"application/octet-stream"}`,
-						runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-						digest.FromString("test content").String(),
-					)),
+				Access: &v2.LocalBlob{
+					LocalReference: digest.FromString("test content").String(),
 				},
 			},
 			identity: map[string]string{
@@ -1227,13 +1172,8 @@ func TestRepository_GetLocalSource(t *testing.T) {
 					},
 				},
 				Type: "test-type",
-				Access: &runtime.Raw{
-					Type: runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-					Data: []byte(fmt.Sprintf(
-						`{"type":"%s","localReference":"%s","mediaType":"application/octet-stream"}`,
-						runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-						digest.FromString("platform specific content").String(),
-					)),
+				Access: &v2.LocalBlob{
+					LocalReference: digest.FromString("platform specific content").String(),
 				},
 			},
 			content: []byte("platform specific content"),
@@ -1262,13 +1202,8 @@ func TestRepository_GetLocalSource(t *testing.T) {
 					},
 				},
 				Type: "test-type",
-				Access: &runtime.Raw{
-					Type: runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-					Data: []byte(fmt.Sprintf(
-						`{"type":"%s","localReference":"%s","mediaType":"application/octet-stream"}`,
-						runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-						digest.FromString("platform specific content").String(),
-					)),
+				Access: &v2.LocalBlob{
+					LocalReference: digest.FromString("platform specific content").String(),
 				},
 			},
 			identity: map[string]string{
@@ -1289,14 +1224,9 @@ func TestRepository_GetLocalSource(t *testing.T) {
 					},
 				},
 				Type: "test-type",
-				Access: &runtime.Raw{
-					Type: runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-					Data: []byte(fmt.Sprintf(
-						`{"type":"%s","localReference":"%s","mediaType":"%s"}`,
-						runtime.NewVersionedType(v2.LocalBlobAccessType, v2.LocalBlobAccessTypeVersion),
-						digest.FromString("oci layout content").String(),
-						layout.MediaTypeOCIImageLayoutV1+"+tar+gzip",
-					)),
+				Access: &v2.LocalBlob{
+					LocalReference: digest.FromString("oci layout content").String(),
+					MediaType:      layout.MediaTypeOCIImageLayoutV1 + "+tar+gzip",
 				},
 			},
 			content: func(t *testing.T) []byte {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

because we only use the runtime package in OCI repositories, we shouldn't need to deal with crazy raw to type conversions. Instead any caller should have preconverted types that we assert on. This means that effectively one has to already use the correct access type and not just Raw to use the lib. This makes the coding easier to handle.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
