### PR TITLE
fix(oci): adjust oci to be able to deal ocm v1 oci manifests of ocm components

### DIFF
--- a/bindings/go/oci/internal/fetch/fetch.go
+++ b/bindings/go/oci/internal/fetch/fetch.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"ocm.software/open-component-model/bindings/go/runtime"
 	"oras.land/oras-go/v2"
 
 	"ocm.software/open-component-model/bindings/go/blob"
@@ -37,7 +38,11 @@ type LocalBlob interface {
 //   - A LocalBlob representing the matching layer
 //   - An error if the layer cannot be found or fetched
 func SingleLayerLocalBlobFromManifestByIdentity(ctx context.Context, store oras.ReadOnlyTarget, manifest *ociImageSpecV1.Manifest, identity map[string]string, artifactKind annotations.ArtifactKind) (LocalBlob, error) {
-	layer, err := annotations.FilterFirstMatchingArtifact(manifest.Layers, identity, artifactKind)
+	// The runtime.IdentitySubset matcher is required to match with annotations
+	// created by the old ocm cli where the version was only included in the
+	// identity if the identity was not unique without the version.
+	identityMatcher := runtime.IdentityMatchingChainFn(runtime.IdentitySubset)
+	layer, err := annotations.FilterFirstMatchingArtifact(manifest.Layers, identity, artifactKind, identityMatcher)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find matching layer: %w", err)
 	}

--- a/bindings/go/oci/internal/fetch/fetch.go
+++ b/bindings/go/oci/internal/fetch/fetch.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 
 	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"ocm.software/open-component-model/bindings/go/runtime"
 	"oras.land/oras-go/v2"
 
 	"ocm.software/open-component-model/bindings/go/blob"
 	ociblob "ocm.software/open-component-model/bindings/go/oci/blob"
 	"ocm.software/open-component-model/bindings/go/oci/spec/annotations"
+	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
 // LocalBlob represents a content-addressable piece of data stored in an OCI repository.

--- a/bindings/go/oci/repository_test.go
+++ b/bindings/go/oci/repository_test.go
@@ -1043,7 +1043,9 @@ func setupLegacyComponentVersion(t *testing.T, store *ocictf.Store, ctx context.
 		Digest:    digest.FromBytes(content),
 		Size:      int64(len(content)),
 	}
-	r.NoError(identity.Adopt(&layerDesc, resource))
+	res := resource.DeepCopy()
+	res.Version = ""
+	r.NoError(identity.Adopt(&layerDesc, res))
 
 	// Push the component version as a layer
 	r.NoError(repoStore.Push(ctx, layerDesc, bytes.NewReader(content)))


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
In ocm v1, the version - even if given - is omitted from the identity if the identity is already unique without the version.
In ocm v2, the version is always part of the identity.

Within oci, the identity of resources and sources is written as an layer annotation. ocm v2 leverages this annotation to filter for the correct layer(s) of a resource. Due to above behavior, in case the version is given but is not required for the identity to be unique, the identities were not **equal** and thus, the layer were not found.

To fix this, this PR exchanges the **equality** matcher with a **subset** matcher. Since `(identity) is subset of (identity + version)`, the layers can now be found. 

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
