### PR TITLE
fix: manager plugin lifecycle handling

### DIFF
--- a/bindings/go/plugin/manager/manager.go
+++ b/bindings/go/plugin/manager/manager.go
@@ -149,7 +149,14 @@ func (pm *PluginManager) Shutdown(ctx context.Context) error {
 	defer pm.mu.Unlock()
 	var errs error
 
-	errs = errors.Join(errs, pm.ComponentVersionRepositoryRegistry.Shutdown(ctx))
+	errs = errors.Join(errs,
+		pm.ComponentVersionRepositoryRegistry.Shutdown(ctx),
+		pm.CredentialRepositoryRegistry.Shutdown(ctx),
+		pm.InputRegistry.Shutdown(ctx),
+		pm.DigestProcessorRegistry.Shutdown(ctx),
+		pm.ResourcePluginRegistry.Shutdown(ctx),
+		pm.BlobTransformerRegistry.Shutdown(ctx),
+	)
 
 	return errs
 }

--- a/bindings/go/plugin/manager/manager_test.go
+++ b/bindings/go/plugin/manager/manager_test.go
@@ -302,7 +302,7 @@ func TestPluginManagerShutdownWithoutWait(t *testing.T) {
 
 	content, err := io.ReadAll(writer)
 	require.NoError(t, err)
-	require.Contains(t, string(content), "Gracefully shutting down plugin")
+	require.Contains(t, string(content), "gracefully shutting down plugin")
 }
 
 func TestPluginManagerMultiplePluginsForSameType(t *testing.T) {

--- a/bindings/go/plugin/manager/registries/input/registry.go
+++ b/bindings/go/plugin/manager/registries/input/registry.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"sync"
 
+	"golang.org/x/sync/errgroup"
 	"ocm.software/open-component-model/bindings/go/constructor"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/contracts/input/v1"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/plugins"
@@ -200,16 +201,33 @@ type constructedPlugin struct {
 func (r *RepositoryRegistry) Shutdown(ctx context.Context) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	var errs error
+	eg, ctx := errgroup.WithContext(ctx)
 	for _, p := range r.constructedPlugins {
-		// The plugins should handle the Interrupt signal for shutdowns.
-		// TODO(Skarlso): Use context to wait for the plugin to actually shut down.
-		if perr := p.cmd.Process.Signal(os.Interrupt); perr != nil {
-			errs = errors.Join(errs, perr)
-		}
+		eg.Go(func() error {
+			// The plugins should handle the Interrupt signal for shutdowns.
+			if err := p.cmd.Process.Signal(os.Interrupt); err != nil {
+				return fmt.Errorf("failed to send interrupt signal to plugin: %w", errors.Join(err, p.cmd.Process.Kill()))
+			}
+
+			shutdownSig := make(chan error, 1)
+			defer func() {
+				close(shutdownSig)
+			}()
+			go func() {
+				_, err := p.cmd.Process.Wait()
+				shutdownSig <- err
+			}()
+
+			select {
+			case err := <-shutdownSig:
+				return err
+			case <-ctx.Done():
+				return errors.Join(ctx.Err(), p.cmd.Process.Kill())
+			}
+		})
 	}
 
-	return errs
+	return eg.Wait()
 }
 
 func startAndReturnPlugin(ctx context.Context, r *RepositoryRegistry, plugin *types.Plugin) (v1.InputPluginContract, error) {
@@ -224,7 +242,7 @@ func startAndReturnPlugin(ctx context.Context, r *RepositoryRegistry, plugin *ty
 
 	// start log streaming once the plugin is up and running.
 	// use the baseCtx here from the manager here so the streaming isn't stopped when the request is stopped.
-	go plugins.StartLogStreamer(r.ctx, plugin)
+	go plugins.StartLogStreamer(context.TODO(), plugin)
 
 	// think about this better, we have a single json schema, maybe even have different maps for different types + schemas?
 	var jsonSchema []byte

--- a/bindings/go/plugin/manager/registries/input/registry.go
+++ b/bindings/go/plugin/manager/registries/input/registry.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"golang.org/x/sync/errgroup"
+
 	"ocm.software/open-component-model/bindings/go/constructor"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/contracts/input/v1"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/plugins"

--- a/bindings/go/plugin/manager/registries/input/resource_input_converter.go
+++ b/bindings/go/plugin/manager/registries/input/resource_input_converter.go
@@ -7,7 +7,6 @@ import (
 	"ocm.software/open-component-model/bindings/go/constructor"
 	constructorruntime "ocm.software/open-component-model/bindings/go/constructor/runtime"
 	descriptorruntime "ocm.software/open-component-model/bindings/go/descriptor/runtime"
-	v2 "ocm.software/open-component-model/bindings/go/descriptor/v2"
 	v1 "ocm.software/open-component-model/bindings/go/plugin/manager/contracts/input/v1"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/blobs"
 	"ocm.software/open-component-model/bindings/go/runtime"
@@ -54,13 +53,8 @@ func (r *resourceInputPluginConverter) ProcessResource(ctx context.Context, reso
 		return nil, fmt.Errorf("failed to create blob data: %w", err)
 	}
 
-	// Convert v2 resource back to descriptor resource
-	descriptorResources := descriptorruntime.ConvertFromV2Resources([]v2.Resource{*result.Resource})
-	if len(descriptorResources) == 0 {
-		return nil, fmt.Errorf("conversion resulted in empty resource list")
-	}
 	// Convert descriptor resource to constructor runtime resource
-	converted := constructorruntime.ConvertFromDescriptorResource(&descriptorResources[0])
+	converted := constructorruntime.ConvertFromDescriptorResource(descriptorruntime.ConvertFromV2Resource(result.Resource))
 	descResource := constructorruntime.ConvertToDescriptorResource(converted)
 	resourceInputMethodResult := &constructor.ResourceInputMethodResult{
 		ProcessedResource: descResource,

--- a/bindings/go/plugin/manager/registries/plugins/log_streamer.go
+++ b/bindings/go/plugin/manager/registries/plugins/log_streamer.go
@@ -83,9 +83,10 @@ func StartLogStreamer(ctx context.Context, plugin *types.Plugin) {
 			}
 
 			log(ctx, parsed.msg, parsed.args...)
-		case err := <-errChan:
-			slog.ErrorContext(ctx, "streaming logs from plugin failed", "error", err)
-			return
+		case err, ok := <-errChan:
+			if ok {
+				slog.ErrorContext(ctx, "streaming logs from plugin failed", "error", err)
+			}
 		case <-ctx.Done():
 			// context is done, we stop streaming logs
 			slog.DebugContext(ctx, "stopping log streamer, context is done")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

- Add proper signal handling for graceful plugin shutdown.
- Fix context usage for server shutdown timeout.
- Log additional shutdown details and handle server close errors.
- Extend plugin manager's shutdown handling to include:
  - CredentialRepositoryRegistry
  - InputRegistry
  - DigestProcessorRegistry
  - ResourcePluginRegistry
  - BlobTransformerRegistry
- Improve error aggregation during shutdown.
- Use `errgroup` for concurrent plugin shutdown.
- Add proper error handling during shutdown, including `os.Interrupt` and process waiting.
- Use `context.Done()` to handle timeout scenarios, killing process if ctx is killed
- Remove unnecessary intermediate steps during v2 resource conversion.
- Use direct conversion to streamline the process.
- Add check for channel closure when receiving errors to avoid panics.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
part of the helm input binary test did with @Skarlso
part of https://github.com/open-component-model/ocm-project/issues/490
