### PR TITLE
fix(tests): improve resource reconciliation and cleanup logic

### DIFF
--- a/kubernetes/controller/internal/controller/resource/resource_controller.go
+++ b/kubernetes/controller/internal/controller/resource/resource_controller.go
@@ -176,6 +176,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 	}
 
 	if !resource.GetDeletionTimestamp().IsZero() {
+		logger.Info("resource is marked for deletion, attempting cleanup")
 		// The resource should only be deleted if no deployer exists that references that resource.
 		deployerList := &v1alpha1.DeployerList{}
 		if err := r.List(ctx, deployerList, &client.ListOptions{

--- a/kubernetes/controller/internal/controller/resource/suite_test.go
+++ b/kubernetes/controller/internal/controller/resource/suite_test.go
@@ -38,6 +38,7 @@ var cancel context.CancelFunc
 var ocmContextCache *ocm.ContextCache
 
 func TestControllers(t *testing.T) {
+	t.Parallel()
 	RegisterFailHandler(Fail)
 
 	RunSpecs(t, "Controller Suite")
@@ -87,7 +88,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	ctx, cancel = context.WithCancel(context.Background())
+	ctx, cancel = context.WithCancel(GinkgoT().Context())
 	DeferCleanup(cancel)
 
 	events := make(chan string)

--- a/kubernetes/controller/internal/util/k8s.go
+++ b/kubernetes/controller/internal/util/k8s.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/fluxcd/pkg/runtime/conditions"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -34,24 +33,6 @@ type Getter interface {
 type ObjectPointerType[T any] interface {
 	*T
 	Getter
-}
-
-func GetNamespaced[T any, P ObjectPointerType[T]](ctx context.Context, client ctrl.Reader, key v1.LocalObjectReference, namespace string) (P, error) {
-	obj := P(new(T))
-	if err := client.Get(ctx, ctrl.ObjectKey{Namespace: namespace, Name: key.Name}, obj); err != nil {
-		return nil, fmt.Errorf("failed to locate object: %w", err)
-	}
-
-	return obj, nil
-}
-
-func Get[T any, P ObjectPointerType[T]](ctx context.Context, client ctrl.Reader, key ctrl.ObjectKey) (P, error) {
-	obj := P(new(T))
-	if err := client.Get(ctx, key, obj); err != nil {
-		return nil, fmt.Errorf("failed to locate object: %w", err)
-	}
-
-	return obj, nil
 }
 
 func GetReadyObject[T any, P ObjectPointerType[T]](ctx context.Context, client ctrl.Reader, key ctrl.ObjectKey) (P, error) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

- Replaced duplicated cleanup steps in tests with `DeferCleanup` for consistent teardown.
- Introduced `NamespaceForTest` function to streamline namespace creation in tests.
- Removed unused methods `GetNamespaced` and `Get` from utilities.
- Centralized default timeout configuration for Kubernetes operations.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Before this, there could be side effects due to shared pointers between tests. this was now fixed
