### PR TITLE
fix: make sure to not use constructors in resource repositories

### DIFF
--- a/bindings/go/plugin/manager/registries/resource/contract.go
+++ b/bindings/go/plugin/manager/registries/resource/contract.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"ocm.software/open-component-model/bindings/go/blob"
-	constructor "ocm.software/open-component-model/bindings/go/constructor/runtime"
 	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
@@ -12,8 +11,8 @@ import (
 // Repository defines the interface for storing and retrieving OCM resources
 // independently of component versions from a Store Implementation
 type Repository interface {
-	// GetResourceCredentialConsumerIdentity resolves the identity of the given [constructor.Resource] to use for credential resolution.
-	GetResourceCredentialConsumerIdentity(ctx context.Context, resource *constructor.Resource) (runtime.Identity, error)
+	// GetResourceCredentialConsumerIdentity resolves the identity of the given [descriptor.Resource] to use for credential resolution.
+	GetResourceCredentialConsumerIdentity(ctx context.Context, resource *descriptor.Resource) (runtime.Identity, error)
 	// DownloadResource downloads a [descriptor.Resource] from the repository.
 	DownloadResource(ctx context.Context, res *descriptor.Resource, credentials map[string]string) (blob.ReadOnlyBlob, error)
 }

--- a/bindings/go/plugin/manager/registries/resource/registry_test.go
+++ b/bindings/go/plugin/manager/registries/resource/registry_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"ocm.software/open-component-model/bindings/go/blob"
-	constructorruntime "ocm.software/open-component-model/bindings/go/constructor/runtime"
 	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
 	"ocm.software/open-component-model/bindings/go/plugin/internal/dummytype"
 	dummyv1 "ocm.software/open-component-model/bindings/go/plugin/internal/dummytype/v1"
@@ -125,7 +124,7 @@ type mockResourcePlugin struct{}
 
 var _ Repository = (*mockResourcePlugin)(nil)
 
-func (m *mockResourcePlugin) GetResourceCredentialConsumerIdentity(ctx context.Context, resource *constructorruntime.Resource) (runtime.Identity, error) {
+func (m *mockResourcePlugin) GetResourceCredentialConsumerIdentity(ctx context.Context, resource *descriptor.Resource) (runtime.Identity, error) {
 	return nil, nil
 }
 

--- a/bindings/go/plugin/manager/registries/resource/resource_converter.go
+++ b/bindings/go/plugin/manager/registries/resource/resource_converter.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"ocm.software/open-component-model/bindings/go/blob"
-	constructorruntime "ocm.software/open-component-model/bindings/go/constructor/runtime"
 	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/contracts/resource/v1"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/blobs"
@@ -17,7 +16,7 @@ type resourcePluginConverter struct {
 	scheme         *runtime.Scheme
 }
 
-func (r *resourcePluginConverter) GetResourceCredentialConsumerIdentity(ctx context.Context, resource *constructorruntime.Resource) (identity runtime.Identity, err error) {
+func (r *resourcePluginConverter) GetResourceCredentialConsumerIdentity(ctx context.Context, resource *descriptor.Resource) (identity runtime.Identity, err error) {
 	request := &v1.GetIdentityRequest[runtime.Typed]{
 		Typ: resource.Access,
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

for resource repositories, we were using the constructor runtime for consumer identity resolution, but this was the wrong interface. instead we should use the descriptor runtime.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
