### PR TITLE
chore(ci): make sure renovate allows if no go is present

### DIFF
--- a/.github/config/renovate.json5
+++ b/.github/config/renovate.json5
@@ -41,6 +41,6 @@
     },
   ],
   "allowedCommands": [
-    "^find\\s\\.\\s-name.+go\\.mod.+-path.+integration.+go\\smod\\stidy"
+    "^(command -v go >/dev/null 2>&1 \\|\\| exit 0;\\s*)?find\\s+\\.\\s+-name\\s+\\\"go\\.mod\\\".*-path\\s+'\\*/integration/\\*'.*go\\s+mod\\s+tidy"
   ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -33,7 +33,7 @@
   ],
   "postUpgradeTasks": {
     "commands": [
-      "find . -name \"go.mod\" -type f -path '*/integration/*' -exec dirname {} \\; | while read dir; do echo \"Running explicit go mod tidy for integration test in $dir\"; cd \"$dir\" && go mod tidy && cd - > /dev/null; done"
+      "command -v go >/dev/null 2>&1 || exit 0; find . -name \"go.mod\" -type f -path '*/integration/*' -exec dirname {} \\; | while read dir; do echo \"Running explicit go mod tidy for integration test in $dir\"; cd \"$dir\" && go mod tidy && cd - > /dev/null; done"
     ],
     "fileFilters": ["**/go.mod", "**/go.sum"],
     "executionMode": "branch"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

in some renovate updates (e.g. github actions only) no go command is present so we need to check for it and skip it there