### PR TITLE
chore(renovate): group Google Golang repositories

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -48,6 +48,13 @@
       ]
     },
     {
+      groupName: 'Google Golang Repositories',
+      groupSlug: 'google-golang-repos',
+      matchPackageNames: [
+        'google.golang.org/{/,}**'
+      ]
+    },
+    {
       groupName: 'Sigstore Repositories',
       groupSlug: 'sigstore',
       matchPackageNames: [


### PR DESCRIPTION
#### What this PR does / why we need it
- Added a new Renovate configuration group for `google.golang.org/{/,}**` packages.
- Helps reduce PR clutter by bundling updates related to Google Golang repositories.

#### Which issue(s) this PR fixes
- Improves dependency update management for Google-related Golang packages.
