### PR TITLE
chore(ci): ensure linkspector config is correct

### DIFF
--- a/.github/config/linkspector.yaml
+++ b/.github/config/linkspector.yaml
@@ -1,5 +1,6 @@
+dirs:
+  - ./
 replacementPatterns:
   - pattern: "^/"
     replacement: "{{BASEURL}}/"
-ignorePatterns: []
 modifiedFilesOnly: true


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

linkspector has a mandatory dir entry

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
