### PR TITLE
chore(renovate): group Golang X repositories

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -41,6 +41,13 @@
       ],
     },
     {
+      groupName: 'Golang X Repositories',
+      groupSlug: 'golang-x-repos',
+      matchPackageNames: [
+        'golang.org/x/{/,}**'
+      ]
+    },
+    {
       matchCategories: [
         'golang',
       ],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

- Added a new Renovate configuration group for `golang.org/x/**` packages.
- Helps reduce noise in PRs by bundling related Golang X dependencies together.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

reduced PR clutter
