### PR TITLE
feat: ocm get resources with tree view

### DIFF
--- a/cli/cmd/get/cmd.go
+++ b/cli/cmd/get/cmd.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	componentversion "ocm.software/open-component-model/cli/cmd/get/component-version"
+	"ocm.software/open-component-model/cli/cmd/get/resources"
 )
 
 // New represents any command that is related to retrieving ( "get"ting ) objects
@@ -15,6 +16,9 @@ func New() *cobra.Command {
 			return cmd.Help()
 		},
 	}
-	cmd.AddCommand(componentversion.New())
+	cmd.AddCommand(
+		componentversion.New(),
+		resources.New(),
+	)
 	return cmd
 }

--- a/cli/cmd/get/resources/cmd.go
+++ b/cli/cmd/get/resources/cmd.go
@@ -1,0 +1,88 @@
+package resources
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	ocmctx "ocm.software/open-component-model/cli/internal/context"
+	"ocm.software/open-component-model/cli/internal/flags/enum"
+	"ocm.software/open-component-model/cli/internal/reference/compref"
+	"ocm.software/open-component-model/cli/internal/repository/ocm"
+)
+
+const (
+	FlagOutput = "output"
+)
+
+func New() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "resources {reference}",
+		Aliases: []string{"resource", "r", "res"},
+		Short:   "Get resource description(s) from an OCM component version",
+		Args:    cobra.MatchAll(cobra.ExactArgs(1), ComponentReferenceAsFirstPositional),
+		Long:    fmt.Sprintf(`Get resource description(s) from an OCM component version.`),
+		Example: strings.TrimSpace(`
+Getting a single component version:
+
+get resources ghcr.io/open-component-model/ocm//ocm.software/ocmcli:0.23.0
+`),
+		RunE:              GetResources,
+		DisableAutoGenTag: true,
+	}
+
+	enum.VarP(cmd.Flags(), FlagOutput, "o", []string{"tree", "treewide"}, "output format of the resource descriptions")
+
+	return cmd
+}
+
+func ComponentReferenceAsFirstPositional(_ *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("missing component reference as first positional argument")
+	}
+	if _, err := compref.Parse(args[0]); err != nil {
+		return fmt.Errorf("parsing component reference from first position argument %q failed: %w", args[0], err)
+	}
+	return nil
+}
+
+func GetResources(cmd *cobra.Command, args []string) error {
+	pluginManager := ocmctx.FromContext(cmd.Context()).PluginManager()
+	if pluginManager == nil {
+		return fmt.Errorf("could not retrieve plugin manager from context")
+	}
+
+	credentialGraph := ocmctx.FromContext(cmd.Context()).CredentialGraph()
+	if credentialGraph == nil {
+		return fmt.Errorf("could not retrieve credential graph from context")
+	}
+
+	output, err := enum.Get(cmd.Flags(), FlagOutput)
+	if err != nil {
+		return fmt.Errorf("getting output flag failed: %w", err)
+	}
+
+	reference := args[0]
+	repo, err := ocm.NewFromRef(cmd.Context(), pluginManager, credentialGraph, reference)
+	if err != nil {
+		return fmt.Errorf("could not initialize ocm repository: %w", err)
+	}
+
+	desc, err := repo.GetComponentVersion(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("getting component reference and versions failed: %w", err)
+	}
+
+	data, size, err := encodeResources(output, desc)
+	if err != nil {
+		return fmt.Errorf("generating output failed: %w", err)
+	}
+
+	if _, err := io.CopyN(cmd.OutOrStdout(), data, size); err != nil {
+		return fmt.Errorf("writing component version descriptor failed: %w", err)
+	}
+
+	return nil
+}

