### PR TITLE
fix(cli): correct default value for `--logoutput` in CLI docs

### DIFF
--- a/cli/docs/reference/ocm.md
+++ b/cli/docs/reference/ocm.md
@@ -53,9 +53,9 @@ ocm [sub-command] [flags]
                                 error: Show errors only
                              (must be one of [debug error info warn]) (default info)
       --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
+                                stdout: Write logs to standard output
                                 stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
+                             (must be one of [stderr stdout]) (default stderr)
       --temp-folder string   Specify a custom temporary folder path for filesystem operations.
 ```
 

--- a/cli/docs/reference/ocm_add.md
+++ b/cli/docs/reference/ocm_add.md
@@ -52,9 +52,9 @@ ocm add {component-version|component-versions|cv|cvs} [flags]
                                 error: Show errors only
                              (must be one of [debug error info warn]) (default info)
       --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
+                                stdout: Write logs to standard output
                                 stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
+                             (must be one of [stderr stdout]) (default stderr)
       --temp-folder string   Specify a custom temporary folder path for filesystem operations.
 ```
 

--- a/cli/docs/reference/ocm_add_component-version.md
+++ b/cli/docs/reference/ocm_add_component-version.md
@@ -81,9 +81,9 @@ add component-version  --repository ./path/to/transport-archive --constructor ./
                                 error: Show errors only
                              (must be one of [debug error info warn]) (default info)
       --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
+                                stdout: Write logs to standard output
                                 stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
+                             (must be one of [stderr stdout]) (default stderr)
       --temp-folder string   Specify a custom temporary folder path for filesystem operations.
 ```
 

--- a/cli/docs/reference/ocm_completion.md
+++ b/cli/docs/reference/ocm_completion.md
@@ -54,9 +54,9 @@ See each sub-command's help for details on how to use the generated script.
                                 error: Show errors only
                              (must be one of [debug error info warn]) (default info)
       --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
+                                stdout: Write logs to standard output
                                 stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
+                             (must be one of [stderr stdout]) (default stderr)
       --temp-folder string   Specify a custom temporary folder path for filesystem operations.
 ```
 

--- a/cli/docs/reference/ocm_completion_bash.md
+++ b/cli/docs/reference/ocm_completion_bash.md
@@ -77,9 +77,9 @@ ocm completion bash
                                 error: Show errors only
                              (must be one of [debug error info warn]) (default info)
       --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
+                                stdout: Write logs to standard output
                                 stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
+                             (must be one of [stderr stdout]) (default stderr)
       --temp-folder string   Specify a custom temporary folder path for filesystem operations.
 ```
 

--- a/cli/docs/reference/ocm_completion_fish.md
+++ b/cli/docs/reference/ocm_completion_fish.md
@@ -68,9 +68,9 @@ ocm completion fish [flags]
                                 error: Show errors only
                              (must be one of [debug error info warn]) (default info)
       --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
+                                stdout: Write logs to standard output
                                 stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
+                             (must be one of [stderr stdout]) (default stderr)
       --temp-folder string   Specify a custom temporary folder path for filesystem operations.
 ```
 

--- a/cli/docs/reference/ocm_completion_powershell.md
+++ b/cli/docs/reference/ocm_completion_powershell.md
@@ -65,9 +65,9 @@ ocm completion powershell [flags]
                                 error: Show errors only
                              (must be one of [debug error info warn]) (default info)
       --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
+                                stdout: Write logs to standard output
                                 stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
+                             (must be one of [stderr stdout]) (default stderr)
       --temp-folder string   Specify a custom temporary folder path for filesystem operations.
 ```
 

--- a/cli/docs/reference/ocm_completion_zsh.md
+++ b/cli/docs/reference/ocm_completion_zsh.md
@@ -79,9 +79,9 @@ ocm completion zsh [flags]
                                 error: Show errors only
                              (must be one of [debug error info warn]) (default info)
       --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
+                                stdout: Write logs to standard output
                                 stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
+                             (must be one of [stderr stdout]) (default stderr)
       --temp-folder string   Specify a custom temporary folder path for filesystem operations.
 ```
 

--- a/cli/docs/reference/ocm_download.md
+++ b/cli/docs/reference/ocm_download.md
@@ -52,9 +52,9 @@ ocm download {resource|resources|plugin|plugins} [flags]
                                 error: Show errors only
                              (must be one of [debug error info warn]) (default info)
       --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
+                                stdout: Write logs to standard output
                                 stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
