### PR TITLE
fix(ci): streamline docker build and push process for multi-architecture support

### DIFF
--- a/.github/workflows/kubernetes-controller.yml
+++ b/.github/workflows/kubernetes-controller.yml
@@ -97,7 +97,5 @@ jobs:
           registry: ghcr.io
           username: ocmbot[ocm]
           password: ${{ steps.generate_token.outputs.token }}
-      - name: Build
-        run: task kubernetes/controller:docker-buildx
-      - name: Push
-        run: task kubernetes/controller:docker-push
+      - name: Build & Push
+        run: task kubernetes/controller:docker-build/multi-arch PUSH=true

--- a/kubernetes/controller/Dockerfile
+++ b/kubernetes/controller/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25@sha256:5502b0e56fca23feba76dbc5387ba59c593c02ccc2f0f7355871ea9a0852cebe AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.25@sha256:5502b0e56fca23feba76dbc5387ba59c593c02ccc2f0f7355871ea9a0852cebe AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/kubernetes/controller/Taskfile.yml
+++ b/kubernetes/controller/Taskfile.yml
@@ -48,7 +48,11 @@ tasks:
 
 
   test/e2e/setup/local:
-    deps: [ docker-build ]
+    deps:
+      # We depend on a locally built image, so we need to load that into the local machine.
+      - task: docker-build
+        vars:
+          LOAD: "true"
     cmds:
       - 'bash test/e2e/hacks/setup.sh'
       - 'kind load docker-image {{.CONTROLLER_IMG}}'
@@ -72,21 +76,43 @@ tasks:
     deps: [manifests, generate, fmt, vet]
     cmd: 'go run {{.TASKFILE_DIR}}/cmd/main.go'
 
+
+  # Always build only for the host architecture.
+  # We force "linux" OS because all Docker base images are Linux,
+  # and derive the arch dynamically from the host Go toolchain.
   docker-build:
     cmd:
-      task: docker-buildx
+      task: docker-build/multi-arch
       vars:
         PLATFORMS:
           sh: 'echo "linux/$(go env GOARCH)"'
 
-  docker-push:
-    cmd: '{{.CONTAINER_TOOL}} push {{.CONTROLLER_IMG}}'
 
-  docker-buildx:
-    cmds:
-      - sed '1s|^FROM|FROM --platform=${BUILDPLATFORM}|' Dockerfile > Dockerfile.cross
-      - '{{.CONTAINER_TOOL}} buildx build --load --platform={{.PLATFORMS}} -t {{.CONTROLLER_IMG}} -f Dockerfile.cross .'
-      - rm Dockerfile.cross
+  # Multi-arch capable build task.
+  # In this setup it is used only with a single platform (the local arch),
+  # but it still supports --push / --load flags if desired.
+  docker-build/multi-arch:
+    requires:
+      vars: [ PLATFORMS, CONTROLLER_IMG ]
+    cmd: |
+      args=(
+        --platform={{.PLATFORMS}}
+        -t {{.CONTROLLER_IMG}}
+        -f {{.TASKFILE_DIR}}/Dockerfile {{.TASKFILE_DIR}}
+      )
+      
+      # If LOAD is set, load single-arch image into local daemon
+      if [ "{{.LOAD | default ""}}" = "true" ]; then
+        args+=(--load)
+      fi
+      
+      # If PUSH is set, push image (or manifest) to registry
+      if [ "{{.PUSH | default ""}}" = "true" ]; then
+        args+=(--push)
+      fi
+
+      # Run docker (or podman) buildx with the constructed args
+      {{.CONTAINER_TOOL}} buildx build "${args[@]}"
 
   build-installer:
     deps: [manifests, generate, kustomize]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

When we push our image, which is multi-arch, we cannot use a "loaded" version from the docker daemon we use for e2e testing, because that doesn't support multi-arch. That means we need to push directly from the builder instance instead of loading it first.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/open-component-model/open-component-model/actions/runs/17262857226/job/48988854136