### PR TITLE
fix: manually update blob dependency to unblock monorepo job

### DIFF
--- a/bindings/go/input/dir/blob.go
+++ b/bindings/go/input/dir/blob.go
@@ -74,7 +74,7 @@ func packDirToTar(ctx context.Context, path string, opt *v1.Dir) (io.Reader, err
 
 	// Determine the base directory for relative paths in the tar archive.
 	baseDir := path
-	subDir := ""
+	subDir := "."
 	if opt.PreserveDir {
 		// PreserveDir defines that the directory specified in the path field should be included in the blob.
 		baseDir = filepath.Dir(path)

--- a/bindings/go/input/dir/go.mod
+++ b/bindings/go/input/dir/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.10.0
-	ocm.software/open-component-model/bindings/go/blob v0.0.8
+	ocm.software/open-component-model/bindings/go/blob v0.0.9
 	ocm.software/open-component-model/bindings/go/constructor v0.0.0-20250816122110-cde8f3437bb7
 	ocm.software/open-component-model/bindings/go/runtime v0.0.2
 )

--- a/bindings/go/input/dir/go.sum
+++ b/bindings/go/input/dir/go.sum
@@ -47,8 +47,8 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-ocm.software/open-component-model/bindings/go/blob v0.0.8 h1:PkIdubMbzXeKonRhd1LlwpDHfDZcSPUeYSJfQeSWiKs=
-ocm.software/open-component-model/bindings/go/blob v0.0.8/go.mod h1:BjErnbAzzY4mJ6cO/hIFj8Gf/v9zerkIQ1Y1XQEOB5M=
+ocm.software/open-component-model/bindings/go/blob v0.0.9 h1:XNK04PnqvsE6KHx/04mYrr2LiKtZk+b6i0rd28r6EGQ=
+ocm.software/open-component-model/bindings/go/blob v0.0.9/go.mod h1:BjErnbAzzY4mJ6cO/hIFj8Gf/v9zerkIQ1Y1XQEOB5M=
 ocm.software/open-component-model/bindings/go/constructor v0.0.0-20250816122110-cde8f3437bb7 h1:usO8Bjowdl3QYj8Yszlt/CHEGq2CanDe7Xq5aAHK0Is=
 ocm.software/open-component-model/bindings/go/constructor v0.0.0-20250816122110-cde8f3437bb7/go.mod h1:sA2FF1jvCOE4oG4ox/Fvg+mAJ8jJIEHCcEVYwbPyJHQ=
 ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20250816122110-cde8f3437bb7 h1:jc6hTeC5yfWpBLqL4HQ63WG3gnFDqOOK6+k1lnI14y8=


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Currently, the monorepo upgrade job is blocked because of a test failure in the dir input methods. This PR resolves the test failure and manually upgrades the blob dependency of the dir input method to work towards unblocking the monorepo upgrade job.

This is the change in the blob module that broke the current behaviour:
```
- func (s *osFileSystem) ReadDir(name string) ([]fs.DirEntry, error) {
-	return os.ReadDir(filepath.Join(s.base, name))
+ func (s *RootFileSystem) ReadDir(name string) ([]fs.DirEntry, error) {
+	return s.root.FS().(fs.ReadDirFS).ReadDir(name)
```

With the original variant, `name == ""` resulted in a valid path due to `filepath.Join(s.base, name)`. With the new variant, we call `rootFS.ReadDir(name)` which internally calls `fs.ValidPath(name)`. `fs.ValidPath(name)` has the following documentation:

> ...
> // Path names passed to open are UTF-8-encoded,
> // unrooted, slash-separated sequences of path elements, like “x/y/z”.
> // **Path names must not contain an element that is “.” or “..” or the empty string,**
> // **except for the special case that the name "." may be used for the root directory**.
> // Paths must not start or end with a slash: “/x” and “x/” are invalid.
> ...

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
