### PR TITLE
feat(repositories): switch from error type to error instance for easier error checks

### DIFF
--- a/bindings/go/repositories/componentrepository/fallback/v1/repository.go
+++ b/bindings/go/repositories/componentrepository/fallback/v1/repository.go
@@ -132,7 +132,7 @@ func (f *FallbackRepository) GetComponentVersion(ctx context.Context, component,
 			return nil, fmt.Errorf("getting repository for component %s failed: %w", component, err)
 		}
 		desc, err := repo.GetComponentVersion(ctx, component, version)
-		if errors.As(err, new(*componentrepository.NotFoundError)) {
+		if errors.Is(err, componentrepository.ErrNotFound) {
 			slog.DebugContext(ctx, "component version not found in repository", "realm", componentrepository.Realm, "repository", repo, "component", component, "version", version)
 			continue // try the next repository
 		}
@@ -228,7 +228,7 @@ func (f *FallbackRepository) GetLocalResource(ctx context.Context, component, ve
 			return nil, nil, fmt.Errorf("getting repository for component %s failed: %w", component, err)
 		}
 		data, res, err := repo.GetLocalResource(ctx, component, version, identity)
-		if errors.As(err, new(*componentrepository.NotFoundError)) {
+		if errors.Is(err, componentrepository.ErrNotFound) {
 			slog.DebugContext(ctx, "local resource not found in repository", "realm", componentrepository.Realm, "repository", repo, "component", component, "version", version, "resource identity", identity)
 			continue // try the next repository
 		}
@@ -273,7 +273,7 @@ func (f *FallbackRepository) GetLocalSource(ctx context.Context, component, vers
 			return nil, nil, fmt.Errorf("getting repository for component %s failed: %w", component, err)
 		}
 		data, source, err := repo.GetLocalSource(ctx, component, version, identity)
-		if errors.As(err, new(*componentrepository.NotFoundError)) {
+		if errors.Is(err, componentrepository.ErrNotFound) {
 			slog.DebugContext(ctx, "local source not found in repository", "realm", componentrepository.Realm, "repository", repo, "component", component, "version", version, "resource identity", identity)
 			continue // try the next repository
 		}

--- a/bindings/go/repositories/componentrepository/interface.go
+++ b/bindings/go/repositories/componentrepository/interface.go
@@ -2,6 +2,7 @@ package componentrepository
 
 import (
 	"context"
+	"errors"
 
 	"ocm.software/open-component-model/bindings/go/blob"
 	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
@@ -11,6 +12,12 @@ import (
 const (
 	Realm = "componentrepository"
 )
+
+// ErrNotFound is an error type that indicates a requested component version
+// was not found. NotFoundError is independent of the underlying repository implementation.
+// It is supposed to be joined with the original technology-specific error to provide a
+// technology-agnostic API to check for not found errors.
+var ErrNotFound = errors.New("component version not found")
 
 // ComponentVersionRepositoryProvider defines the contract for providers that can retrieve
 // and manage component version repositories. It supports different types of repository
@@ -92,28 +99,4 @@ type LocalSourceRepository interface {
 type CredentialProvider interface {
 	// Resolve attempts to resolve credentials for the given identity.
 	Resolve(ctx context.Context, identity runtime.Identity) (map[string]string, error)
-}
-
-// NotFoundError is an error type that indicates a requested component version
-// was not found. NotFoundError is independent of the underlying repository implementation.
-// It is supposed to wrap the original technology-specific error and to provide a
-// technology-agnostic API to check for not found errors.
-type NotFoundError struct {
-	msg string
-	err error
-}
-
-func (e *NotFoundError) Error() string {
-	return e.msg
-}
-
-func (e *NotFoundError) Unwrap() error {
-	return e.err
-}
-
-func NewNotFoundError(msg string, err error) *NotFoundError {
-	return &NotFoundError{
-		msg: msg,
-		err: err,
-	}
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Instead of defining an error type, we decided, we'd rather join the errors and check for the error using `errors.Is`.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
