### PR TITLE
feat(configuration): introduce global scheme and improve registration handling

### DIFF
--- a/bindings/go/configuration/filesystem/v1alpha1/spec/config.go
+++ b/bindings/go/configuration/filesystem/v1alpha1/spec/config.go
@@ -15,10 +15,10 @@ const (
 	ConfigType = "filesystem.config.ocm.software"
 )
 
-var scheme = runtime.NewScheme()
+var Scheme = runtime.NewScheme()
 
 func init() {
-	scheme.MustRegisterWithAlias(&Config{}, runtime.NewVersionedType(ConfigType, Version))
+	Scheme.MustRegisterWithAlias(&Config{}, runtime.NewVersionedType(ConfigType, Version))
 }
 
 // Config represents the top-level configuration for the plugin manager.
@@ -68,7 +68,7 @@ func LookupConfig(cfg *genericv1.Config) (*Config, error) {
 		cfgs := make([]*Config, 0, len(cfg.Configurations))
 		for _, entry := range cfg.Configurations {
 			var config Config
-			if err := scheme.Convert(entry, &config); err != nil {
+			if err := Scheme.Convert(entry, &config); err != nil {
 				return nil, fmt.Errorf("failed to decode credential config: %w", err)
 			}
 			cfgs = append(cfgs, &config)
@@ -95,7 +95,7 @@ func Merge(configs ...*Config) *Config {
 	}
 
 	merged := new(Config)
-	_, _ = scheme.DefaultType(merged)
+	_, _ = Scheme.DefaultType(merged)
 
 	for _, config := range configs {
 		if config.TempFolder != merged.TempFolder {

--- a/bindings/go/configuration/scheme.go
+++ b/bindings/go/configuration/scheme.go
@@ -1,0 +1,26 @@
+package configuration
+
+import (
+	extractv1alpha1 "ocm.software/open-component-model/bindings/go/configuration/extract/v1alpha1/spec"
+	filesystemv1alpha1 "ocm.software/open-component-model/bindings/go/configuration/filesystem/v1alpha1/spec"
+	genericspecv1 "ocm.software/open-component-model/bindings/go/configuration/generic/v1/spec"
+	ocmv1 "ocm.software/open-component-model/bindings/go/configuration/ocm/v1/spec"
+	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+var Scheme = runtime.NewScheme()
+
+func init() {
+	if err := Register(Scheme); err != nil {
+		panic(err)
+	}
+}
+
+func Register(scheme *runtime.Scheme) error {
+	return scheme.RegisterSchemes(
+		genericspecv1.Scheme,
+		filesystemv1alpha1.Scheme,
+		extractv1alpha1.Scheme,
+		ocmv1.Scheme,
+	)
+}

--- a/bindings/go/configuration/scheme_test.go
+++ b/bindings/go/configuration/scheme_test.go
@@ -1,0 +1,15 @@
+package configuration_test
+
+import (
+	"testing"
+
+	"ocm.software/open-component-model/bindings/go/configuration"
+	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+func TestRegister(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := configuration.Register(s); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

- Implemented a global `Scheme` in the configuration package.
- Refactored `filesystem` configuration to use the global `Scheme`.
- Added a unified `Register` function for managing scheme registrations across sub-packages.
- Introduced tests to validate registration functionality.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

This enables a centralized management of runtime schemes and simplifies scheme integration in the codebase.
