### PR TITLE
fix: export ocm config type scheme

### DIFF
--- a/bindings/go/configuration/ocm/v1/spec/config.go
+++ b/bindings/go/configuration/ocm/v1/spec/config.go
@@ -18,10 +18,10 @@ const (
 	DefaultLookupPriority = 10
 )
 
-var scheme = runtime.NewScheme()
+var Scheme = runtime.NewScheme()
 
 func init() {
-	scheme.MustRegisterWithAlias(&Config{},
+	Scheme.MustRegisterWithAlias(&Config{},
 		runtime.NewVersionedType(ConfigType, Version),
 		runtime.NewUnversionedType(ConfigType),
 	)
@@ -122,7 +122,7 @@ func Lookup(cfg *genericv1.Config) (*Config, error) {
 	cfgs := make([]*Config, 0, len(cfg.Configurations))
 	for _, entry := range cfg.Configurations {
 		var config Config
-		if err := scheme.Convert(entry, &config); err != nil {
+		if err := Scheme.Convert(entry, &config); err != nil {
 			return nil, fmt.Errorf("failed to decode credential config: %w", err)
 		}
 		cfgs = append(cfgs, &config)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Scheme should be exported to be usable in other packages.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
