### PR TITLE
fix(ctf): make sure that index is truncated

### DIFF
--- a/bindings/go/ctf/filesystem_ctf.go
+++ b/bindings/go/ctf/filesystem_ctf.go
@@ -147,7 +147,10 @@ func (c *FileSystemCTF) writeFile(name string, raw io.Reader, size int64) (err e
 	}
 
 	var file fs.File
-	if file, err = c.ofFS.OpenFile(name, os.O_CREATE|os.O_WRONLY, 0o644); err != nil {
+	// If the file does not exist, we create it.
+	// If it exists, we truncate it to make sure that size is correct
+	// and we can write the new data to it.
+	if file, err = c.ofFS.OpenFile(name, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644); err != nil {
 		return fmt.Errorf("unable to open artifact index: %w", err)
 	}
 	defer func() {

--- a/bindings/go/ctf/filesystem_ctf_test.go
+++ b/bindings/go/ctf/filesystem_ctf_test.go
@@ -232,6 +232,31 @@ func Test_FileSystemCTF_IndexOperations(t *testing.T) {
 	r.Equal("test-repo", artifact.Repository)
 	r.Equal("latest", artifact.Tag)
 	r.Equal(digest, artifact.Digest)
+
+	idx.AddArtifact(v1.ArtifactMetadata{
+		Repository: "test-repo2",
+		Tag:        "latest",
+		Digest:     digest,
+		MediaType:  "application/json",
+	})
+	err = fs.SetIndex(ctx, idx)
+	r.NoError(err)
+
+	// Verify index was saved correctly
+	savedIdx, err = fs.GetIndex(ctx)
+	r.NoError(err)
+	r.Len(savedIdx.GetArtifacts(), 2)
+	artifact = savedIdx.GetArtifacts()[1]
+	r.Equal("test-repo2", artifact.Repository)
+	r.Equal("latest", artifact.Tag)
+	r.Equal(digest, artifact.Digest)
+
+	// make sure smaller index is saved correctly
+	r.NoError(fs.SetIndex(ctx, v1.NewIndex()))
+	// Verify index was saved correctly
+	savedIdx, err = fs.GetIndex(ctx)
+	r.NoError(err)
+	r.Len(savedIdx.GetArtifacts(), 0)
 }
 
 func Test_FileSystemCTF_FileSystemOperations(t *testing.T) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

previously the ctf file writing was not truncated which led to cases where files that were written had trailing data which was invalid

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
