### PR TITLE
chore: add support for repository-specific Renovate environment variable

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -24,6 +24,7 @@ jobs:
         uses: renovatebot/github-action@13da59cf7cfbd3bfea72ce26752ed22edf747ce9 # v43.0.2
         env:
           RENOVATE_PLATFORM_COMMIT: 'true'
+          RENOVATE_REPOSITORIES: "${{ github.repository }}"
         with:
           configurationFile: .github/config/renovate.json5
           token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
#### What this PR does / why we need it

- Introduced `RENOVATE_REPOSITORIES` variable to `renovate.yml`.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

- Properly triggers renovate
