### PR TITLE
chore(renovate): update dry-run condition in GitHub workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -24,7 +24,7 @@ env:
   cache_dir: /tmp/renovate/cache/renovate/repository
   cache_key: renovate-cache
   RENOVATE_CONFIG_FILE: .github/renovate.json5
-  RENOVATE_DRY_RUN: ${{ github.repository_owner == 'open-component-model' && '' || 'extract' }}
+  RENOVATE_DRY_RUN: ${{ github.event_name == 'pull_request' && 'extract' || 'none' }}
 
 jobs:
   renovate:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

- Updated `RENOVATE_DRY_RUN` environment variable in `.github/workflows/renovate.yml` to trigger dry runs for pull requests and disable it for other events.
- Ensures proper validation of Renovate changes on relevant PRs.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
