### PR TITLE
fix(blobtransformer-plugin): introduce named return to catch deferred error

### DIFF
--- a/bindings/go/plugin/manager/registries/blobtransformer/converter.go
+++ b/bindings/go/plugin/manager/registries/blobtransformer/converter.go
@@ -19,7 +19,7 @@ type converter struct {
 	scheme         *runtime.Scheme
 }
 
-func (c *converter) TransformBlob(ctx context.Context, blob blob.ReadOnlyBlob, spec runtime.Typed, credentials map[string]string) (blob.ReadOnlyBlob, error) {
+func (c *converter) TransformBlob(ctx context.Context, blob blob.ReadOnlyBlob, spec runtime.Typed, credentials map[string]string) (_ blob.ReadOnlyBlob, err error) {
 	tmp, err := os.CreateTemp("", "blob")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp file: %w", err)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Currently, the joined error would be ignored.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
