### PR TITLE
fix: use environment property if defined and fall back to gh otherwise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,7 @@ jobs:
       - name: Run Tests
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GITHUB_USER: ocmbot[ocm]
         run: task ${{ matrix.module }}:test/integration
 
   run_unit_tests:

--- a/bindings/go/oci/integration/integration_test.go
+++ b/bindings/go/oci/integration/integration_test.go
@@ -905,18 +905,11 @@ func getUserAndPasswordWithGitHubCLIAndJQ(t *testing.T) (string, string) {
 		t.Errorf("gh CLI not found, skipping test %v", err)
 	}
 
-	//out, err := exec.CommandContext(t.Context(), "sh", "-c", fmt.Sprintf("%s api user", gh)).CombinedOutput()
-	//if err != nil {
-	//	t.Logf("gh CLI output: %s", out)
-	//	t.Errorf("gh CLI for user failed: %v", err)
-	//}
-	//structured := map[string]interface{}{}
-	//if err := json.Unmarshal(out, &structured); err != nil {
-	//	t.Logf("gh CLI output: %s", out)
-	//	t.Errorf("gh failed to parse output: %v", err)
-	//}
-	//user := structured["login"].(string)
-	user := "ocmbot[bot]"
+	user, err := getUsername(t, gh)
+	if err != nil {
+		t.Errorf("gh CLI for username failed: %v", err)
+		return "", ""
+	}
 	pw := exec.CommandContext(t.Context(), "sh", "-c", fmt.Sprintf("%s auth token", gh))
 	out, err := pw.CombinedOutput()
 	if err != nil {
@@ -926,4 +919,23 @@ func getUserAndPasswordWithGitHubCLIAndJQ(t *testing.T) (string, string) {
 	password := strings.TrimSpace(string(out))
 
 	return user, password
+}
+
+func getUsername(t *testing.T, gh string) (string, error) {
+	if githubUser := os.Getenv("GITHUB_USER"); githubUser != "" {
+		return githubUser, nil
+	}
+
+	out, err := exec.CommandContext(t.Context(), "sh", "-c", fmt.Sprintf("%s api user", gh)).CombinedOutput()
+	if err != nil {
+		t.Logf("gh CLI output: %s", out)
+		return "", fmt.Errorf("gh CLI for user failed: %w", err)
+	}
+	structured := map[string]interface{}{}
+	if err := json.Unmarshal(out, &structured); err != nil {
+		t.Logf("gh CLI output: %s", out)
+		return "", fmt.Errorf("gh failed to parse output: %w", err)
+	}
+
+	return structured["login"].(string), nil
 }

--- a/cli/cmd/download/plugin/integration/integration_test.go
+++ b/cli/cmd/download/plugin/integration/integration_test.go
@@ -188,21 +188,38 @@ func getUserAndPasswordForTest(t *testing.T) (string, string) {
 		t.Skip("gh CLI not found, skipping test")
 	}
 
-	out, err := exec.CommandContext(t.Context(), "sh", "-c", fmt.Sprintf("%s api user", gh)).CombinedOutput()
+	user, err := getUsername(t, gh)
 	if err != nil {
-		t.Skipf("gh CLI for user failed: %v", err)
+		t.Errorf("gh CLI for username failed: %v", err)
+		return "", ""
 	}
-	structured := map[string]interface{}{}
-	if err := json.Unmarshal(out, &structured); err != nil {
-		t.Skipf("gh CLI for user failed: %v", err)
-	}
-	user := structured["login"].(string)
 
 	pw := exec.CommandContext(t.Context(), "sh", "-c", fmt.Sprintf("%s auth token", gh))
-	if out, err = pw.CombinedOutput(); err != nil {
-		t.Skipf("gh CLI for password failed: %v", err)
+	out, err := pw.CombinedOutput()
+	if err != nil {
+		t.Logf("gh auth token output: %s", out)
+		t.Errorf("gh CLI for password failed: %v", err)
 	}
 	password := strings.TrimSpace(string(out))
 
 	return user, password
+}
+
+func getUsername(t *testing.T, gh string) (string, error) {
+	if githubUser := os.Getenv("GITHUB_USER"); githubUser != "" {
+		return githubUser, nil
+	}
+
+	out, err := exec.CommandContext(t.Context(), "sh", "-c", fmt.Sprintf("%s api user", gh)).CombinedOutput()
+	if err != nil {
+		t.Logf("gh CLI output: %s", out)
+		return "", fmt.Errorf("gh CLI for user failed: %w", err)
+	}
+	structured := map[string]interface{}{}
+	if err := json.Unmarshal(out, &structured); err != nil {
+		t.Logf("gh CLI output: %s", out)
+		return "", fmt.Errorf("gh failed to parse output: %w", err)
+	}
+
+	return structured["login"].(string), nil
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
