### PR TITLE
fix(dag): fix various races

### DIFF
--- a/bindings/go/dag/dag_test.go
+++ b/bindings/go/dag/dag_test.go
@@ -58,10 +58,10 @@ func TestDAGAddNode(t *testing.T) {
 
 	t.Run("degrees", func(t *testing.T) {
 		r := require.New(t)
-		r.Equal(d.OutDegree["A"], 0, "expected out-degree of A to be 0, but got %d", d.OutDegree["A"])
-		r.Equal(d.InDegree["A"], 0, "expected in-degree of A to be 0, but got %d", d.InDegree["A"])
-		r.Equal(d.OutDegree["B"], 0, "expected out-degree of B to be 0, but got %d", d.OutDegree["B"])
-		r.Equal(d.InDegree["B"], 0, "expected in-degree of B to be 0, but got %d", d.InDegree["B"])
+		r.Equal(d.Vertices["A"].OutDegree, 0, "expected out-degree of A to be 0, but got %d", d.Vertices["A"].OutDegree)
+		r.Equal(d.Vertices["A"].InDegree, 0, "expected in-degree of A to be 0, but got %d", d.Vertices["A"].InDegree)
+		r.Equal(d.Vertices["B"].OutDegree, 0, "expected out-degree of B to be 0, but got %d", d.Vertices["B"].OutDegree)
+		r.Equal(d.Vertices["B"].InDegree, 0, "expected in-degree of B to be 0, but got %d", d.Vertices["B"].InDegree)
 	})
 
 	t.Run("delete", func(t *testing.T) {
@@ -70,9 +70,9 @@ func TestDAGAddNode(t *testing.T) {
 		r.Lenf(d.Vertices, 1, "expected 1 node after deleting 'A', but got %d", len(d.Vertices))
 		r.Equal("B", d.Vertices["B"].ID, "expected node ID to be 'B', but got %s", d.Vertices["B"].ID)
 		r.Error(d.DeleteVertex("A"), "expected error when deleting non-existent node 'A', but got nil")
-		_, outExists := d.OutDegree["A"]
+		_, outExists := d.Vertices["A"]
 		r.False(outExists)
-		_, inExists := d.InDegree["A"]
+		_, inExists := d.Vertices["A"]
 		r.False(inExists)
 	})
 }
@@ -96,11 +96,11 @@ func TestDAGAddEdge(t *testing.T) {
 	r.Len(d.Vertices["B"].Edges, 0, "expected 0 edges from B to A, but got %d", len(d.Vertices["B"].Edges))
 
 	t.Run("degrees", func(t *testing.T) {
-		r.Equal(d.OutDegree["A"], 1, "expected out-degree of A to be 1, but got %d", d.OutDegree["A"])
-		r.Equal(d.InDegree["A"], 0, "expected in-degree of A to be 0, but got %d", d.InDegree["A"])
+		r.Equal(d.Vertices["A"].OutDegree, 1, "expected out-degree of A to be 1, but got %d", d.Vertices["A"].OutDegree)
+		r.Equal(d.Vertices["A"].InDegree, 0, "expected in-degree of A to be 0, but got %d", d.Vertices["A"].InDegree)
 
-		r.Equal(d.OutDegree["B"], 0, "expected out-degree of B to be 0, but got %d", d.OutDegree["B"])
-		r.Equal(d.InDegree["B"], 1, "expected in-degree of B to be 1, but got %d", d.InDegree["B"])
+		r.Equal(d.Vertices["B"].OutDegree, 0, "expected out-degree of B to be 0, but got %d", d.Vertices["B"].OutDegree)
+		r.Equal(d.Vertices["B"].InDegree, 1, "expected in-degree of B to be 1, but got %d", d.Vertices["B"].InDegree)
 	})
 
 	t.Run("reverse", func(t *testing.T) {
@@ -118,9 +118,9 @@ func TestDAGAddEdge(t *testing.T) {
 		r.Lenf(d.Vertices, 1, "expected 1 node after deleting 'A', but got %d", len(d.Vertices))
 		r.Equal("B", d.Vertices["B"].ID, "expected node ID to be 'B', but got %s", d.Vertices["B"].ID)
 		r.Error(d.DeleteVertex("A"), "expected error when deleting non-existent node 'A', but got nil")
-		_, outExists := d.OutDegree["A"]
+		_, outExists := d.Vertices["A"]
 		r.False(outExists)
-		_, inExists := d.InDegree["A"]
+		_, inExists := d.Vertices["A"]
 		r.False(inExists)
 	})
 }

--- a/bindings/go/dag/sync/conversion_test.go
+++ b/bindings/go/dag/sync/conversion_test.go
@@ -46,13 +46,13 @@ func TestMapToSynced(t *testing.T) {
 		r.ElementsMatchf(syncMapBasedDAG.MustGetVertex("B").EdgeKeys(), slices.Collect(maps.Keys(mapBasedDAG.Vertices["B"].Edges)), "expected vertex B to match, but they differ")
 		r.ElementsMatchf(syncMapBasedDAG.MustGetVertex("C").EdgeKeys(), slices.Collect(maps.Keys(mapBasedDAG.Vertices["C"].Edges)), "expected vertex C to match, but they differ")
 
-		r.Equalf(syncMapBasedDAG.MustGetOutDegree("A"), mapBasedDAG.OutDegree["A"], "expected out-degree to match, but they differ")
-		r.Equalf(syncMapBasedDAG.MustGetOutDegree("B"), mapBasedDAG.OutDegree["B"], "expected out-degree to match, but they differ")
-		r.Equalf(syncMapBasedDAG.MustGetOutDegree("C"), mapBasedDAG.OutDegree["C"], "expected out-degree to match, but they differ")
+		r.Equalf(int(syncMapBasedDAG.MustGetOutDegree("A").Load()), mapBasedDAG.Vertices["A"].OutDegree, "expected out-degree to match, but they differ")
+		r.Equalf(int(syncMapBasedDAG.MustGetOutDegree("B").Load()), mapBasedDAG.Vertices["B"].OutDegree, "expected out-degree to match, but they differ")
+		r.Equalf(int(syncMapBasedDAG.MustGetOutDegree("C").Load()), mapBasedDAG.Vertices["C"].OutDegree, "expected out-degree to match, but they differ")
 
-		r.Equalf(syncMapBasedDAG.MustGetInDegree("A"), mapBasedDAG.InDegree["A"], "expected in-degree to match, but they differ")
-		r.Equalf(syncMapBasedDAG.MustGetInDegree("B"), mapBasedDAG.InDegree["B"], "expected in-degree to match, but they differ")
-		r.Equalf(syncMapBasedDAG.MustGetInDegree("C"), mapBasedDAG.InDegree["C"], "expected in-degree to match, but they differ")
+		r.Equalf(int(syncMapBasedDAG.MustGetInDegree("A").Load()), mapBasedDAG.Vertices["A"].InDegree, "expected in-degree to match, but they differ")
+		r.Equalf(int(syncMapBasedDAG.MustGetInDegree("B").Load()), mapBasedDAG.Vertices["B"].InDegree, "expected in-degree to match, but they differ")
+		r.Equalf(int(syncMapBasedDAG.MustGetInDegree("C").Load()), mapBasedDAG.Vertices["C"].InDegree, "expected in-degree to match, but they differ")
 
 		r.Equalf(syncMapBasedDAG.Roots(), mapBasedDAG.Roots(), "expected roots to match, but they differ")
 	}

--- a/bindings/go/dag/sync/dag.go
+++ b/bindings/go/dag/sync/dag.go
@@ -26,6 +26,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 )
 
 var (
@@ -39,33 +40,28 @@ var (
 type DirectedAcyclicGraph[T cmp.Ordered] struct {
 	// Vertices stores the nodes in the graph
 	Vertices *sync.Map // map[T]*Vertex[T]
-	// OutDegree of each vertex (number of outgoing edges)
-	OutDegree *sync.Map // map[T]int
-	// InDegree of each vertex (number of incoming edges)
-	InDegree *sync.Map // map[T]int
 }
 
 // NewDirectedAcyclicGraph creates a new directed acyclic graph.
 func NewDirectedAcyclicGraph[T cmp.Ordered]() *DirectedAcyclicGraph[T] {
 	return &DirectedAcyclicGraph[T]{
-		Vertices:  &sync.Map{},
-		OutDegree: &sync.Map{},
-		InDegree:  &sync.Map{},
+		Vertices: &sync.Map{},
 	}
 }
 
 // GetOutDegree returns the out-degree (number of outgoing edges) of the given
 // vertex and a boolean indicating if the vertex exists in the graph.
-func (d *DirectedAcyclicGraph[T]) GetOutDegree(id T) (int, bool) {
-	if outDegree, ok := d.OutDegree.Load(id); ok {
-		return outDegree.(int), true
+func (d *DirectedAcyclicGraph[T]) GetOutDegree(id T) (*atomic.Int64, bool) {
+	v, ok := d.GetVertex(id)
+	if !ok {
+		return nil, false
 	}
-	return 0, false
+	return &v.OutDegree, true
 }
 
 // MustGetOutDegree returns the out-degree of the given vertex, panicking if
 // the vertex does not exist in the graph.
-func (d *DirectedAcyclicGraph[T]) MustGetOutDegree(id T) int {
+func (d *DirectedAcyclicGraph[T]) MustGetOutDegree(id T) *atomic.Int64 {
 	inDegree, ok := d.GetOutDegree(id)
 	if !ok {
 		panic(fmt.Sprintf("out-degree for vertex %v not found in the graph", id))
@@ -75,16 +71,17 @@ func (d *DirectedAcyclicGraph[T]) MustGetOutDegree(id T) int {
 
 // GetInDegree returns the in-degree (number of incoming edges) of the given
 // vertex and a boolean indicating if the vertex exists in the graph.
-func (d *DirectedAcyclicGraph[T]) GetInDegree(id T) (int, bool) {
-	if inDegree, ok := d.InDegree.Load(id); ok {
-		return inDegree.(int), true
+func (d *DirectedAcyclicGraph[T]) GetInDegree(id T) (*atomic.Int64, bool) {
+	v, ok := d.GetVertex(id)
+	if !ok {
+		return nil, false
 	}
-	return 0, false
+	return &v.InDegree, true
 }
 
 // MustGetInDegree returns the in-degree of the given vertex, panicking if
 // the vertex does not exist in the graph.
-func (d *DirectedAcyclicGraph[T]) MustGetInDegree(id T) int {
+func (d *DirectedAcyclicGraph[T]) MustGetInDegree(id T) *atomic.Int64 {
 	inDegree, ok := d.GetInDegree(id)
 	if !ok {
 		panic(fmt.Sprintf("in-degree for vertex %v not found in the graph", id))
@@ -112,22 +109,11 @@ func (d *DirectedAcyclicGraph[T]) Clone() *DirectedAcyclicGraph[T] {
 		cloned.Vertices.Store(key, value.(*Vertex[T]).Clone())
 		return true
 	})
-	d.OutDegree.Range(func(key, value any) bool {
-		cloned.OutDegree.Store(key, value)
-		return true
-	})
-	d.InDegree.Range(func(key, value any) bool {
-		cloned.InDegree.Store(key, value)
-		return true
-	})
 	return cloned
 }
 
 // AddVertex adds a new node to the graph.
 func (d *DirectedAcyclicGraph[T]) AddVertex(id T, attributes ...map[string]any) error {
-	if _, exists := d.Vertices.Load(id); exists {
-		return fmt.Errorf("node %v already exists: %w", id, ErrAlreadyExists)
-	}
 	vertex := &Vertex[T]{
 		ID:         id,
 		Attributes: &sync.Map{},
@@ -138,10 +124,9 @@ func (d *DirectedAcyclicGraph[T]) AddVertex(id T, attributes ...map[string]any) 
 			vertex.Attributes.Store(k, v)
 		}
 	}
-	d.Vertices.Store(vertex.ID, vertex)
-
-	d.OutDegree.Store(vertex.ID, 0)
-	d.InDegree.Store(vertex.ID, 0)
+	if actual, exists := d.Vertices.LoadOrStore(id, vertex); exists && actual != vertex {
+		return fmt.Errorf("node %v already exists: %w", id, ErrAlreadyExists)
+	}
 	return nil
 }
 
@@ -157,8 +142,7 @@ func (d *DirectedAcyclicGraph[T]) DeleteVertex(id T) error {
 		node.Edges.Range(func(edgeKey, _ any) bool {
 			if edgeKey == id {
 				// Decrement the in-degree of the node
-				inDegree, _ := d.InDegree.Load(node.ID)
-				d.InDegree.Store(node.ID, inDegree.(int)-1)
+				node.InDegree.Add(-1)
 				// Remove the edge from the node
 				node.Edges.Delete(id)
 			}
@@ -168,8 +152,6 @@ func (d *DirectedAcyclicGraph[T]) DeleteVertex(id T) error {
 	})
 
 	d.Vertices.Delete(id)
-	d.OutDegree.Delete(id)
-	d.InDegree.Delete(id)
 
 	return nil
 }
@@ -189,7 +171,7 @@ func formatCycle(cycle []string) string {
 // AddEdge adds a directed edge from one node to another.
 func (d *DirectedAcyclicGraph[T]) AddEdge(from, to T, attributes ...map[string]any) error {
 	fromNode, fromExists := d.GetVertex(from)
-	_, toExists := d.GetVertex(to)
+	toNode, toExists := d.GetVertex(to)
 	if !fromExists {
 		return fmt.Errorf("node %v does not exist", from)
 	}
@@ -206,18 +188,16 @@ func (d *DirectedAcyclicGraph[T]) AddEdge(from, to T, attributes ...map[string]a
 		// Only initialize the map if the edge was added
 		fromNode.Edges.Store(to, &sync.Map{})
 		// Only increment the out-degree and in-degree if the edge was added
-		outDegree, _ := d.OutDegree.Load(from)
-		d.OutDegree.Store(from, outDegree.(int)+1)
-		inDegree, _ := d.InDegree.Load(to)
-		d.InDegree.Store(to, inDegree.(int)+1)
+		fromNode.OutDegree.Add(1)
+		toNode.InDegree.Add(1)
 
 		// Check if the graph is still a DAG
 		hasCycle, cycle := d.HasCycle()
 		if hasCycle {
 			// Ehmmm, we have a cycle, let's remove the edge we just added
 			fromNode.Edges.Delete(to)
-			d.OutDegree.Store(from, outDegree.(int)-1)
-			d.InDegree.Store(to, inDegree.(int)-1)
+			toNode.InDegree.Add(-1)
+			fromNode.OutDegree.Add(-1)
 			return fmt.Errorf("adding an edge from %v to %v would create a cycle: %w", fmt.Sprintf("%v", from), fmt.Sprintf("%v", to), &CycleError{
 				Cycle: cycle,
 			})
@@ -239,8 +219,8 @@ func (d *DirectedAcyclicGraph[T]) AddEdge(from, to T, attributes ...map[string]a
 // Roots returns the root nodes of the graph, which are nodes with no incoming edges.
 func (d *DirectedAcyclicGraph[T]) Roots() []T {
 	var roots []T
-	d.InDegree.Range(func(key, value any) bool {
-		if value.(int) == 0 {
+	d.Vertices.Range(func(key, value any) bool {
+		if value.(*Vertex[T]).InDegree.Load() == 0 {
 			roots = append(roots, key.(T))
 		}
 		return true
@@ -476,6 +456,8 @@ type Vertex[T cmp.Ordered] struct {
 	// Edges stores the IDs of the nodes that this node has an outgoing edge to,
 	// as well as any attributes associated with that edge.
 	Edges *sync.Map // map[T]*sync.Map with map[string]any (attributes)
+
+	InDegree, OutDegree atomic.Int64
 }
 
 func (v *Vertex[T]) Clone() *Vertex[T] {
@@ -484,6 +466,8 @@ func (v *Vertex[T]) Clone() *Vertex[T] {
 		Attributes: &sync.Map{},
 		Edges:      &sync.Map{},
 	}
+	cloned.InDegree.Store(v.InDegree.Load())
+	cloned.OutDegree.Store(v.OutDegree.Load())
 	v.Attributes.Range(func(key, value any) bool {
 		k := key.(string)
 		cloned.Attributes.Store(k, value)

--- a/bindings/go/dag/sync/map_to_synced.go
+++ b/bindings/go/dag/sync/map_to_synced.go
@@ -11,16 +11,17 @@ import (
 func ToSyncMapBasedDAG[T cmp.Ordered](d *dag.DirectedAcyclicGraph[T]) *DirectedAcyclicGraph[T] {
 	vertices := &sync.Map{}
 	for id, v := range d.Vertices {
-		vertices.Store(id, &Vertex[T]{
+		vtx := &Vertex[T]{
 			ID:         v.ID,
 			Attributes: VertexAttributesToSyncMap(v),
 			Edges:      VertexEdgesToSyncMap(v),
-		})
+		}
+		vtx.InDegree.Store(int64(v.InDegree))
+		vtx.OutDegree.Store(int64(v.OutDegree))
+		vertices.Store(id, vtx)
 	}
 	return &DirectedAcyclicGraph[T]{
-		Vertices:  vertices,
-		OutDegree: OutDegreeToSyncMap(d),
-		InDegree:  InDegreeToSyncMap(d),
+		Vertices: vertices,
 	}
 }
 
@@ -34,14 +35,6 @@ func VertexEdgesToSyncMap[T cmp.Ordered](v *dag.Vertex[T]) *sync.Map {
 		edges.Store(edgeID, MapToSyncMap[string, any](attrMap))
 	}
 	return edges
-}
-
-func OutDegreeToSyncMap[T cmp.Ordered](d *dag.DirectedAcyclicGraph[T]) *sync.Map {
-	return MapToSyncMap[T, int](d.OutDegree)
-}
-
-func InDegreeToSyncMap[T cmp.Ordered](d *dag.DirectedAcyclicGraph[T]) *sync.Map {
-	return MapToSyncMap[T, int](d.InDegree)
 }
 
 // MapToSyncMap converts a map to a sync.Map.

--- a/bindings/go/dag/sync/process.go
+++ b/bindings/go/dag/sync/process.go
@@ -232,14 +232,14 @@ func (d *DirectedAcyclicGraph[T]) processLayer(
 		vertex := topology.MustGetVertex(id)
 		for _, child := range vertex.EdgeKeys() {
 			inDegree := topology.MustGetInDegree(child)
+			newValue := inDegree.Add(-1)
 			// If all parents of the child have been processed and the
 			// child has not been enqueued yet, add it to the next layer.
-			if inDegree.Load()-1 == 0 {
+			if newValue == 0 {
 				d.MustGetVertex(child).Attributes.Store(AttributeProcessingState, ProcessingStateQueued)
 				next = append(next, child)
 			}
 			vertex.Edges.Delete(child)
-			inDegree.Add(-1)
 		}
 		topology.Vertices.Delete(id)
 	}

--- a/bindings/go/dag/sync/synced_to_map.go
+++ b/bindings/go/dag/sync/synced_to_map.go
@@ -20,17 +20,18 @@ func ToMapBasedDAG[T cmp.Ordered](d *DirectedAcyclicGraph[T]) *dag.DirectedAcycl
 		if !ok {
 			return true
 		}
-		vertices[id] = &dag.Vertex[T]{
+		vtx := &dag.Vertex[T]{
 			ID:         v.ID,
 			Attributes: VertexAttributesToMap(v),
 			Edges:      VertexEdgesToMap(v),
+			InDegree:   int(v.InDegree.Load()),
+			OutDegree:  int(v.OutDegree.Load()),
 		}
+		vertices[id] = vtx
 		return true
 	})
 	return &dag.DirectedAcyclicGraph[T]{
-		Vertices:  vertices,
-		OutDegree: OutDegreeToMap(d),
-		InDegree:  InDegreeToMap(d),
+		Vertices: vertices,
 	}
 }
 
@@ -53,16 +54,6 @@ func VertexEdgesToMap[T cmp.Ordered](v *Vertex[T]) map[T]map[string]any {
 		return true
 	})
 	return edges
-}
-
-// OutDegreeToMap converts the graph's out-degree sync.Map to a regular.
-func OutDegreeToMap[T cmp.Ordered](d *DirectedAcyclicGraph[T]) map[T]int {
-	return MustSyncMapToMap[T, int](d.OutDegree)
-}
-
-// InDegreeToMap converts the graph's in-degree sync.Map to a regular map.
-func InDegreeToMap[T cmp.Ordered](d *DirectedAcyclicGraph[T]) map[T]int {
-	return MustSyncMapToMap[T, int](d.InDegree)
 }
 
 // SyncMapToMap converts a sync.Map to a regular map with type assertions.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

fixes a nil pointer and a data race that could occur on vertex retrieval

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
