### PR TITLE
chore: update `DEEPCOPY_GEN_VERSION` datasource

### DIFF
--- a/.env
+++ b/.env
@@ -7,7 +7,7 @@ TASK_X_ENV_PRECEDENCE=1
 # renovate: datasource=github-releases depName=golangci/golangci-lint
 GOLANGCI_LINT_VERSION=v2.4.0
 
-# renovate: datasource=go depName=sigs.k8s.io/controller-tools
+# renovate: datasource=go depName=k8s.io/code-generator
 DEEPCOPY_GEN_VERSION=v0.32.3
 
 # renovate: datasource=go depName=sigs.k8s.io/controller-tools


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it


- Updated the Renovate datasource for `DEEPCOPY_GEN_VERSION` in `.env` from `sigs.k8s.io/controller-tools` to `k8s.io/code-generator`.
- Aligns the dependency configuration with the correct module to avoid potential mismatches during updates.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
