### PR TITLE
feat(cli): add plugin shutdown timeout flag

### DIFF
--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -18,7 +19,9 @@ import (
 )
 
 const (
-	tempFolderFlag = "temp-folder"
+	tempFolderFlag               = "temp-folder"
+	pluginShutdownTimeoutFlag    = "plugin-shutdown-timeout"
+	pluginShutdownTimeoutDefault = 10 * time.Second
 )
 
 // Execute adds all child commands to the Cmd command and sets flags appropriately.
@@ -47,6 +50,9 @@ func New() *cobra.Command {
 
 	configuration.RegisterConfigFlag(cmd)
 	cmd.PersistentFlags().String(tempFolderFlag, "", `Specify a custom temporary folder path for filesystem operations.`)
+	cmd.PersistentFlags().Duration(pluginShutdownTimeoutFlag, pluginShutdownTimeoutDefault,
+		`Timeout for plugin shutdown. If a plugin does not shut down within this time, it is forcefully killed`)
+
 	log.RegisterLoggingFlags(cmd.PersistentFlags())
 	cmd.AddCommand(generate.New())
 	cmd.AddCommand(get.New())

--- a/cli/docs/reference/ocm.md
+++ b/cli/docs/reference/ocm.md
@@ -24,39 +24,40 @@ ocm [sub-command] [flags]
 ### Options
 
 ```
-      --config string        supply configuration by a given configuration file.
-                             By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
-                             1. The path specified in the OCM_CONFIG_PATH environment variable
-                             2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
-                             - $XDG_CONFIG_HOME/ocm/config
-                             - $XDG_CONFIG_HOME/.ocmconfig
-                             - $HOME/.config/ocm/config
-                             - $HOME/.config/.ocmconfig
-                             - $HOME/.ocm/config
-                             - $HOME/.ocmconfig
-                             3. The current working directory:
-                             - $PWD/ocm/config
-                             - $PWD/.ocmconfig
-                             4. The directory of the current executable:
-                             - $EXE_DIR/ocm/config
-                             - $EXE_DIR/.ocmconfig
-                             Using the option, this configuration file be used instead of the lookup above.
-  -h, --help                 help for ocm
-      --logformat enum       set the log output format that is used to print individual logs
-                                json: Output logs in JSON format, suitable for machine processing
-                                text: Output logs in human-readable text format, suitable for console output
-                             (must be one of [json text]) (default text)
-      --loglevel enum        sets the logging level
-                                debug: Show all logs including detailed debugging information
-                                info:  Show informational messages and above
-                                warn:  Show warnings and errors only (default)
-                                error: Show errors only
-                             (must be one of [debug error info warn]) (default info)
-      --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
-                                stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
-      --temp-folder string   Specify a custom temporary folder path for filesystem operations.
+      --config string                      supply configuration by a given configuration file.
+                                           By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
+                                           1. The path specified in the OCM_CONFIG_PATH environment variable
+                                           2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
+                                           - $XDG_CONFIG_HOME/ocm/config
+                                           - $XDG_CONFIG_HOME/.ocmconfig
+                                           - $HOME/.config/ocm/config
+                                           - $HOME/.config/.ocmconfig
+                                           - $HOME/.ocm/config
+                                           - $HOME/.ocmconfig
+                                           3. The current working directory:
+                                           - $PWD/ocm/config
+                                           - $PWD/.ocmconfig
+                                           4. The directory of the current executable:
+                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocmconfig
+                                           Using the option, this configuration file be used instead of the lookup above.
+  -h, --help                               help for ocm
+      --logformat enum                     set the log output format that is used to print individual logs
+                                              json: Output logs in JSON format, suitable for machine processing
+                                              text: Output logs in human-readable text format, suitable for console output
+                                           (must be one of [json text]) (default text)
+      --loglevel enum                      sets the logging level
+                                              debug: Show all logs including detailed debugging information
+                                              info:  Show informational messages and above
+                                              warn:  Show warnings and errors only (default)
+                                              error: Show errors only
+                                           (must be one of [debug error info warn]) (default info)
+      --logoutput enum                     set the log output destination
+                                              stdout: Write logs to standard output (default)
+                                              stderr: Write logs to standard error, useful for separating logs from normal output
+                                           (must be one of [stderr stdout]) (default stdout)
+      --plugin-shutdown-timeout duration   Timeout for plugin shutdown. If a plugin does not shut down within this time, it is forcefully killed (default 10s)
+      --temp-folder string                 Specify a custom temporary folder path for filesystem operations.
 ```
 
 ### SEE ALSO

--- a/cli/docs/reference/ocm_add.md
+++ b/cli/docs/reference/ocm_add.md
@@ -24,38 +24,39 @@ ocm add {component-version|component-versions|cv|cvs} [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        supply configuration by a given configuration file.
-                             By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
-                             1. The path specified in the OCM_CONFIG_PATH environment variable
-                             2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
-                             - $XDG_CONFIG_HOME/ocm/config
-                             - $XDG_CONFIG_HOME/.ocmconfig
-                             - $HOME/.config/ocm/config
-                             - $HOME/.config/.ocmconfig
-                             - $HOME/.ocm/config
-                             - $HOME/.ocmconfig
-                             3. The current working directory:
-                             - $PWD/ocm/config
-                             - $PWD/.ocmconfig
-                             4. The directory of the current executable:
-                             - $EXE_DIR/ocm/config
-                             - $EXE_DIR/.ocmconfig
-                             Using the option, this configuration file be used instead of the lookup above.
-      --logformat enum       set the log output format that is used to print individual logs
-                                json: Output logs in JSON format, suitable for machine processing
-                                text: Output logs in human-readable text format, suitable for console output
-                             (must be one of [json text]) (default text)
-      --loglevel enum        sets the logging level
-                                debug: Show all logs including detailed debugging information
-                                info:  Show informational messages and above
-                                warn:  Show warnings and errors only (default)
-                                error: Show errors only
-                             (must be one of [debug error info warn]) (default info)
-      --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
-                                stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
-      --temp-folder string   Specify a custom temporary folder path for filesystem operations.
+      --config string                      supply configuration by a given configuration file.
+                                           By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
+                                           1. The path specified in the OCM_CONFIG_PATH environment variable
+                                           2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
+                                           - $XDG_CONFIG_HOME/ocm/config
+                                           - $XDG_CONFIG_HOME/.ocmconfig
+                                           - $HOME/.config/ocm/config
+                                           - $HOME/.config/.ocmconfig
+                                           - $HOME/.ocm/config
+                                           - $HOME/.ocmconfig
+                                           3. The current working directory:
+                                           - $PWD/ocm/config
+                                           - $PWD/.ocmconfig
+                                           4. The directory of the current executable:
+                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocmconfig
+                                           Using the option, this configuration file be used instead of the lookup above.
+      --logformat enum                     set the log output format that is used to print individual logs
+                                              json: Output logs in JSON format, suitable for machine processing
+                                              text: Output logs in human-readable text format, suitable for console output
+                                           (must be one of [json text]) (default text)
+      --loglevel enum                      sets the logging level
+                                              debug: Show all logs including detailed debugging information
+                                              info:  Show informational messages and above
+                                              warn:  Show warnings and errors only (default)
+                                              error: Show errors only
+                                           (must be one of [debug error info warn]) (default info)
+      --logoutput enum                     set the log output destination
+                                              stdout: Write logs to standard output (default)
+                                              stderr: Write logs to standard error, useful for separating logs from normal output
+                                           (must be one of [stderr stdout]) (default stdout)
+      --plugin-shutdown-timeout duration   Timeout for plugin shutdown. If a plugin does not shut down within this time, it is forcefully killed (default 10s)
+      --temp-folder string                 Specify a custom temporary folder path for filesystem operations.
 ```
 
 ### SEE ALSO

--- a/cli/docs/reference/ocm_add_component-version.md
+++ b/cli/docs/reference/ocm_add_component-version.md
@@ -53,38 +53,39 @@ add component-version  --repository ./path/to/transport-archive --constructor ./
 ### Options inherited from parent commands
 
 ```
-      --config string        supply configuration by a given configuration file.
-                             By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
-                             1. The path specified in the OCM_CONFIG_PATH environment variable
-                             2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
-                             - $XDG_CONFIG_HOME/ocm/config
-                             - $XDG_CONFIG_HOME/.ocmconfig
-                             - $HOME/.config/ocm/config
-                             - $HOME/.config/.ocmconfig
-                             - $HOME/.ocm/config
-                             - $HOME/.ocmconfig
-                             3. The current working directory:
-                             - $PWD/ocm/config
-                             - $PWD/.ocmconfig
-                             4. The directory of the current executable:
-                             - $EXE_DIR/ocm/config
-                             - $EXE_DIR/.ocmconfig
-                             Using the option, this configuration file be used instead of the lookup above.
-      --logformat enum       set the log output format that is used to print individual logs
-                                json: Output logs in JSON format, suitable for machine processing
-                                text: Output logs in human-readable text format, suitable for console output
-                             (must be one of [json text]) (default text)
-      --loglevel enum        sets the logging level
-                                debug: Show all logs including detailed debugging information
-                                info:  Show informational messages and above
-                                warn:  Show warnings and errors only (default)
-                                error: Show errors only
-                             (must be one of [debug error info warn]) (default info)
-      --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
-                                stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
-      --temp-folder string   Specify a custom temporary folder path for filesystem operations.
+      --config string                      supply configuration by a given configuration file.
+                                           By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
+                                           1. The path specified in the OCM_CONFIG_PATH environment variable
+                                           2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
+                                           - $XDG_CONFIG_HOME/ocm/config
+                                           - $XDG_CONFIG_HOME/.ocmconfig
+                                           - $HOME/.config/ocm/config
+                                           - $HOME/.config/.ocmconfig
+                                           - $HOME/.ocm/config
+                                           - $HOME/.ocmconfig
+                                           3. The current working directory:
+                                           - $PWD/ocm/config
+                                           - $PWD/.ocmconfig
+                                           4. The directory of the current executable:
+                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocmconfig
+                                           Using the option, this configuration file be used instead of the lookup above.
+      --logformat enum                     set the log output format that is used to print individual logs
+                                              json: Output logs in JSON format, suitable for machine processing
+                                              text: Output logs in human-readable text format, suitable for console output
+                                           (must be one of [json text]) (default text)
+      --loglevel enum                      sets the logging level
+                                              debug: Show all logs including detailed debugging information
+                                              info:  Show informational messages and above
+                                              warn:  Show warnings and errors only (default)
+                                              error: Show errors only
+                                           (must be one of [debug error info warn]) (default info)
+      --logoutput enum                     set the log output destination
+                                              stdout: Write logs to standard output (default)
+                                              stderr: Write logs to standard error, useful for separating logs from normal output
+                                           (must be one of [stderr stdout]) (default stdout)
+      --plugin-shutdown-timeout duration   Timeout for plugin shutdown. If a plugin does not shut down within this time, it is forcefully killed (default 10s)
+      --temp-folder string                 Specify a custom temporary folder path for filesystem operations.
 ```
 
 ### SEE ALSO

--- a/cli/docs/reference/ocm_completion.md
+++ b/cli/docs/reference/ocm_completion.md
@@ -26,38 +26,39 @@ See each sub-command's help for details on how to use the generated script.
 ### Options inherited from parent commands
 
 ```
-      --config string        supply configuration by a given configuration file.
-                             By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
-                             1. The path specified in the OCM_CONFIG_PATH environment variable
-                             2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
-                             - $XDG_CONFIG_HOME/ocm/config
-                             - $XDG_CONFIG_HOME/.ocmconfig
-                             - $HOME/.config/ocm/config
-                             - $HOME/.config/.ocmconfig
-                             - $HOME/.ocm/config
-                             - $HOME/.ocmconfig
-                             3. The current working directory:
-                             - $PWD/ocm/config
-                             - $PWD/.ocmconfig
-                             4. The directory of the current executable:
-                             - $EXE_DIR/ocm/config
-                             - $EXE_DIR/.ocmconfig
-                             Using the option, this configuration file be used instead of the lookup above.
-      --logformat enum       set the log output format that is used to print individual logs
-                                json: Output logs in JSON format, suitable for machine processing
-                                text: Output logs in human-readable text format, suitable for console output
-                             (must be one of [json text]) (default text)
-      --loglevel enum        sets the logging level
-                                debug: Show all logs including detailed debugging information
-                                info:  Show informational messages and above
-                                warn:  Show warnings and errors only (default)
-                                error: Show errors only
-                             (must be one of [debug error info warn]) (default info)
-      --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
-                                stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
-      --temp-folder string   Specify a custom temporary folder path for filesystem operations.
+      --config string                      supply configuration by a given configuration file.
+                                           By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
+                                           1. The path specified in the OCM_CONFIG_PATH environment variable
+                                           2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
+                                           - $XDG_CONFIG_HOME/ocm/config
+                                           - $XDG_CONFIG_HOME/.ocmconfig
+                                           - $HOME/.config/ocm/config
+                                           - $HOME/.config/.ocmconfig
+                                           - $HOME/.ocm/config
+                                           - $HOME/.ocmconfig
+                                           3. The current working directory:
+                                           - $PWD/ocm/config
+                                           - $PWD/.ocmconfig
+                                           4. The directory of the current executable:
+                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocmconfig
+                                           Using the option, this configuration file be used instead of the lookup above.
+      --logformat enum                     set the log output format that is used to print individual logs
+                                              json: Output logs in JSON format, suitable for machine processing
+                                              text: Output logs in human-readable text format, suitable for console output
+                                           (must be one of [json text]) (default text)
+      --loglevel enum                      sets the logging level
+                                              debug: Show all logs including detailed debugging information
+                                              info:  Show informational messages and above
+                                              warn:  Show warnings and errors only (default)
+                                              error: Show errors only
+                                           (must be one of [debug error info warn]) (default info)
+      --logoutput enum                     set the log output destination
+                                              stdout: Write logs to standard output (default)
+                                              stderr: Write logs to standard error, useful for separating logs from normal output
+                                           (must be one of [stderr stdout]) (default stdout)
+      --plugin-shutdown-timeout duration   Timeout for plugin shutdown. If a plugin does not shut down within this time, it is forcefully killed (default 10s)
+      --temp-folder string                 Specify a custom temporary folder path for filesystem operations.
 ```
 
 ### SEE ALSO

--- a/cli/docs/reference/ocm_completion_bash.md
+++ b/cli/docs/reference/ocm_completion_bash.md
@@ -49,38 +49,39 @@ ocm completion bash
 ### Options inherited from parent commands
 
 ```
-      --config string        supply configuration by a given configuration file.
-                             By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
-                             1. The path specified in the OCM_CONFIG_PATH environment variable
-                             2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
-                             - $XDG_CONFIG_HOME/ocm/config
-                             - $XDG_CONFIG_HOME/.ocmconfig
-                             - $HOME/.config/ocm/config
-                             - $HOME/.config/.ocmconfig
-                             - $HOME/.ocm/config
-                             - $HOME/.ocmconfig
-                             3. The current working directory:
-                             - $PWD/ocm/config
-                             - $PWD/.ocmconfig
-                             4. The directory of the current executable:
-                             - $EXE_DIR/ocm/config
-                             - $EXE_DIR/.ocmconfig
-                             Using the option, this configuration file be used instead of the lookup above.
-      --logformat enum       set the log output format that is used to print individual logs
-                                json: Output logs in JSON format, suitable for machine processing
-                                text: Output logs in human-readable text format, suitable for console output
-                             (must be one of [json text]) (default text)
-      --loglevel enum        sets the logging level
-                                debug: Show all logs including detailed debugging information
-                                info:  Show informational messages and above
-                                warn:  Show warnings and errors only (default)
-                                error: Show errors only
-                             (must be one of [debug error info warn]) (default info)
-      --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
-                                stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
-      --temp-folder string   Specify a custom temporary folder path for filesystem operations.
+      --config string                      supply configuration by a given configuration file.
+                                           By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
+                                           1. The path specified in the OCM_CONFIG_PATH environment variable
+                                           2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
+                                           - $XDG_CONFIG_HOME/ocm/config
+                                           - $XDG_CONFIG_HOME/.ocmconfig
+                                           - $HOME/.config/ocm/config
+                                           - $HOME/.config/.ocmconfig
+                                           - $HOME/.ocm/config
+                                           - $HOME/.ocmconfig
+                                           3. The current working directory:
+                                           - $PWD/ocm/config
+                                           - $PWD/.ocmconfig
+                                           4. The directory of the current executable:
+                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocmconfig
+                                           Using the option, this configuration file be used instead of the lookup above.
+      --logformat enum                     set the log output format that is used to print individual logs
+                                              json: Output logs in JSON format, suitable for machine processing
+                                              text: Output logs in human-readable text format, suitable for console output
+                                           (must be one of [json text]) (default text)
+      --loglevel enum                      sets the logging level
+                                              debug: Show all logs including detailed debugging information
+                                              info:  Show informational messages and above
+                                              warn:  Show warnings and errors only (default)
+                                              error: Show errors only
+                                           (must be one of [debug error info warn]) (default info)
+      --logoutput enum                     set the log output destination
+                                              stdout: Write logs to standard output (default)
+                                              stderr: Write logs to standard error, useful for separating logs from normal output
+                                           (must be one of [stderr stdout]) (default stdout)
+      --plugin-shutdown-timeout duration   Timeout for plugin shutdown. If a plugin does not shut down within this time, it is forcefully killed (default 10s)
+      --temp-folder string                 Specify a custom temporary folder path for filesystem operations.
 ```
 
 ### SEE ALSO

--- a/cli/docs/reference/ocm_completion_fish.md
+++ b/cli/docs/reference/ocm_completion_fish.md
@@ -40,38 +40,39 @@ ocm completion fish [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        supply configuration by a given configuration file.
-                             By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
-                             1. The path specified in the OCM_CONFIG_PATH environment variable
-                             2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
-                             - $XDG_CONFIG_HOME/ocm/config
-                             - $XDG_CONFIG_HOME/.ocmconfig
-                             - $HOME/.config/ocm/config
-                             - $HOME/.config/.ocmconfig
-                             - $HOME/.ocm/config
-                             - $HOME/.ocmconfig
-                             3. The current working directory:
-                             - $PWD/ocm/config
-                             - $PWD/.ocmconfig
-                             4. The directory of the current executable:
-                             - $EXE_DIR/ocm/config
-                             - $EXE_DIR/.ocmconfig
-                             Using the option, this configuration file be used instead of the lookup above.
-      --logformat enum       set the log output format that is used to print individual logs
-                                json: Output logs in JSON format, suitable for machine processing
-                                text: Output logs in human-readable text format, suitable for console output
-                             (must be one of [json text]) (default text)
-      --loglevel enum        sets the logging level
-                                debug: Show all logs including detailed debugging information
-                                info:  Show informational messages and above
-                                warn:  Show warnings and errors only (default)
-                                error: Show errors only
-                             (must be one of [debug error info warn]) (default info)
-      --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
-                                stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
-      --temp-folder string   Specify a custom temporary folder path for filesystem operations.
+      --config string                      supply configuration by a given configuration file.
+                                           By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
+                                           1. The path specified in the OCM_CONFIG_PATH environment variable
+                                           2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
+                                           - $XDG_CONFIG_HOME/ocm/config
+                                           - $XDG_CONFIG_HOME/.ocmconfig
+                                           - $HOME/.config/ocm/config
+                                           - $HOME/.config/.ocmconfig
+                                           - $HOME/.ocm/config
+                                           - $HOME/.ocmconfig
+                                           3. The current working directory:
+                                           - $PWD/ocm/config
+                                           - $PWD/.ocmconfig
+                                           4. The directory of the current executable:
+                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocmconfig
+                                           Using the option, this configuration file be used instead of the lookup above.
+      --logformat enum                     set the log output format that is used to print individual logs
+                                              json: Output logs in JSON format, suitable for machine processing
+                                              text: Output logs in human-readable text format, suitable for console output
+                                           (must be one of [json text]) (default text)
+      --loglevel enum                      sets the logging level
+                                              debug: Show all logs including detailed debugging information
+                                              info:  Show informational messages and above
+                                              warn:  Show warnings and errors only (default)
+                                              error: Show errors only
+                                           (must be one of [debug error info warn]) (default info)
+      --logoutput enum                     set the log output destination
+                                              stdout: Write logs to standard output (default)
+                                              stderr: Write logs to standard error, useful for separating logs from normal output
+                                           (must be one of [stderr stdout]) (default stdout)
+      --plugin-shutdown-timeout duration   Timeout for plugin shutdown. If a plugin does not shut down within this time, it is forcefully killed (default 10s)
+      --temp-folder string                 Specify a custom temporary folder path for filesystem operations.
 ```
 
 ### SEE ALSO

--- a/cli/docs/reference/ocm_completion_powershell.md
+++ b/cli/docs/reference/ocm_completion_powershell.md
@@ -37,38 +37,39 @@ ocm completion powershell [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        supply configuration by a given configuration file.
-                             By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
-                             1. The path specified in the OCM_CONFIG_PATH environment variable
-                             2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
-                             - $XDG_CONFIG_HOME/ocm/config
-                             - $XDG_CONFIG_HOME/.ocmconfig
-                             - $HOME/.config/ocm/config
-                             - $HOME/.config/.ocmconfig
-                             - $HOME/.ocm/config
-                             - $HOME/.ocmconfig
-                             3. The current working directory:
-                             - $PWD/ocm/config
-                             - $PWD/.ocmconfig
-                             4. The directory of the current executable:
-                             - $EXE_DIR/ocm/config
-                             - $EXE_DIR/.ocmconfig
-                             Using the option, this configuration file be used instead of the lookup above.
-      --logformat enum       set the log output format that is used to print individual logs
-                                json: Output logs in JSON format, suitable for machine processing
-                                text: Output logs in human-readable text format, suitable for console output
-                             (must be one of [json text]) (default text)
-      --loglevel enum        sets the logging level
-                                debug: Show all logs including detailed debugging information
-                                info:  Show informational messages and above
-                                warn:  Show warnings and errors only (default)
-                                error: Show errors only
-                             (must be one of [debug error info warn]) (default info)
-      --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
-                                stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
-      --temp-folder string   Specify a custom temporary folder path for filesystem operations.
+      --config string                      supply configuration by a given configuration file.
+                                           By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
+                                           1. The path specified in the OCM_CONFIG_PATH environment variable
+                                           2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
+                                           - $XDG_CONFIG_HOME/ocm/config
+                                           - $XDG_CONFIG_HOME/.ocmconfig
+                                           - $HOME/.config/ocm/config
+                                           - $HOME/.config/.ocmconfig
+                                           - $HOME/.ocm/config
+                                           - $HOME/.ocmconfig
+                                           3. The current working directory:
+                                           - $PWD/ocm/config
+                                           - $PWD/.ocmconfig
+                                           4. The directory of the current executable:
+                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocmconfig
+                                           Using the option, this configuration file be used instead of the lookup above.
+      --logformat enum                     set the log output format that is used to print individual logs
+                                              json: Output logs in JSON format, suitable for machine processing
+                                              text: Output logs in human-readable text format, suitable for console output
+                                           (must be one of [json text]) (default text)
+      --loglevel enum                      sets the logging level
+                                              debug: Show all logs including detailed debugging information
+                                              info:  Show informational messages and above
+                                              warn:  Show warnings and errors only (default)
+                                              error: Show errors only
+                                           (must be one of [debug error info warn]) (default info)
+      --logoutput enum                     set the log output destination
+                                              stdout: Write logs to standard output (default)
+                                              stderr: Write logs to standard error, useful for separating logs from normal output
+                                           (must be one of [stderr stdout]) (default stdout)
+      --plugin-shutdown-timeout duration   Timeout for plugin shutdown. If a plugin does not shut down within this time, it is forcefully killed (default 10s)
+      --temp-folder string                 Specify a custom temporary folder path for filesystem operations.
 ```
 
 ### SEE ALSO

--- a/cli/docs/reference/ocm_completion_zsh.md
+++ b/cli/docs/reference/ocm_completion_zsh.md
@@ -51,38 +51,39 @@ ocm completion zsh [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        supply configuration by a given configuration file.
-                             By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
-                             1. The path specified in the OCM_CONFIG_PATH environment variable
-                             2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
-                             - $XDG_CONFIG_HOME/ocm/config
-                             - $XDG_CONFIG_HOME/.ocmconfig
-                             - $HOME/.config/ocm/config
-                             - $HOME/.config/.ocmconfig
-                             - $HOME/.ocm/config
-                             - $HOME/.ocmconfig
-                             3. The current working directory:
-                             - $PWD/ocm/config
-                             - $PWD/.ocmconfig
-                             4. The directory of the current executable:
-                             - $EXE_DIR/ocm/config
-                             - $EXE_DIR/.ocmconfig
-                             Using the option, this configuration file be used instead of the lookup above.
-      --logformat enum       set the log output format that is used to print individual logs
-                                json: Output logs in JSON format, suitable for machine processing
-                                text: Output logs in human-readable text format, suitable for console output
-                             (must be one of [json text]) (default text)
-      --loglevel enum        sets the logging level
-                                debug: Show all logs including detailed debugging information
-                                info:  Show informational messages and above
-                                warn:  Show warnings and errors only (default)
-                                error: Show errors only
-                             (must be one of [debug error info warn]) (default info)
-      --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
-                                stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
-      --temp-folder string   Specify a custom temporary folder path for filesystem operations.
+      --config string                      supply configuration by a given configuration file.
+                                           By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
+                                           1. The path specified in the OCM_CONFIG_PATH environment variable
+                                           2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
+                                           - $XDG_CONFIG_HOME/ocm/config
+                                           - $XDG_CONFIG_HOME/.ocmconfig
+                                           - $HOME/.config/ocm/config
+                                           - $HOME/.config/.ocmconfig
+                                           - $HOME/.ocm/config
+                                           - $HOME/.ocmconfig
+                                           3. The current working directory:
+                                           - $PWD/ocm/config
+                                           - $PWD/.ocmconfig
+                                           4. The directory of the current executable:
+                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocmconfig
+                                           Using the option, this configuration file be used instead of the lookup above.
+      --logformat enum                     set the log output format that is used to print individual logs
+                                              json: Output logs in JSON format, suitable for machine processing
+                                              text: Output logs in human-readable text format, suitable for console output
+                                           (must be one of [json text]) (default text)
+      --loglevel enum                      sets the logging level
+                                              debug: Show all logs including detailed debugging information
+                                              info:  Show informational messages and above
+                                              warn:  Show warnings and errors only (default)
+                                              error: Show errors only
+                                           (must be one of [debug error info warn]) (default info)
+      --logoutput enum                     set the log output destination
+                                              stdout: Write logs to standard output (default)
+                                              stderr: Write logs to standard error, useful for separating logs from normal output
+                                           (must be one of [stderr stdout]) (default stdout)
+      --plugin-shutdown-timeout duration   Timeout for plugin shutdown. If a plugin does not shut down within this time, it is forcefully killed (default 10s)
+      --temp-folder string                 Specify a custom temporary folder path for filesystem operations.
 ```
 
 ### SEE ALSO

--- a/cli/docs/reference/ocm_download.md
+++ b/cli/docs/reference/ocm_download.md
@@ -24,38 +24,39 @@ ocm download {resource|resources|plugin|plugins} [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        supply configuration by a given configuration file.
-                             By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
-                             1. The path specified in the OCM_CONFIG_PATH environment variable
-                             2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
-                             - $XDG_CONFIG_HOME/ocm/config
-                             - $XDG_CONFIG_HOME/.ocmconfig
-                             - $HOME/.config/ocm/config
-                             - $HOME/.config/.ocmconfig
-                             - $HOME/.ocm/config
-                             - $HOME/.ocmconfig
-                             3. The current working directory:
-                             - $PWD/ocm/config
-                             - $PWD/.ocmconfig
-                             4. The directory of the current executable:
-                             - $EXE_DIR/ocm/config
-                             - $EXE_DIR/.ocmconfig
-                             Using the option, this configuration file be used instead of the lookup above.
-      --logformat enum       set the log output format that is used to print individual logs
-                                json: Output logs in JSON format, suitable for machine processing
-                                text: Output logs in human-readable text format, suitable for console output
-                             (must be one of [json text]) (default text)
-      --loglevel enum        sets the logging level
-                                debug: Show all logs including detailed debugging information
-                                info:  Show informational messages and above
-                                warn:  Show warnings and errors only (default)
-                                error: Show errors only
-                             (must be one of [debug error info warn]) (default info)
-      --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
-                                stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
-      --temp-folder string   Specify a custom temporary folder path for filesystem operations.
+      --config string                      supply configuration by a given configuration file.
+                                           By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
+                                           1. The path specified in the OCM_CONFIG_PATH environment variable
+                                           2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
+                                           - $XDG_CONFIG_HOME/ocm/config
+                                           - $XDG_CONFIG_HOME/.ocmconfig
+                                           - $HOME/.config/ocm/config
+                                           - $HOME/.config/.ocmconfig
+                                           - $HOME/.ocm/config
+                                           - $HOME/.ocmconfig
+                                           3. The current working directory:
+                                           - $PWD/ocm/config
+                                           - $PWD/.ocmconfig
+                                           4. The directory of the current executable:
+                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocmconfig
+                                           Using the option, this configuration file be used instead of the lookup above.
+      --logformat enum                     set the log output format that is used to print individual logs
+                                              json: Output logs in JSON format, suitable for machine processing
+                                              text: Output logs in human-readable text format, suitable for console output
+                                           (must be one of [json text]) (default text)
+      --loglevel enum                      sets the logging level
+                                              debug: Show all logs including detailed debugging information
+                                              info:  Show informational messages and above
+                                              warn:  Show warnings and errors only (default)
+                                              error: Show errors only
+                                           (must be one of [debug error info warn]) (default info)
+      --logoutput enum                     set the log output destination
+                                              stdout: Write logs to standard output (default)
+                                              stderr: Write logs to standard error, useful for separating logs from normal output
+                                           (must be one of [stderr stdout]) (default stdout)
+      --plugin-shutdown-timeout duration   Timeout for plugin shutdown. If a plugin does not shut down within this time, it is forcefully killed (default 10s)
+      --temp-folder string                 Specify a custom temporary folder path for filesystem operations.
 ```
 
 ### SEE ALSO

--- a/cli/docs/reference/ocm_download_plugin.md
+++ b/cli/docs/reference/ocm_download_plugin.md
@@ -53,38 +53,39 @@ ocm download plugin [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        supply configuration by a given configuration file.
-                             By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
-                             1. The path specified in the OCM_CONFIG_PATH environment variable
-                             2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
-                             - $XDG_CONFIG_HOME/ocm/config
-                             - $XDG_CONFIG_HOME/.ocmconfig
-                             - $HOME/.config/ocm/config
-                             - $HOME/.config/.ocmconfig
-                             - $HOME/.ocm/config
-                             - $HOME/.ocmconfig
-                             3. The current working directory:
-                             - $PWD/ocm/config
-                             - $PWD/.ocmconfig
-                             4. The directory of the current executable:
-                             - $EXE_DIR/ocm/config
-                             - $EXE_DIR/.ocmconfig
-                             Using the option, this configuration file be used instead of the lookup above.
-      --logformat enum       set the log output format that is used to print individual logs
-                                json: Output logs in JSON format, suitable for machine processing
-                                text: Output logs in human-readable text format, suitable for console output
-                             (must be one of [json text]) (default text)
-      --loglevel enum        sets the logging level
-                                debug: Show all logs including detailed debugging information
-                                info:  Show informational messages and above
-                                warn:  Show warnings and errors only (default)
-                                error: Show errors only
-                             (must be one of [debug error info warn]) (default info)
-      --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
-                                stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
-      --temp-folder string   Specify a custom temporary folder path for filesystem operations.
+      --config string                      supply configuration by a given configuration file.
+                                           By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
+                                           1. The path specified in the OCM_CONFIG_PATH environment variable
+                                           2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
+                                           - $XDG_CONFIG_HOME/ocm/config
+                                           - $XDG_CONFIG_HOME/.ocmconfig
+                                           - $HOME/.config/ocm/config
+                                           - $HOME/.config/.ocmconfig
+                                           - $HOME/.ocm/config
+                                           - $HOME/.ocmconfig
+                                           3. The current working directory:
+                                           - $PWD/ocm/config
+                                           - $PWD/.ocmconfig
+                                           4. The directory of the current executable:
+                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocmconfig
+                                           Using the option, this configuration file be used instead of the lookup above.
+      --logformat enum                     set the log output format that is used to print individual logs
+                                              json: Output logs in JSON format, suitable for machine processing
+                                              text: Output logs in human-readable text format, suitable for console output
+                                           (must be one of [json text]) (default text)
+      --loglevel enum                      sets the logging level
+                                              debug: Show all logs including detailed debugging information
+                                              info:  Show informational messages and above
+                                              warn:  Show warnings and errors only (default)
+                                              error: Show errors only
+                                           (must be one of [debug error info warn]) (default info)
+      --logoutput enum                     set the log output destination
+                                              stdout: Write logs to standard output (default)
+                                              stderr: Write logs to standard error, useful for separating logs from normal output
+                                           (must be one of [stderr stdout]) (default stdout)
+      --plugin-shutdown-timeout duration   Timeout for plugin shutdown. If a plugin does not shut down within this time, it is forcefully killed (default 10s)
+      --temp-folder string                 Specify a custom temporary folder path for filesystem operations.
 ```
 
 ### SEE ALSO

--- a/cli/docs/reference/ocm_download_resource.md
+++ b/cli/docs/reference/ocm_download_resource.md
@@ -52,38 +52,39 @@ ocm download resource [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        supply configuration by a given configuration file.
-                             By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
-                             1. The path specified in the OCM_CONFIG_PATH environment variable
-                             2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
-                             - $XDG_CONFIG_HOME/ocm/config
-                             - $XDG_CONFIG_HOME/.ocmconfig
-                             - $HOME/.config/ocm/config
-                             - $HOME/.config/.ocmconfig
-                             - $HOME/.ocm/config
-                             - $HOME/.ocmconfig
-                             3. The current working directory:
-                             - $PWD/ocm/config
-                             - $PWD/.ocmconfig
-                             4. The directory of the current executable:
-                             - $EXE_DIR/ocm/config
-                             - $EXE_DIR/.ocmconfig
-                             Using the option, this configuration file be used instead of the lookup above.
-      --logformat enum       set the log output format that is used to print individual logs
-                                json: Output logs in JSON format, suitable for machine processing
-                                text: Output logs in human-readable text format, suitable for console output
-                             (must be one of [json text]) (default text)
-      --loglevel enum        sets the logging level
-                                debug: Show all logs including detailed debugging information
-                                info:  Show informational messages and above
-                                warn:  Show warnings and errors only (default)
-                                error: Show errors only
-                             (must be one of [debug error info warn]) (default info)
-      --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
-                                stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
-      --temp-folder string   Specify a custom temporary folder path for filesystem operations.
+      --config string                      supply configuration by a given configuration file.
+                                           By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
+                                           1. The path specified in the OCM_CONFIG_PATH environment variable
+                                           2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
+                                           - $XDG_CONFIG_HOME/ocm/config
+                                           - $XDG_CONFIG_HOME/.ocmconfig
+                                           - $HOME/.config/ocm/config
+                                           - $HOME/.config/.ocmconfig
+                                           - $HOME/.ocm/config
+                                           - $HOME/.ocmconfig
+                                           3. The current working directory:
+                                           - $PWD/ocm/config
+                                           - $PWD/.ocmconfig
+                                           4. The directory of the current executable:
+                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocmconfig
+                                           Using the option, this configuration file be used instead of the lookup above.
+      --logformat enum                     set the log output format that is used to print individual logs
+                                              json: Output logs in JSON format, suitable for machine processing
+                                              text: Output logs in human-readable text format, suitable for console output
+                                           (must be one of [json text]) (default text)
+      --loglevel enum                      sets the logging level
+                                              debug: Show all logs including detailed debugging information
+                                              info:  Show informational messages and above
+                                              warn:  Show warnings and errors only (default)
+                                              error: Show errors only
+                                           (must be one of [debug error info warn]) (default info)
+      --logoutput enum                     set the log output destination
+                                              stdout: Write logs to standard output (default)
+                                              stderr: Write logs to standard error, useful for separating logs from normal output
+                                           (must be one of [stderr stdout]) (default stdout)
+      --plugin-shutdown-timeout duration   Timeout for plugin shutdown. If a plugin does not shut down within this time, it is forcefully killed (default 10s)
+      --temp-folder string                 Specify a custom temporary folder path for filesystem operations.
 ```
 
 ### SEE ALSO

--- a/cli/docs/reference/ocm_generate.md
+++ b/cli/docs/reference/ocm_generate.md
@@ -29,38 +29,39 @@ to quickly create a Cobra application.
 ### Options inherited from parent commands
 
 ```
-      --config string        supply configuration by a given configuration file.
-                             By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
-                             1. The path specified in the OCM_CONFIG_PATH environment variable
-                             2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
-                             - $XDG_CONFIG_HOME/ocm/config
-                             - $XDG_CONFIG_HOME/.ocmconfig
-                             - $HOME/.config/ocm/config
-                             - $HOME/.config/.ocmconfig
-                             - $HOME/.ocm/config
-                             - $HOME/.ocmconfig
-                             3. The current working directory:
-                             - $PWD/ocm/config
-                             - $PWD/.ocmconfig
-                             4. The directory of the current executable:
-                             - $EXE_DIR/ocm/config
-                             - $EXE_DIR/.ocmconfig
-                             Using the option, this configuration file be used instead of the lookup above.
-      --logformat enum       set the log output format that is used to print individual logs
-                                json: Output logs in JSON format, suitable for machine processing
-                                text: Output logs in human-readable text format, suitable for console output
-                             (must be one of [json text]) (default text)
-      --loglevel enum        sets the logging level
-                                debug: Show all logs including detailed debugging information
-                                info:  Show informational messages and above
-                                warn:  Show warnings and errors only (default)
-                                error: Show errors only
-                             (must be one of [debug error info warn]) (default info)
-      --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
-                                stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
-      --temp-folder string   Specify a custom temporary folder path for filesystem operations.
+      --config string                      supply configuration by a given configuration file.
+                                           By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
+                                           1. The path specified in the OCM_CONFIG_PATH environment variable
+                                           2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
+                                           - $XDG_CONFIG_HOME/ocm/config
+                                           - $XDG_CONFIG_HOME/.ocmconfig
+                                           - $HOME/.config/ocm/config
+                                           - $HOME/.config/.ocmconfig
+                                           - $HOME/.ocm/config
+                                           - $HOME/.ocmconfig
+                                           3. The current working directory:
+                                           - $PWD/ocm/config
+                                           - $PWD/.ocmconfig
+                                           4. The directory of the current executable:
+                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocmconfig
+                                           Using the option, this configuration file be used instead of the lookup above.
+      --logformat enum                     set the log output format that is used to print individual logs
+                                              json: Output logs in JSON format, suitable for machine processing
+                                              text: Output logs in human-readable text format, suitable for console output
+                                           (must be one of [json text]) (default text)
+      --loglevel enum                      sets the logging level
+                                              debug: Show all logs including detailed debugging information
+                                              info:  Show informational messages and above
+                                              warn:  Show warnings and errors only (default)
+                                              error: Show errors only
+                                           (must be one of [debug error info warn]) (default info)
+      --logoutput enum                     set the log output destination
+                                              stdout: Write logs to standard output (default)
+                                              stderr: Write logs to standard error, useful for separating logs from normal output
+                                           (must be one of [stderr stdout]) (default stdout)
+      --plugin-shutdown-timeout duration   Timeout for plugin shutdown. If a plugin does not shut down within this time, it is forcefully killed (default 10s)
+      --temp-folder string                 Specify a custom temporary folder path for filesystem operations.
 ```
 
 ### SEE ALSO

--- a/cli/docs/reference/ocm_generate_docs.md
+++ b/cli/docs/reference/ocm_generate_docs.md
@@ -31,38 +31,39 @@ ocm generate docs [-d <directory>] [--mode <format>] [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        supply configuration by a given configuration file.
-                             By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
-                             1. The path specified in the OCM_CONFIG_PATH environment variable
-                             2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
-                             - $XDG_CONFIG_HOME/ocm/config
-                             - $XDG_CONFIG_HOME/.ocmconfig
-                             - $HOME/.config/ocm/config
-                             - $HOME/.config/.ocmconfig
-                             - $HOME/.ocm/config
-                             - $HOME/.ocmconfig
-                             3. The current working directory:
-                             - $PWD/ocm/config
-                             - $PWD/.ocmconfig
-                             4. The directory of the current executable:
-                             - $EXE_DIR/ocm/config
-                             - $EXE_DIR/.ocmconfig
-                             Using the option, this configuration file be used instead of the lookup above.
-      --logformat enum       set the log output format that is used to print individual logs
-                                json: Output logs in JSON format, suitable for machine processing
-                                text: Output logs in human-readable text format, suitable for console output
-                             (must be one of [json text]) (default text)
-      --loglevel enum        sets the logging level
-                                debug: Show all logs including detailed debugging information
-                                info:  Show informational messages and above
-                                warn:  Show warnings and errors only (default)
-                                error: Show errors only
-                             (must be one of [debug error info warn]) (default info)
-      --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
-                                stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
-      --temp-folder string   Specify a custom temporary folder path for filesystem operations.
+      --config string                      supply configuration by a given configuration file.
+                                           By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
+                                           1. The path specified in the OCM_CONFIG_PATH environment variable
+                                           2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
+                                           - $XDG_CONFIG_HOME/ocm/config
+                                           - $XDG_CONFIG_HOME/.ocmconfig
+                                           - $HOME/.config/ocm/config
+                                           - $HOME/.config/.ocmconfig
+                                           - $HOME/.ocm/config
+                                           - $HOME/.ocmconfig
+                                           3. The current working directory:
+                                           - $PWD/ocm/config
+                                           - $PWD/.ocmconfig
+                                           4. The directory of the current executable:
+                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocmconfig
+                                           Using the option, this configuration file be used instead of the lookup above.
+      --logformat enum                     set the log output format that is used to print individual logs
+                                              json: Output logs in JSON format, suitable for machine processing
+                                              text: Output logs in human-readable text format, suitable for console output
+                                           (must be one of [json text]) (default text)
+      --loglevel enum                      sets the logging level
+                                              debug: Show all logs including detailed debugging information
+                                              info:  Show informational messages and above
+                                              warn:  Show warnings and errors only (default)
+                                              error: Show errors only
+                                           (must be one of [debug error info warn]) (default info)
+      --logoutput enum                     set the log output destination
+                                              stdout: Write logs to standard output (default)
+                                              stderr: Write logs to standard error, useful for separating logs from normal output
+                                           (must be one of [stderr stdout]) (default stdout)
+      --plugin-shutdown-timeout duration   Timeout for plugin shutdown. If a plugin does not shut down within this time, it is forcefully killed (default 10s)
+      --temp-folder string                 Specify a custom temporary folder path for filesystem operations.
 ```
 
 ### SEE ALSO

--- a/cli/docs/reference/ocm_get.md
+++ b/cli/docs/reference/ocm_get.md
@@ -24,38 +24,39 @@ ocm get {component-version|component-versions|cv|cvs} [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string        supply configuration by a given configuration file.
-                             By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
-                             1. The path specified in the OCM_CONFIG_PATH environment variable
-                             2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
-                             - $XDG_CONFIG_HOME/ocm/config
-                             - $XDG_CONFIG_HOME/.ocmconfig
-                             - $HOME/.config/ocm/config
-                             - $HOME/.config/.ocmconfig
-                             - $HOME/.ocm/config
-                             - $HOME/.ocmconfig
-                             3. The current working directory:
-                             - $PWD/ocm/config
-                             - $PWD/.ocmconfig
-                             4. The directory of the current executable:
-                             - $EXE_DIR/ocm/config
-                             - $EXE_DIR/.ocmconfig
-                             Using the option, this configuration file be used instead of the lookup above.
-      --logformat enum       set the log output format that is used to print individual logs
-                                json: Output logs in JSON format, suitable for machine processing
-                                text: Output logs in human-readable text format, suitable for console output
-                             (must be one of [json text]) (default text)
-      --loglevel enum        sets the logging level
-                                debug: Show all logs including detailed debugging information
-                                info:  Show informational messages and above
-                                warn:  Show warnings and errors only (default)
-                                error: Show errors only
-                             (must be one of [debug error info warn]) (default info)
-      --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
-                                stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
-      --temp-folder string   Specify a custom temporary folder path for filesystem operations.
+      --config string                      supply configuration by a given configuration file.
+                                           By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
+                                           1. The path specified in the OCM_CONFIG_PATH environment variable
+                                           2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
+                                           - $XDG_CONFIG_HOME/ocm/config
+                                           - $XDG_CONFIG_HOME/.ocmconfig
+                                           - $HOME/.config/ocm/config
+                                           - $HOME/.config/.ocmconfig
+                                           - $HOME/.ocm/config
+                                           - $HOME/.ocmconfig
+                                           3. The current working directory:
+                                           - $PWD/ocm/config
+                                           - $PWD/.ocmconfig
+                                           4. The directory of the current executable:
+                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocmconfig
+                                           Using the option, this configuration file be used instead of the lookup above.
+      --logformat enum                     set the log output format that is used to print individual logs
+                                              json: Output logs in JSON format, suitable for machine processing
+                                              text: Output logs in human-readable text format, suitable for console output
+                                           (must be one of [json text]) (default text)
+      --loglevel enum                      sets the logging level
+                                              debug: Show all logs including detailed debugging information
+                                              info:  Show informational messages and above
+                                              warn:  Show warnings and errors only (default)
+                                              error: Show errors only
+                                           (must be one of [debug error info warn]) (default info)
+      --logoutput enum                     set the log output destination
+                                              stdout: Write logs to standard output (default)
+                                              stderr: Write logs to standard error, useful for separating logs from normal output
+                                           (must be one of [stderr stdout]) (default stdout)
+      --plugin-shutdown-timeout duration   Timeout for plugin shutdown. If a plugin does not shut down within this time, it is forcefully killed (default 10s)
+      --temp-folder string                 Specify a custom temporary folder path for filesystem operations.
 ```
 
 ### SEE ALSO

--- a/cli/docs/reference/ocm_get_component-version.md
+++ b/cli/docs/reference/ocm_get_component-version.md
@@ -65,38 +65,39 @@ get cvs oci::http://localhost:8080//ocm.software/ocmcli
 ### Options inherited from parent commands
 
 ```
-      --config string        supply configuration by a given configuration file.
-                             By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
-                             1. The path specified in the OCM_CONFIG_PATH environment variable
-                             2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
-                             - $XDG_CONFIG_HOME/ocm/config
-                             - $XDG_CONFIG_HOME/.ocmconfig
-                             - $HOME/.config/ocm/config
-                             - $HOME/.config/.ocmconfig
-                             - $HOME/.ocm/config
-                             - $HOME/.ocmconfig
-                             3. The current working directory:
-                             - $PWD/ocm/config
-                             - $PWD/.ocmconfig
-                             4. The directory of the current executable:
-                             - $EXE_DIR/ocm/config
-                             - $EXE_DIR/.ocmconfig
-                             Using the option, this configuration file be used instead of the lookup above.
-      --logformat enum       set the log output format that is used to print individual logs
-                                json: Output logs in JSON format, suitable for machine processing
-                                text: Output logs in human-readable text format, suitable for console output
-                             (must be one of [json text]) (default text)
-      --loglevel enum        sets the logging level
-                                debug: Show all logs including detailed debugging information
-                                info:  Show informational messages and above
-                                warn:  Show warnings and errors only (default)
-                                error: Show errors only
-                             (must be one of [debug error info warn]) (default info)
-      --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
-                                stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
-      --temp-folder string   Specify a custom temporary folder path for filesystem operations.
+      --config string                      supply configuration by a given configuration file.
+                                           By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
+                                           1. The path specified in the OCM_CONFIG_PATH environment variable
+                                           2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
+                                           - $XDG_CONFIG_HOME/ocm/config
+                                           - $XDG_CONFIG_HOME/.ocmconfig
+                                           - $HOME/.config/ocm/config
+                                           - $HOME/.config/.ocmconfig
+                                           - $HOME/.ocm/config
+                                           - $HOME/.ocmconfig
+                                           3. The current working directory:
+                                           - $PWD/ocm/config
+                                           - $PWD/.ocmconfig
+                                           4. The directory of the current executable:
+                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocmconfig
+                                           Using the option, this configuration file be used instead of the lookup above.
+      --logformat enum                     set the log output format that is used to print individual logs
+                                              json: Output logs in JSON format, suitable for machine processing
+                                              text: Output logs in human-readable text format, suitable for console output
+                                           (must be one of [json text]) (default text)
+      --loglevel enum                      sets the logging level
+                                              debug: Show all logs including detailed debugging information
+                                              info:  Show informational messages and above
+                                              warn:  Show warnings and errors only (default)
+                                              error: Show errors only
+                                           (must be one of [debug error info warn]) (default info)
+      --logoutput enum                     set the log output destination
+                                              stdout: Write logs to standard output (default)
+                                              stderr: Write logs to standard error, useful for separating logs from normal output
+                                           (must be one of [stderr stdout]) (default stdout)
+      --plugin-shutdown-timeout duration   Timeout for plugin shutdown. If a plugin does not shut down within this time, it is forcefully killed (default 10s)
+      --temp-folder string                 Specify a custom temporary folder path for filesystem operations.
 ```
 
 ### SEE ALSO

--- a/cli/docs/reference/ocm_version.md
+++ b/cli/docs/reference/ocm_version.md
@@ -51,38 +51,39 @@ ocm version --format legacyjson
 ### Options inherited from parent commands
 
 ```
-      --config string        supply configuration by a given configuration file.
-                             By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
-                             1. The path specified in the OCM_CONFIG_PATH environment variable
-                             2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
-                             - $XDG_CONFIG_HOME/ocm/config
-                             - $XDG_CONFIG_HOME/.ocmconfig
-                             - $HOME/.config/ocm/config
-                             - $HOME/.config/.ocmconfig
-                             - $HOME/.ocm/config
-                             - $HOME/.ocmconfig
-                             3. The current working directory:
-                             - $PWD/ocm/config
-                             - $PWD/.ocmconfig
-                             4. The directory of the current executable:
-                             - $EXE_DIR/ocm/config
-                             - $EXE_DIR/.ocmconfig
-                             Using the option, this configuration file be used instead of the lookup above.
-      --logformat enum       set the log output format that is used to print individual logs
-                                json: Output logs in JSON format, suitable for machine processing
-                                text: Output logs in human-readable text format, suitable for console output
-                             (must be one of [json text]) (default text)
-      --loglevel enum        sets the logging level
-                                debug: Show all logs including detailed debugging information
-                                info:  Show informational messages and above
-                                warn:  Show warnings and errors only (default)
-                                error: Show errors only
-                             (must be one of [debug error info warn]) (default info)
-      --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
-                                stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
-      --temp-folder string   Specify a custom temporary folder path for filesystem operations.
+      --config string                      supply configuration by a given configuration file.
+                                           By default (without specifying custom locations with this flag), the file will be read from one of the well known locations:
+                                           1. The path specified in the OCM_CONFIG_PATH environment variable
+                                           2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
+                                           - $XDG_CONFIG_HOME/ocm/config
+                                           - $XDG_CONFIG_HOME/.ocmconfig
+                                           - $HOME/.config/ocm/config
+                                           - $HOME/.config/.ocmconfig
+                                           - $HOME/.ocm/config
+                                           - $HOME/.ocmconfig
+                                           3. The current working directory:
+                                           - $PWD/ocm/config
+                                           - $PWD/.ocmconfig
+                                           4. The directory of the current executable:
+                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocmconfig
+                                           Using the option, this configuration file be used instead of the lookup above.
+      --logformat enum                     set the log output format that is used to print individual logs
+                                              json: Output logs in JSON format, suitable for machine processing
+                                              text: Output logs in human-readable text format, suitable for console output
+                                           (must be one of [json text]) (default text)
+      --loglevel enum                      sets the logging level
+                                              debug: Show all logs including detailed debugging information
+                                              info:  Show informational messages and above
+                                              warn:  Show warnings and errors only (default)
+                                              error: Show errors only
+                                           (must be one of [debug error info warn]) (default info)
+      --logoutput enum                     set the log output destination
+                                              stdout: Write logs to standard output (default)
+                                              stderr: Write logs to standard error, useful for separating logs from normal output
+                                           (must be one of [stderr stdout]) (default stdout)
+      --plugin-shutdown-timeout duration   Timeout for plugin shutdown. If a plugin does not shut down within this time, it is forcefully killed (default 10s)
+      --temp-folder string                 Specify a custom temporary folder path for filesystem operations.
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

- Introduced `--plugin-shutdown-timeout` flag to manage plugin termination.
- Default timeout is set to 10 seconds. Forces plugins to shut down if not completed within the specified time.
- Updated CLI commands and documentation to include the new flag.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Rationale: This ensures plugins do not hang during shutdown, improving the CLI's reliability and user experience.

part of the helm input binary test did with @Skarlso
part of https://github.com/open-component-model/ocm-project/issues/490