### PR TITLE
feat: add `dir` input to cli

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/cli
 
-go 1.24.2
+go 1.24.3
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
@@ -17,6 +17,7 @@ require (
 	ocm.software/open-component-model/bindings/go/ctf v0.2.0
 	ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20250718123610-c4fc9b2af637
 	ocm.software/open-component-model/bindings/go/descriptor/v2 v2.0.1-alpha3
+	ocm.software/open-component-model/bindings/go/input/dir v0.0.0-20250722071949-33d369286538
 	ocm.software/open-component-model/bindings/go/input/file v0.0.0-20250718123610-c4fc9b2af637
 	ocm.software/open-component-model/bindings/go/input/utf8 v0.0.0-20250718123610-c4fc9b2af637
 	ocm.software/open-component-model/bindings/go/oci v0.0.4

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -98,6 +98,8 @@ ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20250718
 ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20250718123610-c4fc9b2af637/go.mod h1:oTBIhNWONtnd1EJaqU50HftlVOvI6kBBXuLPEU5GQEc=
 ocm.software/open-component-model/bindings/go/descriptor/v2 v2.0.1-alpha3 h1:daGC2XnJEJkukGdhvKxobUH+vF5TKYPlVQ6nl5ASdFM=
 ocm.software/open-component-model/bindings/go/descriptor/v2 v2.0.1-alpha3/go.mod h1:nnLzPfpD2zy9YUgIuQxA3vCmUUKFQqSCl6jFAQXVE8M=
+ocm.software/open-component-model/bindings/go/input/dir v0.0.0-20250722071949-33d369286538 h1:y/+0kJLlJeWW/kFqAZ0qNMRjRe3pj45jN7hfBrwByy4=
+ocm.software/open-component-model/bindings/go/input/dir v0.0.0-20250722071949-33d369286538/go.mod h1:zAR++bks2IZgxPJMh6eHRWVxBlAWpYdMwj5UbCwAV2Q=
 ocm.software/open-component-model/bindings/go/input/file v0.0.0-20250718123610-c4fc9b2af637 h1:ClUCvZGlS3ByBAksQ+nEbo8PO5ORwfOAa4jNZYFkG/0=
 ocm.software/open-component-model/bindings/go/input/file v0.0.0-20250718123610-c4fc9b2af637/go.mod h1:W016RMV6w5UCYuUCMxThIOUxoXBNWJW2pxaMv/R/G14=
 ocm.software/open-component-model/bindings/go/input/utf8 v0.0.0-20250718123610-c4fc9b2af637 h1:RJML33SpRj2ImLVe8JCCpIfRFY3dCOlVIGyejeW+qcE=

--- a/cli/internal/plugin/builtin/builtin.go
+++ b/cli/internal/plugin/builtin/builtin.go
@@ -7,6 +7,7 @@ import (
 	"ocm.software/open-component-model/bindings/go/plugin/manager"
 	ocicredentialplugin "ocm.software/open-component-model/cli/internal/plugin/builtin/credentials/oci"
 	ctfplugin "ocm.software/open-component-model/cli/internal/plugin/builtin/ctf"
+	"ocm.software/open-component-model/cli/internal/plugin/builtin/input/dir"
 	"ocm.software/open-component-model/cli/internal/plugin/builtin/input/file"
 	"ocm.software/open-component-model/cli/internal/plugin/builtin/input/utf8"
 	ociplugin "ocm.software/open-component-model/cli/internal/plugin/builtin/oci"
@@ -35,6 +36,9 @@ func Register(manager *manager.PluginManager, filesystemConfig *v1alpha1.Config)
 	}
 	if err := utf8.Register(manager.InputRegistry); err != nil {
 		return fmt.Errorf("could not register utf8 input plugin: %w", err)
+	}
+	if err := dir.Register(manager.InputRegistry); err != nil {
+		return fmt.Errorf("could not register dir input plugin: %w", err)
 	}
 
 	return nil

--- a/cli/internal/plugin/builtin/input/dir/method.go
+++ b/cli/internal/plugin/builtin/input/dir/method.go
@@ -1,0 +1,28 @@
+package dir
+
+import (
+	"fmt"
+
+	"ocm.software/open-component-model/bindings/go/input/dir"
+	dirv1 "ocm.software/open-component-model/bindings/go/input/dir/spec/v1"
+	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/input"
+)
+
+func Register(inputRegistry *input.RepositoryRegistry) error {
+	if err := RegisterDirInputV1(inputRegistry); err != nil {
+		return err
+	}
+	return nil
+}
+
+func RegisterDirInputV1(inputRegistry *input.RepositoryRegistry) error {
+	method := &dir.InputMethod{}
+	spec := &dirv1.Dir{}
+	if err := input.RegisterInternalResourceInputPlugin(dir.Scheme, inputRegistry, method, spec); err != nil {
+		return fmt.Errorf("could not register dir resource input method: %w", err)
+	}
+	if err := input.RegisterInternalSourcePlugin(dir.Scheme, inputRegistry, method, spec); err != nil {
+		return fmt.Errorf("could not register dir source input method: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

This PR adds the `dir` input method to the CLI. I.e. when merged, it will be possible to do `ocm add cv` command with `--constructor` flag pointing to a `component-constructor.yaml`, which has a resource with an `input` of type `dir`.

Supported scope:
* Absolute paths or paths relative to the working directory in the `path` filed
* Uncompressed input (`compress` field omitted or set to false)

Out of scope:
* Paths relative to component constructor (open-component-model/ocm-project#565)
* `compress: true` (open-component-model/ocm-project#566)

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
