### PR TITLE
chore: update oci repo dependency

### DIFF
--- a/bindings/go/oci/go.mod
+++ b/bindings/go/oci/go.mod
@@ -11,11 +11,11 @@ require (
 	github.com/veqryn/slog-context v0.8.0
 	golang.org/x/sync v0.17.0
 	ocm.software/open-component-model/bindings/go/blob v0.0.9
-	ocm.software/open-component-model/bindings/go/configuration v0.0.8
+	ocm.software/open-component-model/bindings/go/configuration v0.0.9
 	ocm.software/open-component-model/bindings/go/ctf v0.2.0
 	ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20250919174641-be28d8d1c750
 	ocm.software/open-component-model/bindings/go/descriptor/v2 v2.0.1-alpha3
-	ocm.software/open-component-model/bindings/go/repository v0.0.0-20250909064434-e1a06fe74668
+	ocm.software/open-component-model/bindings/go/repository v0.0.2
 	ocm.software/open-component-model/bindings/go/runtime v0.0.2
 	oras.land/oras-go/v2 v2.6.0
 	sigs.k8s.io/yaml v1.6.0

--- a/bindings/go/oci/go.sum
+++ b/bindings/go/oci/go.sum
@@ -61,6 +61,7 @@ ocm.software/open-component-model/bindings/go/blob v0.0.9 h1:XNK04PnqvsE6KHx/04m
 ocm.software/open-component-model/bindings/go/blob v0.0.9/go.mod h1:BjErnbAzzY4mJ6cO/hIFj8Gf/v9zerkIQ1Y1XQEOB5M=
 ocm.software/open-component-model/bindings/go/configuration v0.0.8 h1:IH5ARqAwUJIV8U3l7Mv/txmjh7HbSwYMGSk9V8QlTVo=
 ocm.software/open-component-model/bindings/go/configuration v0.0.8/go.mod h1:VZ8jQ3a6oTWyOpY09C7V3L0CfzKe9i1/Z4uJjLAVjN4=
+ocm.software/open-component-model/bindings/go/configuration v0.0.9/go.mod h1:VZ8jQ3a6oTWyOpY09C7V3L0CfzKe9i1/Z4uJjLAVjN4=
 ocm.software/open-component-model/bindings/go/ctf v0.2.0 h1:BGZ+irknUVjZkOjL5j5bK5shmGWbOjpszfuETkPndVw=
 ocm.software/open-component-model/bindings/go/ctf v0.2.0/go.mod h1:L9JjTdoWDybr2YY9zXCsCAtNLracxW3aMK2f2TrqYZo=
 ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20250919174641-be28d8d1c750 h1:0KRBkVc0XusnkClrfNhGHbEU7VbJm+Uh/7iZ/Ch/964=
@@ -69,6 +70,7 @@ ocm.software/open-component-model/bindings/go/descriptor/v2 v2.0.1-alpha3 h1:daG
 ocm.software/open-component-model/bindings/go/descriptor/v2 v2.0.1-alpha3/go.mod h1:nnLzPfpD2zy9YUgIuQxA3vCmUUKFQqSCl6jFAQXVE8M=
 ocm.software/open-component-model/bindings/go/repository v0.0.0-20250909064434-e1a06fe74668 h1:W+W0JCbfK9VHuAPFYPMztitiKgDhZqgLk1fEBTqla24=
 ocm.software/open-component-model/bindings/go/repository v0.0.0-20250909064434-e1a06fe74668/go.mod h1:SBR5IbnJ+r7ggJ0X6LIXsi3l6cGe/FT+j2KZLJ/xsds=
+ocm.software/open-component-model/bindings/go/repository v0.0.2/go.mod h1:WUkvMtap6mxQAqVQBCmi+clmT73jLsE9a1Ig6NMPkXA=
 ocm.software/open-component-model/bindings/go/runtime v0.0.2 h1:YA20enOxMsk4gDWF+Anltwkc616dXebfgPz/0Bl0EKE=
 ocm.software/open-component-model/bindings/go/runtime v0.0.2/go.mod h1:9qeyWvvxkua6NyDVGxeQV6B022WqoAfdU/JnuImm1ws=
 oras.land/oras-go/v2 v2.6.0 h1:X4ELRsiGkrbeox69+9tzTu492FMUu7zJQW6eJU+I2oc=


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Required to update oci repo dependency for
https://github.com/open-component-model/open-component-model/pull/913

#### Which issue(s) this PR fixes
Contributes https://github.com/open-component-model/ocm-project/issues/575
