### PR TITLE
chore: add debug log if no plugins were loaded

### DIFF
--- a/cli/cmd/setup/setup.go
+++ b/cli/cmd/setup/setup.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -54,6 +55,7 @@ func PluginManager(cmd *cobra.Command) error {
 			pluginCfg.IdleTimeout = v2alpha1.Duration(time.Hour)
 		}
 
+		var loadedAnyPlugins bool
 		for _, pluginLocation := range pluginCfg.Locations {
 			err := pluginManager.RegisterPlugins(cmd.Context(), pluginLocation,
 				manager.WithIdleTimeout(time.Duration(pluginCfg.IdleTimeout)),
@@ -65,6 +67,12 @@ func PluginManager(cmd *cobra.Command) error {
 			if err != nil {
 				return err
 			}
+
+			loadedAnyPlugins = true
+		}
+
+		if !loadedAnyPlugins {
+			slog.DebugContext(cmd.Context(), "no plugins found at any of the configured locations", slog.String("locations", strings.Join(pluginCfg.Locations, ", ")))
 		}
 	}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Fixes https://github.com/open-component-model/open-component-model/issues/622.

Basically, if there were no locations configured or we didn't find any plugins at any of the given locations we utter a final warning that there are NO plugins configured AT ALL.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
