### PR TITLE
chore: group docker package updates into a single pull request

### DIFF
--- a/.github/config/renovate.json5
+++ b/.github/config/renovate.json5
@@ -1,3 +1,5 @@
+// Note: This is the top-level config for Renovate.
+// For repository-specific configuration please use the renovate.json5 file at the root of the repository.
 {
   "branchPrefix": "renovate/",
   "username": "ocmbot[bot]",

--- a/renovate.json5
+++ b/renovate.json5
@@ -29,6 +29,7 @@
         'sigs.k8s.io/controller-tools',
         'k8s.io/*',
         'envtest',
+        'github.com/docker/*',
       ],
       groupName: 'Kubernetes dependencies',
       groupSlug: 'kubernetes-deps',

--- a/renovate.json5
+++ b/renovate.json5
@@ -29,10 +29,16 @@
         'sigs.k8s.io/controller-tools',
         'k8s.io/*',
         'envtest',
-        'github.com/docker/*',
       ],
       groupName: 'Kubernetes dependencies',
       groupSlug: 'kubernetes-deps',
+    },
+    {
+      matchPackagePrefixes: [
+        'github.com/docker/'
+      ],
+      groupName: 'Docker dependencies',
+      groupSlug: 'docker-deps',
     },
     {
       matchCategories: [


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Turns out neither of the defaults or extends are dealing with groupping go modules related to docker repositories. I looked at extends, group defaults, recommended and default grouppings. Looked for extendable docker configs and presets. They mostly deal with Dockerfile image versions actually. And not go modules.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
