### PR TITLE
feat(565): update filesystem to support working dir

### DIFF
--- a/bindings/go/configuration/filesystem/v1alpha1/spec/config.go
+++ b/bindings/go/configuration/filesystem/v1alpha1/spec/config.go
@@ -28,9 +28,16 @@ func init() {
 // +ocm:typegen=true
 type Config struct {
 	Type runtime.Type `json:"type"`
+
 	// TempFolder defines places where plugins and other functionalities can put ephemeral files under.
 	// If not defined, os.TempDir is used as a default.
 	TempFolder string `json:"tempFolder,omitempty"`
+
+	// WorkingDirectory defines the working directory for the filesystem operations.
+	// This is typically the directory where the plugin operates, and it can be used
+	// to resolve relative paths for file operations.
+	// If not defined, the current working directory is used as a default for file operations.
+	WorkingDirectory string `json:"workingDirectory,omitempty"`
 }
 
 type Duration time.Duration
@@ -93,6 +100,9 @@ func Merge(configs ...*Config) *Config {
 	for _, config := range configs {
 		if config.TempFolder != merged.TempFolder {
 			merged.TempFolder = config.TempFolder
+		}
+		if config.WorkingDirectory != merged.WorkingDirectory {
+			merged.WorkingDirectory = config.WorkingDirectory
 		}
 	}
 


### PR DESCRIPTION
Cherry picking filesystem changes from https://github.com/open-component-model/open-component-model/pull/540

#### What this PR does / why we need it
Resolve file/dir inputs relative to the constructor file by wiring a filesystem working directory through input methods; default-deny path escapes with an explicit opt-out.

Changes (high level):

- Added WorkingDirectory to FS config

#### Which issue(s) this PR fixes
Fixes [#565](https://github.com/open-component-model/ocm-project/issues/565)