--- a/cli/cmd/get/resources/encode.go
+++ b/cli/cmd/get/resources/encode.go
@@ -1,0 +1,114 @@
+package resources
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/jedib0t/go-pretty/v6/list"
+
+	descruntime "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+)
+
+// Keys order identity attributes are grouped by in the tree output.
+var treeAttributeGroupingOrder = []string{"version", "architecture", "os", "variant"}
+
+func encodeResources(format string, descriptor *descruntime.Descriptor) (io.Reader, int64, error) {
+	switch format {
+	case "tree":
+		return encodeResourcesTree(descriptor, treeOptions{})
+	case "treewide":
+		return encodeResourcesTree(descriptor, treeOptions{ShowDigest: true})
+	default:
+		return nil, 0, fmt.Errorf("unknown format: %s", format)
+	}
+}
+
+type treeOptions struct {
+	ShowDigest bool
+}
+
+func encodeResourcesTree(descriptor *descruntime.Descriptor, opts treeOptions) (io.Reader, int64, error) {
+	var buf bytes.Buffer
+	t := list.NewWriter()
+	t.SetOutputMirror(&buf)
+	t.AppendItem(descriptor.String())
+
+	// Group by <name(version)>
+	nameGroup := map[string][]descruntime.Resource{}
+	for _, resource := range descriptor.Component.Resources {
+		key := resource.Name
+		nameGroup[key] = append(nameGroup[key], resource)
+	}
+
+	t.Indent()
+
+	// Process each name(version) group
+	for name, resources := range nameGroup {
+		t.AppendItem(name)
+		t.Indent()
+		groupByKeys(t, resources, 0, opts) // start grouping at first key
+		t.UnIndent()
+	}
+	t.UnIndent()
+
+	t.SetStyle(list.StyleConnectedRounded)
+	t.Render()
+	return &buf, int64(buf.Len()), nil
+}
+
+func groupByKeys(t list.Writer, resources []descruntime.Resource, depth int, opts treeOptions) {
+	if depth >= len(treeAttributeGroupingOrder) {
+		// leaf level: show resources
+		for _, resource := range resources {
+			t.AppendItem("access: " + resource.Access.GetType().String())
+			t.AppendItem("relation: " + resource.Relation)
+
+			if opts.ShowDigest {
+				t.AppendItem("digest")
+				if dig := resource.Digest; dig != nil {
+					t.Indent()
+					t.AppendItem("value: " + dig.Value)
+					t.AppendItem("normalization: " + dig.NormalisationAlgorithm)
+					t.AppendItem("hash: " + dig.HashAlgorithm)
+					t.UnIndent()
+				}
+			}
+		}
+		return
+	}
+
+	key := treeAttributeGroupingOrder[depth]
+
+	// Group resources by this key
+	group := map[string][]descruntime.Resource{}
+	for _, r := range resources {
+		id := r.ToIdentity()
+		value := id[key]
+		if value == "" {
+			value = "<none>"
+		}
+		group[value] = append(group[value], r)
+	}
+
+	// Sorted group keys
+	var values []string
+	for v := range group {
+		values = append(values, v)
+	}
+	sort.Strings(values)
+
+	// Output each subgroup and recurse deeper
+	for _, v := range values {
+		if v == "<none>" {
+			// Skip extra indent, just continue grouping deeper
+			groupByKeys(t, group[v], depth+1, opts)
+		} else {
+			t.AppendItem(key + ": " + v)
+			t.Indent()
+			groupByKeys(t, group[v], depth+1, opts)
+			t.UnIndent()
+		}
+	}
+}

--- a/docs/reference/cli/ocm_get_resources.md
+++ b/docs/reference/cli/ocm_get_resources.md
@@ -1,24 +1,38 @@
 ---
-title: ocm get
-description: Get anything from OCM.
+title: ocm get resources
+description: Get resource description(s) from an OCM component version.
 suppressTitle: true
 toc: true
 sidebar:
   collapsed: true
 ---
 
-## ocm get
+## ocm get resources
 
-Get anything from OCM
+Get resource description(s) from an OCM component version
+
+### Synopsis
+
+Get resource description(s) from an OCM component version.
 
 ```
-ocm get {component-version|component-versions|cv|cvs} [flags]
+ocm get resources {reference} [flags]
+```
+
+### Examples
+
+```
+Getting a single component version:
+
+get resources ghcr.io/open-component-model/ocm//ocm.software/ocmcli:0.23.0
 ```
 
 ### Options
 
 ```
-  -h, --help   help for get
+  -h, --help          help for resources
+  -o, --output enum   output format of the resource descriptions
+                      (must be one of [tree treewide]) (default tree)
 ```
 
 ### Options inherited from parent commands
@@ -60,7 +74,5 @@ ocm get {component-version|component-versions|cv|cvs} [flags]
 
 ### SEE ALSO
 
-* [ocm](ocm.md)	 - The official Open Component Model (OCM) CLI
-* [ocm get component-version](ocm_get_component-version.md)	 - Get component version(s) from an OCM repository
-* [ocm get resources](ocm_get_resources.md)	 - Get resource description(s) from an OCM component version
+* [ocm get](ocm_get.md)	 - Get anything from OCM
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Implements a get resource command that shows similar trees to ocm v1


```text
ocm get resources ghcr.io/open-component-model/ocm//ocm.software/ocmcli:0.26.0 -otree
── ocm.software/ocmcli:0.26.0 (schema version v2)
   ├─ ocmcli
   │  ╰─ version: 0.26.0
   │     ├─ architecture: amd64
   │     │  ├─ os: darwin
   │     │  │  ├─ access: localBlob
   │     │  │  ╰─ relation: local
   │     │  ├─ os: linux
   │     │  │  ├─ access: localBlob
   │     │  │  ╰─ relation: local
   │     │  ╰─ os: windows
   │     │     ├─ access: localBlob
   │     │     ╰─ relation: local
   │     ╰─ architecture: arm64
   │        ├─ os: darwin
   │        │  ├─ access: localBlob
   │        │  ╰─ relation: local
   │        ╰─ os: linux
   │           ├─ access: localBlob
   │           ╰─ relation: local
   ╰─ ocmcli-image
      ╰─ version: 0.26.0
         ├─ access: ociArtifact
         ╰─ relation: local
```

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
