### PR TITLE
fix: wrap layer data with `io.NopCloser` to prevent premature closing by storage implementation

### DIFF
--- a/bindings/go/oci/internal/pack/pack.go
+++ b/bindings/go/oci/internal/pack/pack.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 
 	"github.com/opencontainers/go-digest"
@@ -191,7 +192,7 @@ func Blob(ctx context.Context, storage content.Pusher, b blob.ReadOnlyBlob, desc
 		err = errors.Join(err, layerData.Close())
 	}()
 
-	if err := storage.Push(ctx, desc, layerData); err != nil {
+	if err := storage.Push(ctx, desc, io.NopCloser(layerData)); err != nil {
 		return fmt.Errorf("failed to push layer: %w", err)
 	}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

the ORAS OCI implementation opinionates push by automatically closing a ReadCloser. since we also close, we would receive a ErrClosed which we want to avoid when working with OCI. That's why this should be wrapped with io.NopCloser

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

part of the helm input binary test did with @Skarlso
