### PR TITLE
fix(oci): fix repository detection for OCI URLs with IP addresses

### DIFF
--- a/cli/internal/reference/compref/compref_test.go
+++ b/cli/internal/reference/compref/compref_test.go
@@ -292,6 +292,7 @@ func Test_ComponentReference_Permutations(t *testing.T) {
 		{"./local/path", false},
 		{"file://./local/path", false},
 		{"/absolute/path", false},
+		{"1.2.3.5:5000/open-component-model/ocm", true},
 	}
 
 	prefixes := []string{

--- a/cli/internal/reference/compref/compref_test.go
+++ b/cli/internal/reference/compref/compref_test.go
@@ -411,6 +411,16 @@ func TestParseRepository(t *testing.T) {
 			},
 		},
 		{
+			name:         "OCI Registry - IP with port",
+			repoRef:      "1.2.3.4:5000/my-repo",
+			expectedType: runtime.NewVersionedType(ociv1.Type, ociv1.Version),
+			validateResult: func(t *testing.T, result runtime.Typed, repoSpec string) {
+				repo, ok := result.(*ociv1.Repository)
+				require.True(t, ok, "expected *ociv1.Repository")
+				require.Equal(t, repoSpec, repo.BaseUrl)
+			},
+		},
+		{
 			name:         "OCI Registry - HTTPS URL",
 			repoRef:      "https://registry.example.com/my-repo",
 			expectedType: runtime.NewVersionedType(ociv1.Type, ociv1.Version),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

Previously, repository references in the format of IP:PORT were incorrectly recognised due to a parsing error. This fix ensures that repositories behind an IP address are correctly detected.

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes https://github.com/open-component-model/ocm-project/issues/651