### PR TITLE
chore: group k8s dependencies together

### DIFF
--- a/.github/workflows/kubernetes-controller.yml
+++ b/.github/workflows/kubernetes-controller.yml
@@ -7,12 +7,14 @@ on:
     paths:
       - kubernetes/controller/**/*
       - .github/workflows/kubernetes-controller.yml
+      - .env
   pull_request:
     branches:
       - main
     paths:
       - kubernetes/controller/**/*
       - .github/workflows/kubernetes-controller.yml
+      - .env
 
 permissions:
   contents: read # for actions/checkout to fetch code

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -24,6 +24,7 @@ jobs:
         uses: renovatebot/github-action@13da59cf7cfbd3bfea72ce26752ed22edf747ce9 # v43.0.2
         env:
           RENOVATE_PLATFORM_COMMIT: 'true'
+          RENOVATE_REPOSITORIES: "${{ github.repository }}"
         with:
           configurationFile: .github/config/renovate.json5
           token: ${{ steps.generate_token.outputs.token }}

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,7 +3,6 @@
   extends: [
     "config:recommended",
     "config:best-practices",
-    "default:automergeDigest",
     "docker:pinDigests",
     "group:kubernetes",
     "group:goOpenapi",
@@ -20,6 +19,20 @@
     GOPRIVATE: "ocm.software/open-component-model"
   },
   packageRules: [
+    {
+      "matchManagers": [
+        "gomod",
+        "regex"
+      ],
+      "matchPackageNames": [
+        "sigs.k8s.io/controller-runtime",
+        "sigs.k8s.io/controller-tools",
+        "k8s.io/*",
+        "envtest"
+      ],
+      "groupName": "Kubernetes dependencies",
+      "groupSlug": "kubernetes-deps"
+    },
     {
       "matchCategories": [
         "golang"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

groups all kubernetes dependencies to create a slug PR for every k8s dep

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
