### PR TITLE
chore: make traversal state a string type to allow for easy printing

### DIFF
--- a/bindings/go/dag/sync/traverse.go
+++ b/bindings/go/dag/sync/traverse.go
@@ -14,6 +14,21 @@ import (
 // on each vertex to indicate its traversal state:
 type TraversalState int
 
+func (t TraversalState) String() string {
+	switch t {
+	case StateDiscovering:
+		return "discovering"
+	case StateDiscovered:
+		return "discovered"
+	case StateCompleted:
+		return "completed"
+	case StateError:
+		return "error"
+	default:
+		return fmt.Sprintf("unknown(%d)", t)
+	}
+}
+
 const (
 	AttributeTraversalState = "dag/traversal-state"
 	AttributeOrderIndex     = "dag/order-index"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
iota cannot easily be printed, which is quite annoying for rendering the graph. lets change it while we still can.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Contributes to https://github.com/open-component-model/ocm-project/issues/563
