### PR TITLE
fix(registry): add credential identity support for internal plugins

### DIFF
--- a/bindings/go/plugin/manager/registries/componentversionrepository/registry.go
+++ b/bindings/go/plugin/manager/registries/componentversionrepository/registry.go
@@ -147,9 +147,17 @@ func (r *RepositoryRegistry) GetComponentVersionRepositoryCredentialConsumerIden
 	// Check if this is an internal plugin first
 	typ := repositorySpecification.GetType()
 	if ok := r.scheme.IsRegistered(typ); ok {
-		// For internal plugins, we don't have credential identity support yet
-		// Return empty identity for now
-		return runtime.Identity{}, nil
+		p, ok := r.internalComponentVersionRepositoryPlugins[typ]
+		if !ok {
+			return nil, fmt.Errorf("no internal plugin registered for type %v", typ)
+		}
+
+		identity, err := p.GetComponentVersionRepositoryCredentialConsumerIdentity(ctx, repositorySpecification)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get component version repository: %w", err)
+		}
+
+		return identity, nil
 	}
 
 	// For external plugins, get the plugin and ask for identity

--- a/bindings/go/plugin/manager/registries/componentversionrepository/registry_test.go
+++ b/bindings/go/plugin/manager/registries/componentversionrepository/registry_test.go
@@ -129,7 +129,9 @@ type mockPluginProvider struct {
 }
 
 func (m *mockPluginProvider) GetComponentVersionRepositoryCredentialConsumerIdentity(ctx context.Context, repositorySpecification runtime.Typed) (runtime.Identity, error) {
-	return nil, nil
+	return runtime.Identity{
+		"test": "identity",
+	}, nil
 }
 
 func (m *mockPluginProvider) GetComponentVersionRepository(ctx context.Context, repositorySpecification runtime.Typed, credentials map[string]string) (repository.ComponentVersionRepository, error) {
@@ -157,6 +159,11 @@ func TestInternalPluginRegistry(t *testing.T) {
 	require.NoError(t, RegisterInternalComponentVersionRepositoryPlugin(scheme, registry, &mockPluginProvider{
 		mockPlugin: &mockedRepository{},
 	}, proto))
+
+	identity, err := registry.GetComponentVersionRepositoryCredentialConsumerIdentity(ctx, proto)
+	require.NoError(t, err)
+	require.NotNil(t, identity)
+
 	retrievedPluginProvider, err := registry.GetComponentVersionRepository(ctx, proto, nil)
 	require.NoError(t, err)
 	require.NotNil(t, retrievedPluginProvider)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Added internal plugin credential identity support for provider that was accidentally left out


#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

follow up to https://github.com/open-component-model/open-component-model/pull/790
