### PR TITLE
fix: make sure we do not ignore defer without a named return

### DIFF
--- a/bindings/go/blob/filesystem/file.go
+++ b/bindings/go/blob/filesystem/file.go
@@ -30,7 +30,7 @@ var ioBufPool = sync.Pool{
 // If the file does not exist, it will be created (os.O_CREATE).
 // The function also handles named pipes by setting the appropriate file mode (os.ModeNamedPipe).
 // It uses a buffered I/O operation to improve performance, leveraing the internal ioBufPool.
-func CopyBlobToOSPath(blob blob.ReadOnlyBlob, path string) error {
+func CopyBlobToOSPath(blob blob.ReadOnlyBlob, path string) (err error) {
 	data, err := blob.ReadCloser()
 	if err != nil {
 		return fmt.Errorf("failed to get resource data: %w", err)

--- a/bindings/go/oci/internal/pack/pack.go
+++ b/bindings/go/oci/internal/pack/pack.go
@@ -172,7 +172,7 @@ func NewBlobOCILayer(b *ociblob.ArtifactBlob, opts ResourceBlobOCILayerOptions) 
 // Blob handles the actual transfer of blob data to the OCI storage.
 // It reads the blob content and pushes it to the storage using the provided descriptor.
 // The function ensures proper cleanup of resources by closing the blob reader after the transfer.
-func Blob(ctx context.Context, storage content.Pusher, b blob.ReadOnlyBlob, desc ociImageSpecV1.Descriptor) error {
+func Blob(ctx context.Context, storage content.Pusher, b blob.ReadOnlyBlob, desc ociImageSpecV1.Descriptor) (err error) {
 	layerData, err := b.ReadCloser()
 	if err != nil {
 		return fmt.Errorf("failed to get blob reader: %w", err)

--- a/bindings/go/oci/repository.go
+++ b/bindings/go/oci/repository.go
@@ -540,7 +540,7 @@ func (repo *Repository) UploadSource(ctx context.Context, src *descriptor.Source
 	return src, nil
 }
 
-func (repo *Repository) uploadOCIImage(ctx context.Context, newAccess runtime.Typed, b blob.ReadOnlyBlob) (ociImageSpecV1.Descriptor, *accessv1.OCIImage, error) {
+func (repo *Repository) uploadOCIImage(ctx context.Context, newAccess runtime.Typed, b blob.ReadOnlyBlob) (_ ociImageSpecV1.Descriptor, _ *accessv1.OCIImage, err error) {
 	var access accessv1.OCIImage
 	if err := repo.scheme.Convert(newAccess, &access); err != nil {
 		return ociImageSpecV1.Descriptor{}, nil, fmt.Errorf("error converting resource target to OCI image: %w", err)

--- a/bindings/go/plugin/manager/registries/blobtransformer/converter.go
+++ b/bindings/go/plugin/manager/registries/blobtransformer/converter.go
@@ -19,7 +19,7 @@ type converter struct {
 	scheme         *runtime.Scheme
 }
 
-func (c *converter) TransformBlob(ctx context.Context, blob blob.ReadOnlyBlob, spec runtime.Typed, credentials map[string]string) (blob.ReadOnlyBlob, error) {
+func (c *converter) TransformBlob(ctx context.Context, blob blob.ReadOnlyBlob, spec runtime.Typed, credentials map[string]string) (_ blob.ReadOnlyBlob, err error) {
 	tmp, err := os.CreateTemp("", "blob")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp file: %w", err)

--- a/cli/cmd/configuration/ocm_config.go
+++ b/cli/cmd/configuration/ocm_config.go
@@ -97,7 +97,7 @@ func GetOCMConfig(additional ...string) (*v1.Config, error) {
 // Returns:
 //   - *v1.Config: The decoded configuration struct.
 //   - error: An error if the file cannot be opened or decoded.
-func GetConfigFromPath(path string) (*v1.Config, error) {
+func GetConfigFromPath(path string) (_ *v1.Config, err error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, err

--- a/tools.Taskfile.yml
+++ b/tools.Taskfile.yml
@@ -31,7 +31,7 @@ tasks:
 
   golangci-lint/run:
     desc: "Run golangci-lint on all go modules"
-    deps: [golangci-lint/install]
+    deps: [golangci-lint/install, deferrlint/install]
     cmds:
       - task: golangci-lint/run-concurrent
     aliases:
@@ -48,6 +48,14 @@ tasks:
       - task: 'golangci-lint/module'
         vars:
           ITEM: 'cli'
+      - for: { var: GO_MODULES }
+        task: 'deferrlint/module'
+        vars:
+          ITEM: '{{ .ITEM }}'
+      - task: 'deferrlint/module'
+        vars:
+          ITEM: 'cli'
+
 
   golangci-lint/module:
     desc: "Run golangci-lint on a single go module specified by ITEM"
@@ -59,8 +67,21 @@ tasks:
           --config={{ .ROOT_DIR }}/.github/config/golangci.yml \
           --path-prefix {{.ITEM}} \
           {{ .CLI_ARGS }} ./...   
-  
-  
+
+  deferrlint/module:
+    desc: "Run deferrlint on a single go module specified by ITEM"
+    internal: true
+    cmd: |
+      cd {{.ITEM}} && {{ .ROOT_DIR }}/tmp/bin/deferrlint ./...
+
+  deferrlint/install:
+    desc: "Install deferrlint at latest into tmp ({{ .ROOT_DIR }}/tmp/bin) if not already present"
+    status:
+      - '{{ .ROOT_DIR }}/tmp/bin/deferrlint'
+    env:
+      GOBIN: '{{ .ROOT_DIR }}/tmp/bin'
+    cmds:
+      - go install github.com/jakobmoellerdev/deferrlint@v0.0.0-20250723114254-0e4b18bb60fe
 
   golangci-lint/install:
     desc: "Install golangci-lint at {{ .GOLANGCI_LINT_TARGET_VERSION }} into tmp ({{ .ROOT_DIR }}/tmp/bin) if not already present"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

This enables https://github.com/jakobmoellerdev/deferrlint which is a result of @fabianburth investigation into why we ignore some deferred errors. Eventually we want to contribute this to golangci-lint, at which point we can remove the explicit task for it

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
fix https://github.com/open-component-model/ocm-project/issues/560