### PR TITLE
chore(ci): make CLI CTF build faster by caching the CLI go dependencies

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -11,12 +11,13 @@ jobs:
     name: CTF
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Go (required for CLI build)
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
-          go-version: '1.24.x'
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+          go-version-file: cli/go.mod
+          cache-dependency-path: cli/go.sum
       - name: Install Task
         uses: arduino/setup-task@v2
         with:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

this makes it so that the CTF build now uses cached values from the CLI go.mod so that it becomes faster and we dont have to maintain a separate go.mod. It does this by checking out the CLI first

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
