### PR TITLE
chore: add logging when a version is skipped to improve ux

### DIFF
--- a/bindings/go/oci/internal/lister/lister.go
+++ b/bindings/go/oci/internal/lister/lister.go
@@ -250,6 +250,7 @@ func listViaTags(ctx context.Context, lister registry.TagLister, opts TagListerO
 			wg.Go(func() error {
 				ver, err := opts.VersionResolver(ctx, tag)
 				if errors.Is(err, ErrSkip) {
+					slogcontext.FromCtx(ctx).With(slog.String("realm", "oci")).Log(ctx, slog.LevelDebug, "skipping tag", slog.String("tag", tag), slog.String("error", err.Error()))
 					return nil
 				}
 				if err != nil {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Fixes https://github.com/open-component-model/ocm-project/issues/593 because we decided that podinfo is an outlier and the issue will be closed regardless. However, improving debuggability helps a lot in figuring out _why_ a version was skipped from listing.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
