### PR TITLE
chore(workflow): add environment restriction for Go module releases

### DIFF
--- a/.github/workflows/release-go-submodule.yaml
+++ b/.github/workflows/release-go-submodule.yaml
@@ -29,6 +29,9 @@ on:
 
 jobs:
   release:
+    environment:
+      # enforce that this job is only run when approved by an approver for the go-modules environment
+      name: go-modules
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
#### What this does
- Introduced an `environment` section with `go-modules` as the required environment in the `release-go-submodule.yaml` workflow.
- Ensures the release job only runs after explicit approval for the `go-modules` environment.

#### Why this change is needed
- Adds a safeguard to prevent accidental or unauthorized execution of the Go module release process.