+                             (must be one of [stderr stdout]) (default stderr)
       --temp-folder string   Specify a custom temporary folder path for filesystem operations.
 ```
 

--- a/cli/docs/reference/ocm_download_plugin.md
+++ b/cli/docs/reference/ocm_download_plugin.md
@@ -81,9 +81,9 @@ ocm download plugin [flags]
                                 error: Show errors only
                              (must be one of [debug error info warn]) (default info)
       --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
+                                stdout: Write logs to standard output
                                 stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
+                             (must be one of [stderr stdout]) (default stderr)
       --temp-folder string   Specify a custom temporary folder path for filesystem operations.
 ```
 

--- a/cli/docs/reference/ocm_download_resource.md
+++ b/cli/docs/reference/ocm_download_resource.md
@@ -80,9 +80,9 @@ ocm download resource [flags]
                                 error: Show errors only
                              (must be one of [debug error info warn]) (default info)
       --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
+                                stdout: Write logs to standard output
                                 stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
+                             (must be one of [stderr stdout]) (default stderr)
       --temp-folder string   Specify a custom temporary folder path for filesystem operations.
 ```
 

--- a/cli/docs/reference/ocm_generate.md
+++ b/cli/docs/reference/ocm_generate.md
@@ -57,9 +57,9 @@ to quickly create a Cobra application.
                                 error: Show errors only
                              (must be one of [debug error info warn]) (default info)
       --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
+                                stdout: Write logs to standard output
                                 stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
+                             (must be one of [stderr stdout]) (default stderr)
       --temp-folder string   Specify a custom temporary folder path for filesystem operations.
 ```
 

--- a/cli/docs/reference/ocm_generate_docs.md
+++ b/cli/docs/reference/ocm_generate_docs.md
@@ -59,9 +59,9 @@ ocm generate docs [-d <directory>] [--mode <format>] [flags]
                                 error: Show errors only
                              (must be one of [debug error info warn]) (default info)
       --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
+                                stdout: Write logs to standard output
                                 stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
+                             (must be one of [stderr stdout]) (default stderr)
       --temp-folder string   Specify a custom temporary folder path for filesystem operations.
 ```
 

--- a/cli/docs/reference/ocm_get.md
+++ b/cli/docs/reference/ocm_get.md
@@ -52,9 +52,9 @@ ocm get {component-version|component-versions|cv|cvs} [flags]
                                 error: Show errors only
                              (must be one of [debug error info warn]) (default info)
       --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
+                                stdout: Write logs to standard output
                                 stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
+                             (must be one of [stderr stdout]) (default stderr)
       --temp-folder string   Specify a custom temporary folder path for filesystem operations.
 ```
 

--- a/cli/docs/reference/ocm_get_component-version.md
+++ b/cli/docs/reference/ocm_get_component-version.md
@@ -93,9 +93,9 @@ get cvs oci::http://localhost:8080//ocm.software/ocmcli
                                 error: Show errors only
                              (must be one of [debug error info warn]) (default info)
       --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
+                                stdout: Write logs to standard output
                                 stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
+                             (must be one of [stderr stdout]) (default stderr)
       --temp-folder string   Specify a custom temporary folder path for filesystem operations.
 ```
 

--- a/cli/docs/reference/ocm_version.md
+++ b/cli/docs/reference/ocm_version.md
@@ -79,9 +79,9 @@ ocm version --format legacyjson
                                 error: Show errors only
                              (must be one of [debug error info warn]) (default info)
       --logoutput enum       set the log output destination
-                                stdout: Write logs to standard output (default)
+                                stdout: Write logs to standard output
                                 stderr: Write logs to standard error, useful for separating logs from normal output
-                             (must be one of [stderr stdout]) (default stdout)
+                             (must be one of [stderr stdout]) (default stderr)
       --temp-folder string   Specify a custom temporary folder path for filesystem operations.
 ```
 

--- a/cli/internal/flags/log/flag.go
+++ b/cli/internal/flags/log/flag.go
@@ -79,10 +79,10 @@ func RegisterLoggingFlags(flagset *pflag.FlagSet) {
    error: Show errors only`)
 
 	enum.Var(flagset, OutputFlagName, []string{
-		OutputStdout,
 		OutputStderr,
+		OutputStdout,
 	}, `set the log output destination
-   stdout: Write logs to standard output (default)
+   stdout: Write logs to standard output
    stderr: Write logs to standard error, useful for separating logs from normal output`)
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

- Updated CLI documentation across multiple commands to reflect the correct default value for the `--logoutput` flag.
- Changed default log output from `stdout` to `stderr` for better separation of logs from normal output.
- Adjusted related internal code to align with this change.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

this solves the problem of not being able to separate out logs and actual output. this allows logging for commands such as `ocm get cv -oyaml | yq`, ensuring the pipe works while still maintaining the ability to generate and display logs
