### PR TITLE
fix: set the temp folder flag on change

### DIFF
--- a/cli/cmd/setup_filesystem_config.go
+++ b/cli/cmd/setup_filesystem_config.go
@@ -14,9 +14,15 @@ import (
 
 // setupFilesystemConfig sets up file system configuration entity.
 func setupFilesystemConfig(cmd *cobra.Command) {
-	value, err := cmd.PersistentFlags().GetString(tempFolderFlag)
-	if err != nil {
-		slog.DebugContext(cmd.Context(), "could not read temp folder flag value", slog.String("error", err.Error()))
+	var (
+		value string
+		err   error
+	)
+	if flag := cmd.Flags().Lookup(tempFolderFlag); flag != nil && flag.Changed {
+		value, err = cmd.Flags().GetString(tempFolderFlag)
+		if err != nil {
+			slog.DebugContext(cmd.Context(), "could not read temp folder flag value", slog.String("error", err.Error()))
+		}
 	}
 
 	ocmCtx := ocmctx.FromContext(cmd.Context())

--- a/cli/cmd/setup_test.go
+++ b/cli/cmd/setup_test.go
@@ -30,7 +30,7 @@ func createConfigWithFilesystemConfig(tempFolder string) *v1.Config {
 			}
 		]
 	}`
-	
+
 	config := &v1.Config{}
 	if err := json.Unmarshal([]byte(configJSON), config); err != nil {
 		panic(err)
@@ -91,9 +91,9 @@ func TestSetupFilesystemConfig(t *testing.T) {
 			cmd := &cobra.Command{
 				Use: "test",
 			}
-			cmd.PersistentFlags().String(tempFolderFlag, "", "test flag")
+			cmd.Flags().String(tempFolderFlag, "", "test flag")
 			if tt.cliFlag != "" {
-				err := cmd.PersistentFlags().Set(tempFolderFlag, tt.cliFlag)
+				err := cmd.Flags().Set(tempFolderFlag, tt.cliFlag)
 				r.NoError(err, "failed to set CLI flag")
 			}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

The flag wasn't taken correctly and it was always outputting an error.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
