### PR TITLE
fix: adjust to identity to omit empty name and/or version

### DIFF
--- a/bindings/go/descriptor/v2/descriptor.go
+++ b/bindings/go/descriptor/v2/descriptor.go
@@ -202,8 +202,12 @@ func (m *ElementMeta) ToIdentity() runtime.Identity {
 	if mp == nil {
 		mp = make(runtime.Identity, 2)
 	}
-	mp[IdentityAttributeName] = m.Name
-	mp[IdentityAttributeVersion] = m.Version
+	if m.Name != "" {
+		mp[IdentityAttributeName] = m.Name
+	}
+	if m.Version != "" {
+		mp[IdentityAttributeVersion] = m.Version
+	}
 	return mp
 }
 
@@ -224,8 +228,12 @@ func (r *ComponentMeta) ToIdentity() runtime.Identity {
 		return nil
 	}
 	m := make(runtime.Identity, 2)
-	m[IdentityAttributeName] = r.Name
-	m[IdentityAttributeVersion] = r.Version
+	if r.Name != "" {
+		m[IdentityAttributeName] = r.Name
+	}
+	if r.Version != "" {
+		m[IdentityAttributeVersion] = r.Version
+	}
 	return m
 }
 

--- a/bindings/go/descriptor/v2/descriptor_test.go
+++ b/bindings/go/descriptor/v2/descriptor_test.go
@@ -303,59 +303,135 @@ func TestElementMeta_String(t *testing.T) {
 }
 
 func TestElementMeta_ToIdentity(t *testing.T) {
-	// Setup
-	elemMeta := descriptorv2.ElementMeta{
-		ObjectMeta: descriptorv2.ObjectMeta{
-			Name:    "test-element",
-			Version: "2.0.0",
+	r := require.New(t)
+
+	tests := []struct {
+		name     string
+		elemMeta *descriptorv2.ElementMeta
+		expected runtime.Identity
+	}{
+		{
+			name: "with extra identity",
+			elemMeta: &descriptorv2.ElementMeta{
+				ObjectMeta: descriptorv2.ObjectMeta{
+					Name:    "test-element",
+					Version: "2.0.0",
+				},
+				ExtraIdentity: runtime.Identity{
+					"namespace": "system",
+				},
+			},
+			expected: runtime.Identity{
+				"namespace": "system",
+				"name":      "test-element",
+				"version":   "2.0.0",
+			},
 		},
-		ExtraIdentity: runtime.Identity{
-			"namespace": "system",
+		{
+			name:     "with nil identity",
+			elemMeta: nil,
+			expected: nil,
+		},
+		{
+			name: "identity without version",
+			elemMeta: &descriptorv2.ElementMeta{
+				ObjectMeta: descriptorv2.ObjectMeta{
+					Name: "test",
+				},
+			},
+			expected: runtime.Identity{
+				descriptorv2.IdentityAttributeName: "test",
+			},
+		},
+		{
+			name: "identity without name",
+			elemMeta: &descriptorv2.ElementMeta{
+				ObjectMeta: descriptorv2.ObjectMeta{
+					Version: "test",
+				},
+			},
+			expected: runtime.Identity{
+				descriptorv2.IdentityAttributeVersion: "test",
+			},
+		},
+		{
+			name: "identity without anything",
+			elemMeta: &descriptorv2.ElementMeta{
+				ObjectMeta: descriptorv2.ObjectMeta{},
+			},
+			expected: runtime.Identity{},
 		},
 	}
 
-	// Test
-	identity := elemMeta.ToIdentity()
-
-	// Assert
-	expected := runtime.Identity{
-		"name":      "test-element",
-		"version":   "2.0.0",
-		"namespace": "system",
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			identity := tt.elemMeta.ToIdentity()
+			r.Equal(tt.expected, identity)
+		})
 	}
-	assert.Equal(t, expected, identity)
-}
-
-func TestElementMeta_ToIdentity_Nil(t *testing.T) {
-	// Test
-	var elemMeta *descriptorv2.ElementMeta
-	identity := elemMeta.ToIdentity()
-
-	// Assert
-	assert.Nil(t, identity)
 }
 
 func TestComponentMeta_ToIdentity(t *testing.T) {
-	// Setup
-	compMeta := descriptorv2.ComponentMeta{
-		ObjectMeta: descriptorv2.ObjectMeta{
-			Name:    "test-component",
-			Version: "3.0.0",
-			Labels: []descriptorv2.Label{
-				{Name: "stage", Value: descriptorv2.MustAsRawMessage("dev")},
+	tests := []struct {
+		name     string
+		compMeta *descriptorv2.ComponentMeta
+		expected runtime.Identity
+	}{
+		{
+			name: "WithNameAndVersion",
+			compMeta: &descriptorv2.ComponentMeta{
+				ObjectMeta: descriptorv2.ObjectMeta{
+					Name:    "test-component",
+					Version: "3.0.0",
+				},
 			},
+			expected: runtime.Identity{
+				"name":    "test-component",
+				"version": "3.0.0",
+			},
+		},
+		{
+			name:     "NilComponentMeta",
+			compMeta: nil,
+			expected: nil,
+		},
+		{
+			name: "NameWithoutVersion",
+			compMeta: &descriptorv2.ComponentMeta{
+				ObjectMeta: descriptorv2.ObjectMeta{
+					Name: "test-component",
+				},
+			},
+			expected: runtime.Identity{
+				descriptorv2.IdentityAttributeName: "test-component",
+			},
+		},
+		{
+			name: "VersionWithoutName",
+			compMeta: &descriptorv2.ComponentMeta{
+				ObjectMeta: descriptorv2.ObjectMeta{
+					Version: "1.0.0",
+				},
+			},
+			expected: runtime.Identity{
+				descriptorv2.IdentityAttributeVersion: "1.0.0",
+			},
+		},
+		{
+			name: "EmptyComponentMeta",
+			compMeta: &descriptorv2.ComponentMeta{
+				ObjectMeta: descriptorv2.ObjectMeta{},
+			},
+			expected: runtime.Identity{},
 		},
 	}
 
-	// Test
-	identity := compMeta.ToIdentity()
-
-	// Assert
-	expected := runtime.Identity{
-		"name":    "test-component",
-		"version": "3.0.0",
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			identity := tt.compMeta.ToIdentity()
+			assert.Equal(t, tt.expected, identity)
+		})
 	}
-	assert.Equal(t, expected, identity)
 }
 
 func TestComponentMeta_ToIdentity_Nil(t *testing.T) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
The ocm specifies that the version property is optional (see https://github.com/open-component-model/ocm-spec/blob/main/doc/01-model/03-elements-sub.md#element-identity).

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
