### PR TITLE
fix(rsa): update default signature encoding policy to SignatureEncodingPolicyDefault

### DIFF
--- a/bindings/go/rsa/signing/v1alpha1/config.go
+++ b/bindings/go/rsa/signing/v1alpha1/config.go
@@ -34,7 +34,7 @@ type Config struct {
 
 func (cfg *Config) GetSignatureEncodingPolicy() SignatureEncodingPolicy {
 	if cfg == nil || cfg.SignatureEncodingPolicy == "" {
-		return SignatureEncodingPolicyPEM
+		return SignatureEncodingPolicyDefault
 	}
 	return cfg.SignatureEncodingPolicy
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

The default signature encoding policy was wrongly hard coded to PEM which caused empty Configs to incorrectly default to PEM even though the default is Plain

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

uses the default constant as originally intended
