### PR TITLE
chore(ci): point to correct linkspector config

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -29,7 +29,7 @@ jobs:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check
           fail_level: any
-          config_file: .github/config/markdown-link-check.json
+          config_file: .github/config/linkspector.yaml
           show_stats: true
   spellcheck:
     name: Spellcheck


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

fixup linkspector config to point to the correct config file (previously used the wrong name)

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
