### PR TITLE
feat(dag)!: introduce dag processing logic

### DIFF
--- a/bindings/go/dag/sync/conversion_test.go
+++ b/bindings/go/dag/sync/conversion_test.go
@@ -21,9 +21,9 @@ func TestMapToSynced(t *testing.T) {
 	r.NoError(mapBasedDAG.AddEdge("B", "C", map[string]any{"key": "2"}))
 
 	syncMapBasedDAG := NewDirectedAcyclicGraph[string]()
-	r.NoError(syncMapBasedDAG.addRawVertex(NewVertex("A", map[string]any{"key": "1"})))
-	r.NoError(syncMapBasedDAG.addRawVertex(NewVertex("B", map[string]any{"key": "2"})))
-	r.NoError(syncMapBasedDAG.addRawVertex(NewVertex("C", map[string]any{"key": "3"})))
+	r.NoError(syncMapBasedDAG.AddVertex("A", map[string]any{"key": "1"}))
+	r.NoError(syncMapBasedDAG.AddVertex("B", map[string]any{"key": "2"}))
+	r.NoError(syncMapBasedDAG.AddVertex("C", map[string]any{"key": "3"}))
 
 	r.NoError(syncMapBasedDAG.AddEdge("A", "B", map[string]any{"key": "1"}))
 	r.NoError(syncMapBasedDAG.AddEdge("B", "C", map[string]any{"key": "2"}))

--- a/bindings/go/dag/sync/dag.go
+++ b/bindings/go/dag/sync/dag.go
@@ -125,17 +125,13 @@ func (d *DirectedAcyclicGraph[T]) Clone() *DirectedAcyclicGraph[T] {
 
 // AddVertex adds a new node to the graph.
 func (d *DirectedAcyclicGraph[T]) AddVertex(id T, attributes ...map[string]any) error {
+	if _, exists := d.Vertices.Load(id); exists {
+		return fmt.Errorf("node %v already exists: %w", id, ErrAlreadyExists)
+	}
 	vertex := &Vertex[T]{
 		ID:         id,
 		Attributes: &sync.Map{},
 		Edges:      &sync.Map{},
-	}
-	return d.addRawVertex(vertex, attributes...)
-}
-
-func (d *DirectedAcyclicGraph[T]) addRawVertex(vertex *Vertex[T], attributes ...map[string]any) error {
-	if _, exists := d.Vertices.Load(vertex.ID); exists {
-		return fmt.Errorf("node %v already exists: %w", vertex.ID, ErrAlreadyExists)
 	}
 	for _, attrs := range attributes {
 		for k, v := range attrs {
@@ -478,21 +474,6 @@ type Vertex[T cmp.Ordered] struct {
 	// Edges stores the IDs of the nodes that this node has an outgoing edge to,
 	// as well as any attributes associated with that edge.
 	Edges *sync.Map // map[T]*sync.Map with map[string]any (attributes)
-}
-
-// NewVertex creates a new vertex with the given ID and optional attributes.
-func NewVertex[T cmp.Ordered](id T, attributes ...map[string]any) *Vertex[T] {
-	v := &Vertex[T]{
-		ID:         id,
-		Attributes: &sync.Map{},
-		Edges:      &sync.Map{},
-	}
-	for _, attrs := range attributes {
-		for key, value := range attrs {
-			v.Attributes.Store(key, value)
-		}
-	}
-	return v
 }
 
 func (v *Vertex[T]) Clone() *Vertex[T] {

--- a/bindings/go/dag/sync/dag.go
+++ b/bindings/go/dag/sync/dag.go
@@ -427,6 +427,8 @@ func (d *DirectedAcyclicGraph[T]) Reverse() (*DirectedAcyclicGraph[T], error) {
 	reverse := NewDirectedAcyclicGraph[T]()
 
 	// Ensure all vertices exist in the new graph
+	// We cannot use vertex.Clone here. vertex.Clone also copies the edges.
+	// But for reversing the graph, the edges have to be inverted.
 	d.Vertices.Range(func(key, value any) bool {
 		origVertex := value.(*Vertex[T])
 		attrs := make(map[string]any)

--- a/bindings/go/dag/sync/discover.go
+++ b/bindings/go/dag/sync/discover.go
@@ -111,7 +111,13 @@ func (d *DirectedAcyclicGraph[T]) Discover(
 	ctx context.Context,
 	discoverer NeighborDiscoverer[T],
 	opts ...DiscoverOption[T],
-) error {
+) (retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("discovery panicked: %v", r))
+		}
+	}()
+
 	options := &DiscoverOptions[T]{}
 	for _, opt := range opts {
 		opt(options)

--- a/bindings/go/dag/sync/discover.go
+++ b/bindings/go/dag/sync/discover.go
@@ -61,7 +61,7 @@ type DiscoverOptions[T cmp.Ordered] struct {
 
 type DiscoverOption[T cmp.Ordered] func(*DiscoverOptions[T])
 
-func WithGoRoutineLimit[T cmp.Ordered](numGoRoutines int) DiscoverOption[T] {
+func WithDiscoveryGoRoutineLimit[T cmp.Ordered](numGoRoutines int) DiscoverOption[T] {
 	return func(options *DiscoverOptions[T]) {
 		options.GoRoutineLimit = numGoRoutines
 	}

--- a/bindings/go/dag/sync/discover_test.go
+++ b/bindings/go/dag/sync/discover_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDAGTraverse(t *testing.T) {
+func TestDAGDiscovery(t *testing.T) {
 	ctx := t.Context()
 	r := require.New(t)
 
-	t.Run("graph traversal succeeds", func(t *testing.T) {
+	t.Run("graph discovery succeeds", func(t *testing.T) {
 		// Emulate external dependency graph.
 		// In real-world scenarios, this information would likely be retrieved from
 		// an API (such as an OCM Repository).
@@ -24,7 +24,7 @@ func TestDAGTraverse(t *testing.T) {
 		}
 
 		dag := NewDirectedAcyclicGraph[string]()
-		traverseFunc := func(ctx context.Context, v string) ([]string, error) {
+		discoverFunc := func(ctx context.Context, v string) ([]string, error) {
 			// Simulate fetching dependencies from an external graph.
 			// In a real-world scenario, this would likely be an API call (such
 			// as OCM GetComponentVersion)
@@ -38,8 +38,8 @@ func TestDAGTraverse(t *testing.T) {
 			}
 			return neighbors, nil
 		}
-		// Start the traversal from multiple roots
-		r.NoError(dag.Traverse(ctx, DiscoverNeighborsFunc[string](traverseFunc), WithRoots[string]("A", "B", "C", "D")))
+		// Start the discovery from multiple roots
+		r.NoError(dag.Discover(ctx, DiscoverNeighborsFunc[string](discoverFunc), WithRoots[string]("A", "B", "C", "D")))
 
 		// Check if the graph structure is as expected
 		r.ElementsMatchf(dag.MustGetVertex("A").EdgeKeys(), []string{"B", "C"}, "expected edges from A to B and C, but got %v", dag.MustGetVertex("A").EdgeKeys())
@@ -47,26 +47,26 @@ func TestDAGTraverse(t *testing.T) {
 		r.ElementsMatchf(dag.MustGetVertex("C").EdgeKeys(), []string{"D"}, "expected edge from C to D, but got %v", dag.MustGetVertex("C").EdgeKeys())
 		r.ElementsMatchf(dag.MustGetVertex("D").EdgeKeys(), []string{}, "expected no edges from D, but got %v", dag.MustGetVertex("D").EdgeKeys())
 
-		// As Traverse uses addRawVertex and AddEdge internally, which are unit tested
+		// As Discover uses addRawVertex and AddEdge internally, which are unit tested
 		// separately, we can assume out degree and in degree are correct if the
 		// graph structure is correct.
 	})
 
-	t.Run("graph traversal fails with canceled context", func(t *testing.T) {
+	t.Run("graph discovery fails with canceled context", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		// Simulate a context cancellation
 		cancel()
 
 		dag := NewDirectedAcyclicGraph[string]()
-		traverseFunc := func(ctx context.Context, v string) ([]string, error) {
+		discoveryFunc := func(ctx context.Context, v string) ([]string, error) {
 			return nil, fmt.Errorf("we should never reach this point due to context cancellation")
 		}
 
-		err := dag.Traverse(ctx, DiscoverNeighborsFunc[string](traverseFunc), WithRoots("A"))
+		err := dag.Discover(ctx, DiscoverNeighborsFunc[string](discoveryFunc), WithRoots("A"))
 		r.ErrorIsf(err, context.Canceled, "expected error due to context cancellation, but got nil")
 	})
 
-	t.Run("graph traversal fails in traversal function", func(t *testing.T) {
+	t.Run("graph discovery fails in discovery function", func(t *testing.T) {
 		// Emulate an invalid external dependency graph. Here, the edge C -> D
 		// exists, but D is not found in the graph.
 		graph := map[string][]string{
@@ -75,7 +75,7 @@ func TestDAGTraverse(t *testing.T) {
 			"C": {"D"},
 		}
 		dag := NewDirectedAcyclicGraph[string]()
-		traverseFunc := func(ctx context.Context, v string) ([]string, error) {
+		discoveryFunc := func(ctx context.Context, v string) ([]string, error) {
 			// Simulate fetching dependencies from an external graph.
 			// In a real-world scenario, this would likely be an API call (such
 			// as OCM GetComponentVersion)
@@ -90,11 +90,11 @@ func TestDAGTraverse(t *testing.T) {
 			return neighbors, nil
 		}
 
-		err := dag.Traverse(ctx, DiscoverNeighborsFunc[string](traverseFunc), WithRoots("A"), WithGoRoutineLimit[string](1))
+		err := dag.Discover(ctx, DiscoverNeighborsFunc[string](discoveryFunc), WithRoots("A"), WithGoRoutineLimit[string](1))
 		r.Error(err, "expected error due to missing node in the external graph, but got nil")
 
-		r.Equal(dag.MustGetVertex("A").MustGetAttribute(AttributeTraversalState), StateError, "expected vertex A to be in error state, but got %s", dag.MustGetVertex("A").MustGetAttribute(AttributeTraversalState))
-		r.Equal(dag.MustGetVertex("B").MustGetAttribute(AttributeTraversalState), StateCompleted, "expected vertex B to be in completed state, but got %s", dag.MustGetVertex("B").MustGetAttribute(AttributeTraversalState))
-		r.Equal(dag.MustGetVertex("C").MustGetAttribute(AttributeTraversalState), StateError, "expected vertex C to be in error state, but got %s", dag.MustGetVertex("C").MustGetAttribute(AttributeTraversalState))
+		r.Equal(dag.MustGetVertex("A").MustGetAttribute(AttributeDiscoveryState), StateError, "expected vertex A to be in error state, but got %s", dag.MustGetVertex("A").MustGetAttribute(AttributeDiscoveryState))
+		r.Equal(dag.MustGetVertex("B").MustGetAttribute(AttributeDiscoveryState), StateCompleted, "expected vertex B to be in completed state, but got %s", dag.MustGetVertex("B").MustGetAttribute(AttributeDiscoveryState))
+		r.Equal(dag.MustGetVertex("C").MustGetAttribute(AttributeDiscoveryState), StateError, "expected vertex C to be in error state, but got %s", dag.MustGetVertex("C").MustGetAttribute(AttributeDiscoveryState))
 	})
 }

--- a/bindings/go/dag/sync/discover_test.go
+++ b/bindings/go/dag/sync/discover_test.go
@@ -90,7 +90,7 @@ func TestDAGDiscovery(t *testing.T) {
 			return neighbors, nil
 		}
 
-		err := dag.Discover(ctx, DiscoverNeighborsFunc[string](discoveryFunc), WithRoots("A"), WithGoRoutineLimit[string](1))
+		err := dag.Discover(ctx, DiscoverNeighborsFunc[string](discoveryFunc), WithRoots("A"), WithDiscoveryGoRoutineLimit[string](1))
 		r.Error(err, "expected error due to missing node in the external graph, but got nil")
 
 		r.Equal(dag.MustGetVertex("A").MustGetAttribute(AttributeDiscoveryState), StateError, "expected vertex A to be in error state, but got %s", dag.MustGetVertex("A").MustGetAttribute(AttributeDiscoveryState))

--- a/bindings/go/dag/sync/discover_test.go
+++ b/bindings/go/dag/sync/discover_test.go
@@ -93,8 +93,8 @@ func TestDAGDiscovery(t *testing.T) {
 		err := dag.Discover(ctx, DiscoverNeighborsFunc[string](discoveryFunc), WithRoots("A"), WithDiscoveryGoRoutineLimit[string](1))
 		r.Error(err, "expected error due to missing node in the external graph, but got nil")
 
-		r.Equal(dag.MustGetVertex("A").MustGetAttribute(AttributeDiscoveryState), StateError, "expected vertex A to be in error state, but got %s", dag.MustGetVertex("A").MustGetAttribute(AttributeDiscoveryState))
-		r.Equal(dag.MustGetVertex("B").MustGetAttribute(AttributeDiscoveryState), StateCompleted, "expected vertex B to be in completed state, but got %s", dag.MustGetVertex("B").MustGetAttribute(AttributeDiscoveryState))
-		r.Equal(dag.MustGetVertex("C").MustGetAttribute(AttributeDiscoveryState), StateError, "expected vertex C to be in error state, but got %s", dag.MustGetVertex("C").MustGetAttribute(AttributeDiscoveryState))
+		r.Equal(dag.MustGetVertex("A").MustGetAttribute(AttributeDiscoveryState), DiscoveryStateError, "expected vertex A to be in error state, but got %s", dag.MustGetVertex("A").MustGetAttribute(AttributeDiscoveryState))
+		r.Equal(dag.MustGetVertex("B").MustGetAttribute(AttributeDiscoveryState), DiscoveryStateCompleted, "expected vertex B to be in completed state, but got %s", dag.MustGetVertex("B").MustGetAttribute(AttributeDiscoveryState))
+		r.Equal(dag.MustGetVertex("C").MustGetAttribute(AttributeDiscoveryState), DiscoveryStateError, "expected vertex C to be in error state, but got %s", dag.MustGetVertex("C").MustGetAttribute(AttributeDiscoveryState))
 	})
 }

--- a/bindings/go/dag/sync/process.go
+++ b/bindings/go/dag/sync/process.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"runtime"
 	"sync"
@@ -97,7 +98,12 @@ func (d *DirectedAcyclicGraph[T]) ProcessTopology(
 	ctx context.Context,
 	processor VertexProcessor[T],
 	opts ...ProcessTopologyOption,
-) error {
+) (retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("discovery panicked: %v", r))
+		}
+	}()
 	if d.LengthVertices() == 0 {
 		return nil
 	}
@@ -189,67 +195,54 @@ func (d *DirectedAcyclicGraph[T]) processLayer(
 ) ([]T, error) {
 	errGroup, ctx := errgroup.WithContext(ctx)
 	errGroup.SetLimit(opts.GoRoutineLimit)
-	// Calculate the upper bound for the next queue channel
-	// this determines how many ids can be processed concurrently in the next
+
+	// wrap this logic into a function to ensure the nextQueueCh is closed
+	for _, id := range ids {
+		errGroup.Go(func() error {
+			// Mark the id as processed or return if already processed.
+			if _, loaded := doneMap.LoadOrStore(id, true); loaded {
+				return nil
+			}
+
+			// Adding the attribute is done on the original dag (d) instead
+			// of on the topology - which is a clone of d - that is modified
+			// during ProcessTopology to perform the topological traversal.
+			d.MustGetVertex(id).Attributes.Store(AttributeProcessingState, ProcessingStateProcessing)
+			if err := processor.ProcessVertex(ctx, id); err != nil {
+				d.MustGetVertex(id).Attributes.Store(AttributeProcessingState, ProcessingStateError)
+				return fmt.Errorf("failed to process vertex with id %v: %w", id, err)
+			}
+			d.MustGetVertex(id).Attributes.Store(AttributeProcessingState, ProcessingStateCompleted)
+			return nil
+		})
+	}
+	if err := errGroup.Wait(); err != nil {
+		return nil, fmt.Errorf("failed to process vertices: %w", err)
+	}
+
+	// Calculate the upper bound for the next slice.
+	// This determines how many ids can be processed concurrently in the next
 	// phase
 	upperBound := 0
 	for _, id := range ids {
 		upperBound += topology.MustGetOutDegree(id)
 	}
-
-	// wrap this logic into a function to ensure the nextQueueCh is closed
-	f := func(nextQueueCh chan T) error {
-		defer close(nextQueueCh)
-
-		for _, id := range ids {
-			errGroup.Go(func() error {
-				// Mark the id as processed or return if already processed.
-				if _, loaded := doneMap.LoadOrStore(id, true); loaded {
-					return nil
-				}
-
-				// Adding the attribute is done on the original dag (d) instead
-				// of on the topology - which is a clone of d - that is modified
-				// during ProcessTopology to perform the topological traversal.
-				d.MustGetVertex(id).Attributes.Store(AttributeProcessingState, ProcessingStateProcessing)
-				if err := processor.ProcessVertex(ctx, id); err != nil {
-					d.MustGetVertex(id).Attributes.Store(AttributeProcessingState, ProcessingStateError)
-					return fmt.Errorf("failed to process vertex with id %v: %w", id, err)
-				}
-				d.MustGetVertex(id).Attributes.Store(AttributeProcessingState, ProcessingStateCompleted)
-
-				vertex := topology.MustGetVertex(id)
-				for _, child := range vertex.EdgeKeys() {
-					inDegree := topology.MustGetInDegree(child)
-					topology.InDegree.Store(child, inDegree-1)
-					vertex.Edges.Delete(child)
-					// If all parents of the child have been processed and the
-					// child has not been enqueued yet, add it to the next layer.
-					if topology.MustGetInDegree(child) == 0 {
-						d.MustGetVertex(child).Attributes.Store(AttributeProcessingState, ProcessingStateQueued)
-						nextQueueCh <- child
-					}
-				}
-				topology.Vertices.Delete(id)
-				return nil
-			})
+	next := make([]T, 0, upperBound)
+	for _, id := range ids {
+		vertex := topology.MustGetVertex(id)
+		for _, child := range vertex.EdgeKeys() {
+			inDegree := topology.MustGetInDegree(child)
+			topology.InDegree.Store(child, inDegree-1)
+			vertex.Edges.Delete(child)
+			// If all parents of the child have been processed and the
+			// child has not been enqueued yet, add it to the next layer.
+			if topology.MustGetInDegree(child) == 0 {
+				d.MustGetVertex(child).Attributes.Store(AttributeProcessingState, ProcessingStateQueued)
+				next = append(next, child)
+			}
 		}
-
-		if err := errGroup.Wait(); err != nil {
-			return fmt.Errorf("failed to process vertices: %w", err)
-		}
-		return nil
+		topology.Vertices.Delete(id)
 	}
 
-	nextQueueCh := make(chan T, upperBound)
-	if err := f(nextQueueCh); err != nil {
-		return nil, err
-	}
-
-	// Collect ids that are ready for the next round.
-	next := make([]T, 0, len(nextQueueCh))
-	for n := range nextQueueCh {
-		next = append(next, n)
-	}
 	return next, nil
 }

--- a/bindings/go/dag/sync/process.go
+++ b/bindings/go/dag/sync/process.go
@@ -1,0 +1,150 @@
+package sync
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// ProcessTopology performs topological sorting and transfers objects in order
+func (d *DirectedAcyclicGraph[T]) ProcessTopology(ctx context.Context, processor VertexProcessor[T]) error {
+	if d.LengthVertices() == 0 {
+		return nil
+	}
+	topology := d.Clone()
+
+	// Collect all Children nodes that are end leafs
+	roots := topology.Roots()
+
+	// A map to track doneMap nodes
+	doneMap := &sync.Map{}
+
+	// Process nodes concurrently
+	if err := topology.processObjectsByTopology(ctx, d, roots, processor, doneMap); err != nil {
+		return err
+	}
+
+	if topology.LengthVertices() > 0 {
+		return fmt.Errorf("failed to process all objects, remaining: %v", topology.Vertices)
+	}
+
+	return nil
+}
+
+// ProcessTopology performs topological sorting and transfers objects in order
+func (d *DirectedAcyclicGraph[T]) ProcessReverseTopology(ctx context.Context, processor VertexProcessor[T]) error {
+	if d.LengthVertices() == 0 {
+		return nil
+	}
+	topology := d.Clone()
+	topology, err := topology.Reverse()
+	if err != nil {
+		return fmt.Errorf("failed to reverse graph: %w", err)
+	}
+
+	// Collect all Children nodes that are end leafs
+	roots := topology.Roots()
+
+	// A map to track doneMap nodes
+	doneMap := &sync.Map{}
+
+	// Process nodes concurrently
+	if err := topology.processObjectsByTopology(ctx, d, roots, processor, doneMap); err != nil {
+		return err
+	}
+
+	if topology.LengthVertices() > 0 {
+		return fmt.Errorf("failed to process all objects, remaining: %v", topology.Vertices)
+	}
+
+	return nil
+}
+
+type VertexProcessor[T cmp.Ordered] interface {
+	ProcessVertex(ctx context.Context, vertex *Vertex[T]) error
+}
+
+type VertexProcessorFunc[T cmp.Ordered] func(ctx context.Context, vertex *Vertex[T]) error
+
+func (f VertexProcessorFunc[T]) ProcessVertex(ctx context.Context, vertex *Vertex[T]) error {
+	return f(ctx, vertex)
+}
+
+// processObjectsByTopology processes nodes in any topological order defined by the topology given through the graph.
+// and handles dependencies
+func (d *DirectedAcyclicGraph[T]) processObjectsByTopology(
+	ctx context.Context,
+	dag *DirectedAcyclicGraph[T],
+	ids []T, // a list of root nodes to start processing with
+	processor VertexProcessor[T], // the processing function
+	doneMap *sync.Map, // a map to track loaded nodes
+) error {
+	errGroup, ctx := errgroup.WithContext(ctx)
+
+	// Calculate the upper bound for the next queue channel
+	// this determines how many ids can be processed concurrently in the next phase
+	upperBound := 0
+	for _, id := range ids {
+		upperBound += d.MustGetOutDegree(id)
+	}
+
+	nextQueueCh := make(chan T, upperBound)
+
+	for _, id := range ids {
+		errGroup.Go(func() error {
+			// Mark the id as processed or return if already processed
+			_, loaded := doneMap.LoadOrStore(id, true)
+			if loaded {
+				return nil
+			}
+
+			// While the traversal logic should operate on a copy of the graph
+			// with a processing order specific topology, the processing of the
+			// vertex should be done on the original graph.
+			vertex := dag.MustGetVertex(id)
+
+			if err := processor.ProcessVertex(ctx, vertex); err != nil {
+				return fmt.Errorf("failed to process vertex with id %v: %w", vertex.ID, err)
+			}
+
+			vertex = d.MustGetVertex(id)
+			for _, parent := range vertex.EdgeKeys() {
+				inDegree := d.MustGetInDegree(parent)
+				d.InDegree.Store(parent, inDegree-1)
+				parentVertex := d.MustGetVertex(parent)
+				parentVertex.Edges.Delete(id)
+				// If all prerequisites (children) of the parent have been processed and
+				// the parent has not been enqueued yet, add it to the next level.
+				if d.MustGetInDegree(parent) == 0 {
+					nextQueueCh <- parent
+				}
+			}
+			d.Vertices.Delete(id)
+			return nil
+		})
+	}
+
+	if err := errGroup.Wait(); err != nil {
+		return err
+	}
+
+	close(nextQueueCh)
+
+	// Collect ids that are ready for the next round.
+	var next []T
+	for n := range nextQueueCh {
+		next = append(next, n)
+	}
+
+	// Recursively process the next batch if available.
+	if len(next) > 0 {
+		if err := d.processObjectsByTopology(ctx, dag, next, processor, doneMap); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/bindings/go/dag/sync/process.go
+++ b/bindings/go/dag/sync/process.go
@@ -204,8 +204,7 @@ func (d *DirectedAcyclicGraph[T]) processLayer(
 		for _, id := range ids {
 			errGroup.Go(func() error {
 				// Mark the id as processed or return if already processed.
-				_, loaded := doneMap.LoadOrStore(id, true)
-				if loaded {
+				if _, loaded := doneMap.LoadOrStore(id, true); loaded {
 					return nil
 				}
 
@@ -220,8 +219,6 @@ func (d *DirectedAcyclicGraph[T]) processLayer(
 				d.MustGetVertex(id).Attributes.Store(AttributeProcessingState, ProcessingStateCompleted)
 
 				vertex := topology.MustGetVertex(id)
-				mapgraph := ToMapBasedDAG(topology)
-				_ = mapgraph
 				for _, child := range vertex.EdgeKeys() {
 					inDegree := topology.MustGetInDegree(child)
 					topology.InDegree.Store(child, inDegree-1)
@@ -233,8 +230,6 @@ func (d *DirectedAcyclicGraph[T]) processLayer(
 						nextQueueCh <- child
 					}
 				}
-				mapgraph = ToMapBasedDAG(topology)
-				_ = mapgraph
 				topology.Vertices.Delete(id)
 				return nil
 			})

--- a/bindings/go/dag/sync/process.go
+++ b/bindings/go/dag/sync/process.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"runtime"
 	"sync"
 
 	"golang.org/x/sync/errgroup"
@@ -78,7 +79,19 @@ func (d *DirectedAcyclicGraph[T]) ProcessTopology(ctx context.Context, processor
 // have been processed.
 //
 // For a more thorough explanation of topological order, see ProcessTopology.
-func (d *DirectedAcyclicGraph[T]) ProcessReverseTopology(ctx context.Context, processor VertexProcessor[T]) error {
+func (d *DirectedAcyclicGraph[T]) ProcessReverseTopology(
+	ctx context.Context,
+	processor VertexProcessor[T],
+	opts ...ProcessTopologyOption,
+) error {
+	options := &ProcessTopologyOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+	if options.GoRoutineLimit <= 0 {
+		options.GoRoutineLimit = runtime.NumCPU()
+	}
+
 	if d.LengthVertices() == 0 {
 		return nil
 	}

--- a/bindings/go/dag/sync/process.go
+++ b/bindings/go/dag/sync/process.go
@@ -10,6 +10,39 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// ProcessingState is an attribute set during ProcessTopology and
+// ProcessReverseTopology on each vertex to indicate its processing state
+type ProcessingState int
+
+func (s ProcessingState) String() string {
+	switch s {
+	case ProcessingStateQueued:
+		return "queued"
+	case ProcessingStateProcessing:
+		return "processing"
+	case ProcessingStateCompleted:
+		return "completed"
+	case ProcessingStateError:
+		return "error"
+	default:
+		return fmt.Sprintf("unknown(%d)", s)
+	}
+}
+
+const (
+	AttributeProcessingState = "dag/processing-state"
+
+	// ProcessingStateQueued indicates the vertex has been queued for processing.
+	// So, all its parents have been processed.
+	ProcessingStateQueued = iota
+	// ProcessingStateProcessing indicates the vertex is currently being processed.
+	ProcessingStateProcessing
+	// ProcessingStateCompleted indicates the vertex has been processed.
+	ProcessingStateCompleted
+	// ProcessingStateError indicates processing the vertex returned an error.
+	ProcessingStateError
+)
+
 type ProcessTopologyOptions struct {
 	// MaxGoroutines limits the number of concurrent goroutines processing
 	// vertices. If 0, it defaults to the number of CPUs.
@@ -47,6 +80,8 @@ func WithProcessGoRoutineLimit(limit int) ProcessTopologyOption {
 // processed, both B and C are processed concurrently. D and E will
 // be processed only after both B and C have been processed - even though E is
 // independent of B.
+//
+// ProcessVertex is guaranteed to be called for each vertex only once.
 func (d *DirectedAcyclicGraph[T]) ProcessTopology(
 	ctx context.Context,
 	processor VertexProcessor[T],
@@ -67,12 +102,15 @@ func (d *DirectedAcyclicGraph[T]) ProcessTopology(
 
 	// Collect all Children nodes that are end leafs
 	roots := topology.Roots()
+	for _, r := range roots {
+		d.MustGetVertex(r).Attributes.Store(AttributeProcessingState, ProcessingStateQueued)
+	}
 
 	// A map to track doneMap nodes
 	doneMap := &sync.Map{}
 
 	// Process nodes concurrently
-	if err := topology.processTopology(ctx, roots, processor, doneMap, options); err != nil {
+	if err := topology.processTopology(ctx, d, roots, processor, doneMap, options); err != nil {
 		return err
 	}
 
@@ -89,6 +127,8 @@ func (d *DirectedAcyclicGraph[T]) ProcessTopology(
 //
 // Effectively, that means that a vertex is only processed when all its children
 // have been processed.
+//
+// ProcessVertex is guaranteed to be called for each vertex only once.
 //
 // For a more thorough explanation of topological order, see ProcessTopology.
 func (d *DirectedAcyclicGraph[T]) ProcessReverseTopology(
@@ -115,12 +155,15 @@ func (d *DirectedAcyclicGraph[T]) ProcessReverseTopology(
 
 	// Collect all Children nodes that are end leafs
 	roots := topology.Roots()
+	for _, r := range roots {
+		d.MustGetVertex(r).Attributes.Store(AttributeProcessingState, ProcessingStateQueued)
+	}
 
 	// A map to track doneMap nodes
 	doneMap := &sync.Map{}
 
 	// Process nodes concurrently
-	if err := topology.processTopology(ctx, roots, processor, doneMap, options); err != nil {
+	if err := topology.processTopology(ctx, d, roots, processor, doneMap, options); err != nil {
 		return err
 	}
 
@@ -143,6 +186,7 @@ func (f VertexProcessorFunc[T]) ProcessVertex(ctx context.Context, vertex T) err
 
 func (d *DirectedAcyclicGraph[T]) processTopology(
 	ctx context.Context,
+	dag *DirectedAcyclicGraph[T],
 	ids []T, // a list of root nodes to start processing with
 	processor VertexProcessor[T], // the processing function
 	doneMap *sync.Map, // a map to track loaded nodes
@@ -151,7 +195,8 @@ func (d *DirectedAcyclicGraph[T]) processTopology(
 	errGroup, ctx := errgroup.WithContext(ctx)
 	errGroup.SetLimit(opts.GoRoutineLimit)
 	// Calculate the upper bound for the next queue channel
-	// this determines how many ids can be processed concurrently in the next phase
+	// this determines how many ids can be processed concurrently in the next
+	// phase
 	upperBound := 0
 	for _, id := range ids {
 		upperBound += d.MustGetOutDegree(id)
@@ -161,15 +206,18 @@ func (d *DirectedAcyclicGraph[T]) processTopology(
 
 	for _, id := range ids {
 		errGroup.Go(func() error {
-			// Mark the id as processed or return if already processed
+			// Mark the id as processed or return if already processed.
 			_, loaded := doneMap.LoadOrStore(id, true)
 			if loaded {
 				return nil
 			}
 
+			dag.MustGetVertex(id).Attributes.Store(AttributeProcessingState, ProcessingStateProcessing)
 			if err := processor.ProcessVertex(ctx, id); err != nil {
+				dag.MustGetVertex(id).Attributes.Store(AttributeProcessingState, ProcessingStateError)
 				return fmt.Errorf("failed to process vertex with id %v: %w", id, err)
 			}
+			dag.MustGetVertex(id).Attributes.Store(AttributeProcessingState, ProcessingStateCompleted)
 
 			vertex := d.MustGetVertex(id)
 			for _, parent := range vertex.EdgeKeys() {
@@ -177,9 +225,11 @@ func (d *DirectedAcyclicGraph[T]) processTopology(
 				d.InDegree.Store(parent, inDegree-1)
 				parentVertex := d.MustGetVertex(parent)
 				parentVertex.Edges.Delete(id)
-				// If all prerequisites (children) of the parent have been processed and
-				// the parent has not been enqueued yet, add it to the next level.
+				// If all prerequisites (children) of the parent have been
+				// processed and the parent has not been enqueued yet, add it to
+				// the next level.
 				if d.MustGetInDegree(parent) == 0 {
+					dag.MustGetVertex(parent).Attributes.Store(AttributeProcessingState, ProcessingStateQueued)
 					nextQueueCh <- parent
 				}
 			}
@@ -202,7 +252,7 @@ func (d *DirectedAcyclicGraph[T]) processTopology(
 
 	// Recursively process the next batch if available.
 	if len(next) > 0 {
-		if err := d.processTopology(ctx, next, processor, doneMap, opts); err != nil {
+		if err := d.processTopology(ctx, dag, next, processor, doneMap, opts); err != nil {
 			return err
 		}
 	}

--- a/bindings/go/dag/sync/process.go
+++ b/bindings/go/dag/sync/process.go
@@ -165,7 +165,7 @@ func (d *DirectedAcyclicGraph[T]) processTopology(
 	}
 
 	// Recursively process the next batch if available.
-	if len(next) <= 0 {
+	if len(next) == 0 {
 		return nil
 	}
 

--- a/bindings/go/dag/sync/process_test.go
+++ b/bindings/go/dag/sync/process_test.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -28,8 +29,12 @@ func TestProcessTopology(t *testing.T) {
 		r.NoError(graph.AddEdge("B", "D", nil))
 		r.NoError(graph.AddEdge("C", "D", nil))
 
+		var orderMu sync.Mutex
 		var order []string
 		processor := VertexProcessorFunc[string](func(ctx context.Context, v string) error {
+			// prevent data race
+			orderMu.Lock()
+			defer orderMu.Unlock()
 			order = append(order, v)
 			return nil
 		})
@@ -84,8 +89,12 @@ func TestProcessReverseTopology(t *testing.T) {
 		r.NoError(graph.AddEdge("B", "D", nil))
 		r.NoError(graph.AddEdge("C", "D", nil))
 
+		var orderMu sync.Mutex
 		var order []string
 		processor := VertexProcessorFunc[string](func(ctx context.Context, v string) error {
+			// prevent data race
+			orderMu.Lock()
+			defer orderMu.Unlock()
 			order = append(order, v)
 			return nil
 		})

--- a/bindings/go/dag/sync/process_test.go
+++ b/bindings/go/dag/sync/process_test.go
@@ -90,7 +90,7 @@ func TestProcessReverseTopology(t *testing.T) {
 			return nil
 		})
 
-		r.NoError(graph.ProcessReverseTopology(ctx, processor))
+		r.NoError(graph.ProcessTopology(ctx, processor, WithReverseTopology()))
 		// A must be last, D must be first, B and C after D, before A
 		idxMap := make(map[string]int)
 		for i, v := range order {
@@ -115,7 +115,7 @@ func TestProcessReverseTopology(t *testing.T) {
 			}
 			return nil
 		})
-		err := graph.ProcessReverseTopology(ctx, processor)
+		err := graph.ProcessTopology(ctx, processor, WithReverseTopology())
 		r.ErrorContains(err, "fail on A")
 	})
 }

--- a/bindings/go/dag/sync/process_test.go
+++ b/bindings/go/dag/sync/process_test.go
@@ -1,0 +1,121 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessTopology(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	t.Run("processes vertices in topological order", func(t *testing.T) {
+		//    A
+		//   / \
+		//  B   C
+		//   \ /
+		//    D
+		graph := NewDirectedAcyclicGraph[string]()
+		r.NoError(graph.AddVertex("A"))
+		r.NoError(graph.AddVertex("B"))
+		r.NoError(graph.AddVertex("C"))
+		r.NoError(graph.AddVertex("D"))
+		r.NoError(graph.AddEdge("A", "B", nil))
+		r.NoError(graph.AddEdge("A", "C", nil))
+		r.NoError(graph.AddEdge("B", "D", nil))
+		r.NoError(graph.AddEdge("C", "D", nil))
+
+		var order []string
+		processor := VertexProcessorFunc[string](func(ctx context.Context, v string) error {
+			order = append(order, v)
+			return nil
+		})
+
+		r.NoError(graph.ProcessTopology(ctx, processor))
+		// D must be last, A must be first, B and C after A, before D
+		idxMap := make(map[string]int)
+		for i, v := range order {
+			idxMap[v] = i
+		}
+		r.True(idxMap["A"] < idxMap["B"], "A before B")
+		r.True(idxMap["A"] < idxMap["C"], "A before C")
+		r.True(idxMap["B"] < idxMap["D"], "B before D")
+		r.True(idxMap["C"] < idxMap["D"], "C before D")
+		r.Equal(4, len(order), "all vertices processed")
+	})
+
+	t.Run("returns error if processor fails", func(t *testing.T) {
+		graph := NewDirectedAcyclicGraph[string]()
+		r.NoError(graph.AddVertex("A"))
+		r.NoError(graph.AddVertex("B"))
+		r.NoError(graph.AddEdge("A", "B", nil))
+
+		processor := VertexProcessorFunc[string](func(ctx context.Context, v string) error {
+			if v == "B" {
+				return fmt.Errorf("fail on B")
+			}
+			return nil
+		})
+		err := graph.ProcessTopology(ctx, processor)
+		r.ErrorContains(err, "fail on B")
+	})
+}
+
+func TestProcessReverseTopology(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	t.Run("processes vertices in reverse topological order", func(t *testing.T) {
+		//    A
+		//   / \
+		//  B   C
+		//   \ /
+		//    D
+		graph := NewDirectedAcyclicGraph[string]()
+		r.NoError(graph.AddVertex("A"))
+		r.NoError(graph.AddVertex("B"))
+		r.NoError(graph.AddVertex("C"))
+		r.NoError(graph.AddVertex("D"))
+		r.NoError(graph.AddEdge("A", "B", nil))
+		r.NoError(graph.AddEdge("A", "C", nil))
+		r.NoError(graph.AddEdge("B", "D", nil))
+		r.NoError(graph.AddEdge("C", "D", nil))
+
+		var order []string
+		processor := VertexProcessorFunc[string](func(ctx context.Context, v string) error {
+			order = append(order, v)
+			return nil
+		})
+
+		r.NoError(graph.ProcessReverseTopology(ctx, processor))
+		// A must be last, D must be first, B and C after D, before A
+		idxMap := make(map[string]int)
+		for i, v := range order {
+			idxMap[v] = i
+		}
+		r.True(idxMap["D"] < idxMap["B"], "D before B")
+		r.True(idxMap["D"] < idxMap["C"], "D before C")
+		r.True(idxMap["B"] < idxMap["A"], "B before A")
+		r.True(idxMap["C"] < idxMap["A"], "C before A")
+		r.Equal(4, len(order), "all vertices processed")
+	})
+
+	t.Run("returns error if processor fails", func(t *testing.T) {
+		graph := NewDirectedAcyclicGraph[string]()
+		r.NoError(graph.AddVertex("A"))
+		r.NoError(graph.AddVertex("B"))
+		r.NoError(graph.AddEdge("A", "B", nil))
+
+		processor := VertexProcessorFunc[string](func(ctx context.Context, v string) error {
+			if v == "A" {
+				return fmt.Errorf("fail on A")
+			}
+			return nil
+		})
+		err := graph.ProcessReverseTopology(ctx, processor)
+		r.ErrorContains(err, "fail on A")
+	})
+}

--- a/bindings/go/dag/sync/traverse.go
+++ b/bindings/go/dag/sync/traverse.go
@@ -55,7 +55,7 @@ const (
 // TODO(fabianburth): Add a recursion depth limit
 type TraverseOptions[T cmp.Ordered] struct {
 	// Roots to start the traversal from
-	Roots          []*Vertex[T]
+	Roots          []T
 	GoRoutineLimit int
 }
 
@@ -67,25 +67,34 @@ func WithGoRoutineLimit[T cmp.Ordered](numGoRoutines int) TraverseOption[T] {
 	}
 }
 
-func WithRoots[T cmp.Ordered](roots ...*Vertex[T]) TraverseOption[T] {
+func WithRoots[T cmp.Ordered](root ...T) TraverseOption[T] {
 	return func(options *TraverseOptions[T]) {
-		options.Roots = roots
+		options.Roots = root
 	}
 }
 
 // NeighborDiscoverer is an interface for a function that discovers neighbor
 // vertices for a given vertex.
-// It MUST treat v as read-only and return its neighbors (created via NewVertex)
+// It MUST treat v as read-only and return its neighbors id
 // or an error.
 type NeighborDiscoverer[T cmp.Ordered] interface {
-	DiscoverNeighbors(ctx context.Context, v *Vertex[T]) (neighbors []*Vertex[T], err error)
+	// DiscoverNeighbors is not allowed to set attributes on the neighbor
+	// vertices as this would lead to data races. Those data races would occur
+	// when multiple vertices have the same neighbor.
+	//    A
+	//   / \
+	//  B   C
+	//   \ /
+	//    D
+	// In this case, B and C could overwrite each others attributes on D.
+	DiscoverNeighbors(ctx context.Context, v T) (neighbors []T, err error)
 }
 
 // DiscoverNeighborsFunc is a function type that implements the NeighborDiscoverer
 // interface. It is used to discover neighbors for a given vertex.
-type DiscoverNeighborsFunc[T cmp.Ordered] func(ctx context.Context, v *Vertex[T]) (neighbors []*Vertex[T], err error)
+type DiscoverNeighborsFunc[T cmp.Ordered] func(ctx context.Context, v T) (neighbors []T, err error)
 
-func (f DiscoverNeighborsFunc[T]) DiscoverNeighbors(ctx context.Context, v *Vertex[T]) (neighbors []*Vertex[T], err error) {
+func (f DiscoverNeighborsFunc[T]) DiscoverNeighbors(ctx context.Context, v T) (neighbors []T, err error) {
 	return f(ctx, v)
 }
 
@@ -115,34 +124,32 @@ func (d *DirectedAcyclicGraph[T]) Traverse(
 	if options.GoRoutineLimit <= 0 {
 		options.GoRoutineLimit = runtime.NumCPU()
 	}
-	rootIDs := make([]T, 0, len(options.Roots))
 	if len(options.Roots) > 0 {
 		for _, root := range options.Roots {
-			if err := d.addRawVertex(root); err != nil && !errors.Is(err, ErrAlreadyExists) {
+			if err := d.AddVertex(root); err != nil && !errors.Is(err, ErrAlreadyExists) {
 				return fmt.Errorf("failed to add vertex for rootID %v: %w", root, err)
 			}
-			rootIDs = append(rootIDs, root.ID)
 		}
 	} else {
 		slog.DebugContext(ctx, "no roots provided for traversal, using dag roots")
 
-		rootIDs = d.Roots()
-		if len(rootIDs) == 0 {
+		options.Roots = d.Roots()
+		if len(options.Roots) == 0 {
 			return fmt.Errorf("no roots provided and no roots found in the dag, cannot traverse")
 		}
 	}
 	doneMap := &sync.Map{}
 	errGroup := errgroup.Group{}
 
-	for _, rootID := range rootIDs {
+	for _, root := range options.Roots {
 		// We ensured that the rootID vertex exists in the graph
-		v, _ := d.GetVertex(rootID)
+		v, _ := d.GetVertex(root)
 		v.Attributes.Store(AttributeTraversalState, StateDiscovering)
 		// Traverse the graph from each rootID vertex concurrently.
 		// This is fine as:
 		// - the doneMap ensures that each vertex is only processed once.
 		errGroup.Go(func() error {
-			return d.traverse(ctx, rootID, discoverer, doneMap, options)
+			return d.traverse(ctx, root, discoverer, doneMap, options)
 		})
 	}
 	if err := errGroup.Wait(); err != nil {
@@ -190,7 +197,20 @@ func (d *DirectedAcyclicGraph[T]) traverse(
 		return fmt.Errorf("vertex %v not found in the graph", id)
 	}
 
-	neighbors, err := discoverer.DiscoverNeighbors(ctx, vertex)
+	// Discover neighbors is not allowed to set attributes on the neighbor
+	// vertices as this would lead to data races. Those data races would occur
+	// when multiple vertices have the same neighbor.
+	//    A
+	//   / \
+	//  B   C
+	//   \ /
+	//    D
+	// In this case, B and C could overwrite each others attributes on D.
+	//
+	// Instead, DiscoverNeighbors is only allowed to return the IDs of the
+	// If needed, we could introduce a capability to set attributes to the edges
+	// map[neighborId]edgeAttributes in the future.
+	neighbors, err := discoverer.DiscoverNeighbors(ctx, vertex.ID)
 	if err != nil {
 		vertex.Attributes.Store(AttributeTraversalState, StateError)
 		return fmt.Errorf("failed to discoverer id %v: %w", id, err)
@@ -204,20 +224,19 @@ func (d *DirectedAcyclicGraph[T]) traverse(
 	// limit the number of goroutines, as the traversal is recursive.
 	errGroup.SetLimit(opts.GoRoutineLimit)
 
-	for index, ref := range neighbors {
-		if err := d.addRawVertex(ref, map[string]any{
+	for index, neighborID := range neighbors {
+		if err := d.AddVertex(neighborID, map[string]any{
 			AttributeTraversalState: StateDiscovering,
 		}); err != nil && !errors.Is(err, ErrAlreadyExists) {
 			vertex.Attributes.Store(AttributeTraversalState, StateError)
-			return fmt.Errorf("failed to add vertex for reference %v: %w", ref, err)
+			return fmt.Errorf("failed to add vertex for reference %v: %w", neighborID, err)
 		}
-		if err := d.AddEdge(id, ref.ID, map[string]any{AttributeOrderIndex: index}); err != nil {
+		if err := d.AddEdge(id, neighborID, map[string]any{AttributeOrderIndex: index}); err != nil {
 			vertex.Attributes.Store(AttributeTraversalState, StateError)
 			return fmt.Errorf("failed to add edge %v: %w", id, err)
 		}
-		refID := ref.ID
 		errGroup.Go(func() error {
-			if err := d.traverse(ctx, refID, discoverer, doneMap, opts); err != nil {
+			if err := d.traverse(ctx, neighborID, discoverer, doneMap, opts); err != nil {
 				return fmt.Errorf("failed to traverse reference %v: %w", id, err)
 			}
 			return nil


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
This PR introduces logic to perform concurrent topological traversal of a dag, with child nodes always being processed before its parent node.

- It also fixes a "bug" in the `Reverse` methods where attributes have not been copied (it was simply not implemented).
- It renames `Traverse` to `Discover` since this caused a lot of confusion.
- It fixes a flaw in the `Discover`/`DiscoverNeighbors` logic that allowed the discover neighbors function to add attributes to the neighbors which had the potential to cause races. Now, the discover neighbors logic is only passed the vertex ID and can only return the neighbor vertices IDs. 
- This is sufficient for our component cases for now. If we need attributes during discovery in the future, we'd have to add them to the edges.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Contributes to: https://github.com/open-component-model/ocm-project/issues/564