### PR TITLE
chore: attempt multi-arch-fix

### DIFF
--- a/.github/workflows/kubernetes-controller.yml
+++ b/.github/workflows/kubernetes-controller.yml
@@ -89,8 +89,8 @@ jobs:
             kubernetes/controller
             .github/workflows/kubernetes-controller.yml
             Taskfile.yml
-      - name: Set up docker
-        uses: docker/setup-docker-action@b60f85385d03ac8acfca6d9996982511d8620a19 # v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Docker Login
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

makes sure that instead of regular docker we use buildx which supports multi-arch envs

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

fix https://github.com/open-component-model/open-component-model/actions/runs/17266023272/job/48998912995