### PR TITLE
chore: refactor filesystem interface to use os.Root

### DIFF
--- a/bindings/go/blob/filesystem/file_blob.go
+++ b/bindings/go/blob/filesystem/file_blob.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"path/filepath"
 
 	"github.com/opencontainers/go-digest"
 
@@ -28,6 +29,22 @@ var (
 	_ blob.DigestAware = (*Blob)(nil)
 )
 
+// NewFileBlobFromPath creates a new Blob from a path, defaulting to read only access.
+func NewFileBlobFromPath(path string) (*Blob, error) {
+	return NewFileBlobFromPathWithFlag(path, os.O_RDONLY)
+}
+
+func NewFileBlobFromPathWithFlag(path string, flag int) (*Blob, error) {
+	path = filepath.Clean(path)
+	dir, base := filepath.Dir(path), filepath.Base(path)
+	rofs, err := NewFS(dir, flag)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup filesystem in %q while trying to create file blob %q: %w", dir, base, err)
+	}
+	return NewFileBlob(rofs, base), nil
+}
+
+// NewFileBlob creates a new Blob from an underlying fs.FS.
 func NewFileBlob(fs fs.FS, path string) *Blob {
 	return &Blob{
 		path:       path,

--- a/bindings/go/blob/filesystem/file_blob_test.go
+++ b/bindings/go/blob/filesystem/file_blob_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -118,4 +119,48 @@ func TestBlob_FS_Compat(t *testing.T) {
 	_, err = b.WriteCloser()
 	r.Error(err)
 	r.Equal(b.Size(), int64(len(td)))
+}
+
+func TestBlob_FromPath(t *testing.T) {
+	t.Run("base is read only", func(t *testing.T) {
+		td := []byte("bar")
+		r := require.New(t)
+		filePath := filepath.Join(t.TempDir(), "foo")
+		r.NoError(os.WriteFile(filePath, td, 0644))
+
+		b, err := filesystem.NewFileBlobFromPath(filePath)
+		r.NoError(err)
+		reader, err := b.ReadCloser()
+		r.NoError(err)
+		data, err := io.ReadAll(reader)
+		r.NoError(err)
+		r.Equal(td, data)
+		r.NoError(reader.Close())
+
+		_, err = b.WriteCloser()
+		r.Error(err)
+		r.Equal(b.Size(), int64(len(td)))
+	})
+
+	t.Run("if flag is rdwr, it is read/write", func(t *testing.T) {
+		td := []byte("bar")
+		r := require.New(t)
+		filePath := filepath.Join(t.TempDir(), "foo")
+		r.NoError(os.WriteFile(filePath, td, 0644))
+
+		b, err := filesystem.NewFileBlobFromPathWithFlag(filePath, os.O_RDWR)
+		r.NoError(err)
+		reader, err := b.ReadCloser()
+		r.NoError(err)
+		data, err := io.ReadAll(reader)
+		r.NoError(err)
+		r.Equal(td, data)
+		r.NoError(reader.Close())
+
+		writer, err := b.WriteCloser()
+		r.NoError(err)
+		_, err = writer.Write([]byte("test data"))
+		r.NoError(err)
+		r.NoError(writer.Close())
+	})
 }

--- a/bindings/go/blob/go.mod
+++ b/bindings/go/blob/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/blob
 
-go 1.24.1
+go 1.25.0
 
 require (
 	github.com/opencontainers/go-digest v1.0.0


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Thanks to go 1.25, we can now use MkdirAll and RemoveAll in os.Root.

This makes it so that our filesystem now uses os.Root underneath which has path escape protection. Also adds 2 convenience methods to open blobs from os based paths

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Further strengthens our blob reading safety from filesystems
