### PR TITLE
fix: ensure component constructors do not omit extra identities during conversion

### DIFF
--- a/bindings/go/constructor/runtime/convert_v1.go
+++ b/bindings/go/constructor/runtime/convert_v1.go
@@ -292,14 +292,9 @@ func ConvertToRuntimeComponent(component *v1.Component) Component {
 // for use in a ComponentConstructor.
 func ConvertToRuntimeConstructorResource(resource v1.Resource) Resource {
 	target := Resource{
-		ElementMeta: ElementMeta{
-			ObjectMeta: ObjectMeta{
-				Name:    resource.Name,
-				Version: resource.Version,
-			},
-		},
-		Type:     resource.Type,
-		Relation: ResourceRelation(resource.Relation),
+		ElementMeta: ConvertFromV1ElementMeta(resource.ElementMeta),
+		Type:        resource.Type,
+		Relation:    ResourceRelation(resource.Relation),
 		ConstructorAttributes: ConstructorAttributes{
 			CopyPolicy: CopyPolicy(resource.CopyPolicy),
 		},
@@ -318,13 +313,8 @@ func ConvertToRuntimeConstructorResource(resource v1.Resource) Resource {
 // for use in a ComponentConstructor.
 func ConvertToRuntimeConstructorSource(source v1.Source) Source {
 	target := Source{
-		ElementMeta: ElementMeta{
-			ObjectMeta: ObjectMeta{
-				Name:    source.Name,
-				Version: source.Version,
-			},
-		},
-		Type: source.Type,
+		ElementMeta: ConvertFromV1ElementMeta(source.ElementMeta),
+		Type:        source.Type,
 		ConstructorAttributes: ConstructorAttributes{
 			CopyPolicy: CopyPolicy(source.CopyPolicy),
 		},
@@ -343,13 +333,8 @@ func ConvertToRuntimeConstructorSource(source v1.Source) Source {
 // for use in a ComponentConstructor.
 func ConvertToRuntimeConstructorReference(reference v1.Reference) Reference {
 	return Reference{
-		ElementMeta: ElementMeta{
-			ObjectMeta: ObjectMeta{
-				Name:    reference.Name,
-				Version: reference.Version,
-			},
-		},
-		Component: reference.Component,
+		ElementMeta: ConvertFromV1ElementMeta(reference.ElementMeta),
+		Component:   reference.Component,
 	}
 }
 

--- a/bindings/go/constructor/runtime/convert_v1_test.go
+++ b/bindings/go/constructor/runtime/convert_v1_test.go
@@ -406,6 +406,9 @@ func TestConvertToRuntimeConstructor(t *testing.T) {
 										Name:    "test-resource",
 										Version: "1.0.0",
 									},
+									ExtraIdentity: rt.Identity{
+										"namespace": "test-namespace",
+									},
 								},
 								Type:     "blob",
 								Relation: v1.LocalRelation,
@@ -417,6 +420,9 @@ func TestConvertToRuntimeConstructor(t *testing.T) {
 									ObjectMeta: v1.ObjectMeta{
 										Name:    "test-source",
 										Version: "1.0.0",
+									},
+									ExtraIdentity: rt.Identity{
+										"namespace": "test-namespace",
 									},
 								},
 								Type: "git",
@@ -444,6 +450,9 @@ func TestConvertToRuntimeConstructor(t *testing.T) {
 										Name:    "test-resource",
 										Version: "1.0.0",
 									},
+									ExtraIdentity: rt.Identity{
+										"namespace": "test-namespace",
+									},
 								},
 								Type:     "blob",
 								Relation: LocalRelation,
@@ -455,6 +464,9 @@ func TestConvertToRuntimeConstructor(t *testing.T) {
 									ObjectMeta: ObjectMeta{
 										Name:    "test-source",
 										Version: "1.0.0",
+									},
+									ExtraIdentity: rt.Identity{
+										"namespace": "test-namespace",
 									},
 								},
 								Type: "git",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

The Constructor V1 conversion used the wrong methods for element meta conversion, this has now been fixed so that extra identity attributes are not ignored.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
