### PR TITLE
chore(ci): try to force monorepo updates via proxy api

### DIFF
--- a/.github/config/renovate.json5
+++ b/.github/config/renovate.json5
@@ -6,6 +6,9 @@
   prConcurrentLimit: 0,
   prHourlyLimit: 0,
   "platform": "github",
+  allowedEnv: [
+    "GOPROXY"
+  ],
   env: {
     GOPROXY: "direct"
   },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

allowing the env is needed for self hosted renovate

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
