### PR TITLE
chore: add dispatch trigger to k8s workflow

### DIFF
--- a/.github/workflows/kubernetes-controller.yml
+++ b/.github/workflows/kubernetes-controller.yml
@@ -1,5 +1,6 @@
 name: Kubernetes Controller
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

adds a manual dispatch trigger in case we want to run k8s controller workflows again without the controller having changed

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
