### PR TITLE
chore(ci): try to force monorepo updates directly from VCS

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -24,6 +24,7 @@ jobs:
         uses: renovatebot/github-action@13da59cf7cfbd3bfea72ce26752ed22edf747ce9 # v43.0.2
         env:
           RENOVATE_PLATFORM_COMMIT: 'true'
+          GONOPROXY: ocm.software/open-component-model
         with:
           configurationFile: .github/config/renovate.json5
           token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

lets try to no proxy our modules so we dont rely on the go proxy cache to hold our digest updates which can confuse renovate

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
