### PR TITLE
feat(cli): support short-syntax referencing for archives

### DIFF
--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -469,6 +469,42 @@ resources:
 			r.NoError(err, "could not construct component version with working directory")
 		})
 	})
+
+	t.Run("archives", func(t *testing.T) {
+		tcs := []string{
+			".tar",
+			".tar.gz",
+		}
+		for _, tc := range tcs {
+			t.Run(tc, func(t *testing.T) {
+				tmp := t.TempDir()
+				constructorYAML = fmt.Sprintf(`
+name: ocm.software/examples-01
+version: 1.0.0
+provider:
+  name: ocm.software
+resources:
+  - name: my-file-replaced
+    type: blob
+    input:
+      type: utf8/v1
+      text: foobar
+`)
+
+				// Create a replacement test file to be added to the component version
+				constructorYAMLFilePath := filepath.Join(tmp, "component-constructor.yaml")
+				r.NoError(os.WriteFile(constructorYAMLFilePath, []byte(constructorYAML), 0o600))
+
+				_, err := test.OCM(t, test.WithArgs("add", "cv",
+					"--constructor", constructorYAMLFilePath,
+					"--repository", filepath.Join("transport-archive", tc),
+					"--working-directory", tmp,
+				), test.WithOutput(logs))
+
+				r.NoError(err, "could not construct component version with working directory")
+			})
+		}
+	})
 }
 
 func Test_Version(t *testing.T) {

--- a/cli/internal/reference/compref/compref.go
+++ b/cli/internal/reference/compref/compref.go
@@ -264,7 +264,7 @@ func GuessType(repository string) (string, error) {
 	}
 
 	// Contains domain-looking part (e.g., github.com, ghcr.io) → assume OCI
-	// Note: Avoids whitelisted "special" suffixes like ".tar"
+	// Note: Avoids allow-listed "special" suffixes like ".tar"
 	if looksLikeDomain(cleaned) {
 		return runtime.NewVersionedType(ociv1.Type, ociv1.Version).String(), nil
 	}
@@ -297,7 +297,7 @@ func looksLikeDomain(s string) bool {
 
 var allowListArchiveFilePathExtensions = []string{".tar", ".tgz", ".tar.gz"}
 
-// looksLikeArchive checks if the string ends with a whitelisted file extension
+// looksLikeArchive checks if the string ends with an allow-listed file extension
 // this makes it so that a path like "my.path.tar" is always considered an archive, and if it should
 // be interpreted as path, it needs to be passed explicitly
 func looksLikeArchive(s string) bool {

--- a/cli/internal/reference/compref/compref_test.go
+++ b/cli/internal/reference/compref/compref_test.go
@@ -247,6 +247,18 @@ func Test_ComponentReference(t *testing.T) {
 			},
 			err: assert.NoError,
 		},
+		{
+			input: "my/path/to/archive.tar.gz//ocm.software/ocmcli:0.23.0",
+			expected: &Ref{
+				Type: runtime.NewVersionedType(ctfv1.Type, ctfv1.Version).String(),
+				Repository: &ctfv1.Repository{
+					Path: "my/path/to/archive.tar.gz",
+				},
+				Component: "ocm.software/ocmcli",
+				Version:   "0.23.0",
+			},
+			err: assert.NoError,
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

- Added logic to recognize and exclude archive-like file paths (e.g., `.tar`, `.tgz`) from being incorrectly identified as domains.
- Introduced a utility function `looksLikeArchive` to validate archive paths against a set of whitelisted extensions (`.tar`, `.tgz`, `.tar.gz`).
- Extended test coverage to include cases involving archive paths.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This enhancement ensures that archive paths are appropriately handled in short-syntax references, improving the accuracy of path resolution.
