### PR TITLE
chore: make sure blob transformer keeps implementing interface and ignores credentials

### DIFF
--- a/bindings/go/oci/transformer/extract.go
+++ b/bindings/go/oci/transformer/extract.go
@@ -48,7 +48,7 @@ func New(logger *slog.Logger) *Transformer {
 }
 
 // TransformBlob transforms an OCI Layout blob by extracting its main artifacts.
-func (t *Transformer) TransformBlob(ctx context.Context, input blob.ReadOnlyBlob, config runtime.Typed) (_ blob.ReadOnlyBlob, err error) {
+func (t *Transformer) TransformBlob(ctx context.Context, input blob.ReadOnlyBlob, config runtime.Typed, _ map[string]string) (_ blob.ReadOnlyBlob, err error) {
 	store, err := ocitar.ReadOCILayout(ctx, input)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read OCI layout: %w", err)

--- a/bindings/go/oci/transformer/extract_test.go
+++ b/bindings/go/oci/transformer/extract_test.go
@@ -49,7 +49,7 @@ func TestTransformer_TransformBlob(t *testing.T) {
 			transformer := New(slog.Default())
 			inputBlob := tt.setupBlob(t)
 
-			result, err := transformer.TransformBlob(t.Context(), inputBlob, nil)
+			result, err := transformer.TransformBlob(t.Context(), inputBlob, nil, nil)
 			if tt.expectError {
 				assert.Error(t, err)
 				assert.Nil(t, result)
@@ -98,7 +98,7 @@ func TestTransformerIntegration(t *testing.T) {
 
 	transformer := New(slog.Default())
 	// no config should default to all layers
-	result, err := transformer.TransformBlob(ctx, ociLayoutBlob, nil)
+	result, err := transformer.TransformBlob(ctx, ociLayoutBlob, nil, nil)
 
 	r.NoError(err, "Transformation should succeed")
 	r.NotNil(result, "Result should not be nil")
@@ -213,7 +213,7 @@ func TestTransformerWithRules(t *testing.T) {
 	r.NotNil(ociLayoutBlob)
 
 	transformer := New(slog.Default())
-	result, err := transformer.TransformBlob(ctx, ociLayoutBlob, config)
+	result, err := transformer.TransformBlob(ctx, ociLayoutBlob, config, nil)
 
 	r.NoError(err)
 	r.NotNil(result)
@@ -254,7 +254,7 @@ func TestTransformerWithIndexSelector(t *testing.T) {
 	r.NotNil(ociLayoutBlob)
 
 	transformer := New(slog.Default())
-	result, err := transformer.TransformBlob(ctx, ociLayoutBlob, config)
+	result, err := transformer.TransformBlob(ctx, ociLayoutBlob, config, nil)
 
 	r.NoError(err)
 	r.NotNil(result)
@@ -310,7 +310,7 @@ func TestTransformerWithMatchExpressions(t *testing.T) {
 	r.NotNil(ociLayoutBlob)
 
 	transformer := New(slog.Default())
-	result, err := transformer.TransformBlob(ctx, ociLayoutBlob, config)
+	result, err := transformer.TransformBlob(ctx, ociLayoutBlob, config, nil)
 
 	r.NoError(err)
 	r.NotNil(result)
@@ -351,7 +351,7 @@ func TestTransformerWithRuleWithoutFilename(t *testing.T) {
 	r.NotNil(ociLayoutBlob)
 
 	transformer := New(slog.Default())
-	result, err := transformer.TransformBlob(ctx, ociLayoutBlob, config)
+	result, err := transformer.TransformBlob(ctx, ociLayoutBlob, config, nil)
 
 	r.NoError(err)
 	r.NotNil(result)
@@ -402,7 +402,7 @@ func TestTransformerWithHelmRulesWithoutFilenames(t *testing.T) {
 	r.NotNil(ociLayoutBlob)
 
 	transformer := New(slog.Default())
-	result, err := transformer.TransformBlob(ctx, ociLayoutBlob, config)
+	result, err := transformer.TransformBlob(ctx, ociLayoutBlob, config, nil)
 
 	r.NoError(err)
 	r.NotNil(result)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

the blob transformer interface has changed to include potential credentials for any transformation. however since we do not actually use them in our transformer, we can ignore them. still the interface has to be adjusted

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
part of https://github.com/open-component-model/ocm-project/issues/553