### PR TITLE
chore: columnar output combined with the visual tree hierarchy

### DIFF
--- a/cli/cmd/cmd_test.go
+++ b/cli/cmd/cmd_test.go
@@ -132,10 +132,11 @@ COMPONENT                   │ VERSION │ PROVIDER
 			expectedError:  false,
 		},
 		{
-			name:           "tree output",
-			args:           []string{"get", "cv", path, "--output=tree"},
-			expectedOutput: "── ocm.software/test-component:0.0.1",
-			expectedError:  false,
+			name: "tree output",
+			args: []string{"get", "cv", path, "--output=tree"},
+			expectedOutput: `NESTING  COMPONENT                    VERSION  PROVIDER      IDENTITY                                       
+ └─       ocm.software/test-component  0.0.1    ocm.software  name=ocm.software/test-component,version=0.0.1`,
+			expectedError: false,
 		},
 		{
 			name:           "Invalid output format",
@@ -326,9 +327,10 @@ COMPONENT           │ VERSION │ PROVIDER
 		{
 			name: "tree output",
 			args: []string{"get", "cv", path, "--output=tree", "--recursive=-1"},
-			expectedOutput: `── ocm.software/root:0.0.1
-   ├─ ocm.software/leaf-a:0.0.1
-   ╰─ ocm.software/leaf-b:0.0.1`,
+			expectedOutput: `NESTING  COMPONENT            VERSION  PROVIDER      IDENTITY                               
+ └─ ●     ocm.software/root    0.0.1    ocm.software  name=ocm.software/root,version=0.0.1   
+    ├─    ocm.software/leaf-a  0.0.1    ocm.software  name=ocm.software/leaf-a,version=0.0.1 
+    └─    ocm.software/leaf-b  0.0.1    ocm.software  name=ocm.software/leaf-b,version=0.0.1`,
 			expectedError: false,
 		},
 	}
@@ -602,11 +604,12 @@ COMPONENT           │ VERSION │ PROVIDER
 		{
 			name: "tree output - all versions",
 			args: []string{"get", "cv", path, "--output=tree", "--recursive=-1"},
-			expectedOutput: `╭─ ocm.software/root:0.0.2
-│  ╰─ ocm.software/leaf-a:0.0.1
-╰─ ocm.software/root:0.0.1
-   ├─ ocm.software/leaf-a:0.0.1
-   ╰─ ocm.software/leaf-b:0.0.1`,
+			expectedOutput: `NESTING  COMPONENT            VERSION  PROVIDER      IDENTITY                               
+ ├─ ●     ocm.software/root    0.0.2    ocm.software  name=ocm.software/root,version=0.0.2   
+ │  └─    ocm.software/leaf-a  0.0.1    ocm.software  name=ocm.software/leaf-a,version=0.0.1 
+ └─ ●     ocm.software/root    0.0.1    ocm.software  name=ocm.software/root,version=0.0.1   
+    ├─    ocm.software/leaf-a  0.0.1    ocm.software  name=ocm.software/leaf-a,version=0.0.1 
+    └─    ocm.software/leaf-b  0.0.1    ocm.software  name=ocm.software/leaf-b,version=0.0.1`,
 			expectedError: false,
 		},
 		{

--- a/cli/cmd/get/component-version/cmd.go
+++ b/cli/cmd/get/component-version/cmd.go
@@ -234,8 +234,7 @@ func buildRenderer(ctx context.Context, dag *syncdag.DirectedAcyclicGraph[string
 		serializer := buildMachineFormatSerializer(format)
 		return list.New(ctx, dag, list.WithListSerializer(serializer), list.WithRoots(roots...)), nil
 	case render.OutputFormatTree.String():
-		serializer := buildTreeFormatSerializer()
-		return tree.New(ctx, dag, tree.WithVertexSerializer(serializer), tree.WithRoots(roots...)), nil
+		return tree.New(ctx, dag, tree.WithRoots(roots...)), nil
 	case render.OutputFormatTable.String():
 		serializer := buildTableFormatSerializer()
 		return list.New(ctx, dag, list.WithListSerializer(serializer), list.WithRoots(roots...)), nil
@@ -264,13 +263,6 @@ func buildMachineFormatSerializer(format string) list.ListSerializer[string] {
 	default:
 		panic(fmt.Errorf("invalid machine output format %q", format)) // should not happen as checked before
 	}
-}
-
-func buildTreeFormatSerializer() tree.VertexSerializer[string] {
-	return tree.VertexSerializerFunc[string](func(vertex *syncdag.Vertex[string]) (string, error) {
-		id, _ := runtime.ParseIdentity(vertex.ID)
-		return fmt.Sprintf("%s:%s", id[descruntime.IdentityAttributeName], id[descruntime.IdentityAttributeVersion]), nil
-	})
 }
 
 func buildTableFormatSerializer() list.ListSerializer[string] {

--- a/cli/internal/render/graph/tree/renderer.go
+++ b/cli/internal/render/graph/tree/renderer.go
@@ -92,15 +92,17 @@ func (t *Renderer[T]) Render(ctx context.Context, writer io.Writer) error {
 		// we want to preserve the order.
 		slices.Sort(roots)
 	} else {
-		for index, root := range roots {
-			if _, exists := t.dag.GetVertex(root); !exists {
+		filteredRoots := make([]T, 0, len(roots))
+		for _, root := range roots {
+			if _, exists := t.dag.GetVertex(root); exists {
 				// If root does not exist in the dag yet, we exclude it from the
 				// current rendering run.
 				// The root might be added to the graph, after the rendering
 				// has started, so we do not want to fail the rendering.
-				roots = append(roots[:index], roots[index+1:]...)
+				filteredRoots = append(filteredRoots, root)
 			}
 		}
+		roots = filteredRoots
 	}
 
 	for i, root := range roots {

--- a/cli/internal/render/graph/tree/renderer.go
+++ b/cli/internal/render/graph/tree/renderer.go
@@ -7,30 +7,40 @@ import (
 	"io"
 	"log/slog"
 	"slices"
+	"strings"
+	"unicode/utf8"
 
-	"github.com/jedib0t/go-pretty/v6/list"
+	"github.com/jedib0t/go-pretty/v6/table"
 
 	syncdag "ocm.software/open-component-model/bindings/go/dag/sync"
 	"ocm.software/open-component-model/cli/internal/render/graph"
 )
 
-// Renderer renders a tree structure from a DirectedAcyclicGraph.
-// The output rendered by the Renderer looks like this:
+// Renderer prints a tree from a DirectedAcyclicGraph as a table.
+// Columns: NESTING, COMPONENT, VERSION, PROVIDER, IDENTITY.
+// NESTING shows the tree structure using Unicode box-drawing characters from [TreeStyle].
 //
-//	── A
-//	   ├─ B
-//	   │  ╰─ C
-//	   ╰─ D
+// Example output:
 //
-// Each letter corresponds to a vertex in the DirectedAcyclicGraph. The concrete
-// representation of the vertex is defined by the VertexSerializer.
+//	NESTING   COMPONENT     VERSION  PROVIDER  IDENTITY
+//	├─ ●      app-frontend  v1.2.0   acme      A
+//	│  ├─ ●   ui-library    v2.1.0   acme      B
+//	│  │  └─  icons         v1.0.0   other     C
+//	│  └─     api-client    v3.0.0   acme      D
+//	├─ ●      app-backend   v2.0.0   acme      X
+//	│  └─     database      v1.1.0   acme      Y
+//	└─        cache-layer   v0.9.0   other     Z
 type Renderer[T cmp.Ordered] struct {
-	// The listWriter is used to write the tree structure. It holds manages
-	// the indentation and style of the output.
-	listWriter list.Writer
-	// The VertexSerializer serializes a vertex to a string.
+	// The tableWriter outputs a table and holds the visual NESTING column.
+	// It manages the formatting/style and the output destination.
+	tableWriter table.Writer
+	// The VertexSerializer serializes a vertex to a Row struct.
 	// It MUST perform READ-ONLY access to the vertex and its attributes.
 	vertexSerializer VertexSerializer[T]
+	// Tree drawing style used for the NESTING column.
+	style TreeStyle
+	// Table style used for the go-pretty table renderer.
+	tableStyle table.Style
 	// The roots of the tree to render.
 	// The roots are part of the Renderer instead of being passed to the
 	// Render method to keep renderer.Renderer decoupled of specific data
@@ -42,20 +52,6 @@ type Renderer[T cmp.Ordered] struct {
 	dag *syncdag.DirectedAcyclicGraph[T]
 }
 
-// VertexSerializer is an interface that defines a method to serialize a vertex.
-type VertexSerializer[T cmp.Ordered] interface {
-	Serialize(*syncdag.Vertex[T]) (string, error)
-}
-
-// VertexSerializerFunc is a function type that implements the VertexSerializer
-// interface.
-type VertexSerializerFunc[T cmp.Ordered] func(*syncdag.Vertex[T]) (string, error)
-
-// Serialize implements the VertexSerializer interface for VertexSerializerFunc.
-func (f VertexSerializerFunc[T]) Serialize(v *syncdag.Vertex[T]) (string, error) {
-	return f(v)
-}
-
 // New creates a new Renderer for the given DirectedAcyclicGraph.
 func New[T cmp.Ordered](ctx context.Context, dag *syncdag.DirectedAcyclicGraph[T], opts ...RendererOption[T]) *Renderer[T] {
 	options := &RendererOptions[T]{}
@@ -64,12 +60,7 @@ func New[T cmp.Ordered](ctx context.Context, dag *syncdag.DirectedAcyclicGraph[T
 	}
 
 	if options.VertexSerializer == nil {
-		options.VertexSerializer = VertexSerializerFunc[T](func(v *syncdag.Vertex[T]) (string, error) {
-			// Default serializer just returns the vertex ID.
-			// This is supposed to be overridden by the user to provide a
-			// meaningful representation.
-			return fmt.Sprintf("%v", v.ID), nil
-		})
+		options.VertexSerializer = defaultVertexSerializer[T]()
 	}
 
 	if len(options.Roots) == 0 {
@@ -77,8 +68,10 @@ func New[T cmp.Ordered](ctx context.Context, dag *syncdag.DirectedAcyclicGraph[T
 	}
 
 	return &Renderer[T]{
-		listWriter:       list.NewWriter(),
+		tableWriter:      table.NewWriter(),
 		vertexSerializer: options.VertexSerializer,
+		style:            DefaultTreeStyle,
+		tableStyle:       defaultTableStyle(),
 		roots:            options.Roots,
 		dag:              dag,
 	}
@@ -87,8 +80,10 @@ func New[T cmp.Ordered](ctx context.Context, dag *syncdag.DirectedAcyclicGraph[T
 // Render renders the tree structure starting from the root ID.
 // It writes the output to the provided writer.
 func (t *Renderer[T]) Render(ctx context.Context, writer io.Writer) error {
-	t.listWriter.SetStyle(list.StyleConnectedRounded)
-	defer t.listWriter.Reset()
+	defer t.tableWriter.ResetHeaders()
+	defer t.tableWriter.ResetRows()
+	t.tableWriter.SetStyle(t.tableStyle)
+	t.tableWriter.AppendHeader(table.Row{"NESTING", "COMPONENT", "VERSION", "PROVIDER", "IDENTITY"})
 
 	roots := t.roots
 	if len(roots) == 0 {
@@ -108,36 +103,87 @@ func (t *Renderer[T]) Render(ctx context.Context, writer io.Writer) error {
 		}
 	}
 
-	for _, root := range roots {
-		if err := t.traverseGraph(ctx, root); err != nil {
+	for i, root := range roots {
+		isLast := i == len(roots)-1
+		if err := t.traverseGraph(ctx, root, 0, true, isLast, nil); err != nil {
 			return fmt.Errorf("failed to traverse graph: %w", err)
 		}
 	}
-	t.listWriter.SetOutputMirror(writer)
-	t.listWriter.Render()
+	t.tableWriter.SetOutputMirror(writer)
+	t.tableWriter.Render()
 	return nil
 }
 
-func (t *Renderer[T]) traverseGraph(ctx context.Context, nodeId T) error {
+// traverseGraph recursively walks the DAG and adds each vertex as a table row with proper tree nesting.
+func (t *Renderer[T]) traverseGraph(ctx context.Context, nodeId T, level int, isRoot, isLast bool, ancestorsHasMore []bool) error {
 	vertex, ok := t.dag.GetVertex(nodeId)
 	if !ok {
 		return fmt.Errorf("vertex for nodeId %v does not exist", nodeId)
 	}
-	item, err := t.vertexSerializer.Serialize(vertex)
+	row, err := t.vertexSerializer.Serialize(vertex)
 	if err != nil {
 		return fmt.Errorf("failed to serialize vertex %v: %w", vertex.ID, err)
 	}
-	t.listWriter.AppendItem(item)
 
-	// Get children and sort them for stable output
+	// Determine children to build proper nesting tree
 	children := graph.GetNeighborsSorted(ctx, vertex)
+	hasChildren := len(children) > 0
+	nesting := buildNesting(t.style, ancestorsHasMore, isLast, hasChildren)
+	t.tableWriter.AppendRow(table.Row{nesting, row.Component, row.Version, row.Provider, row.Identity})
 
-	for _, child := range children {
-		t.listWriter.Indent()
-		if err := t.traverseGraph(ctx, child); err != nil {
+	// Recurse into children
+	for i, child := range children {
+		childIsLast := i == len(children)-1
+		// For descendants, include whether the current node has more siblings after it
+		// Create a new slice to track ancestor vertical line states for the child nodes
+		nextAncestors := make([]bool, 0, len(ancestorsHasMore)+1)
+		// Copy all existing ancestor states (whether each ancestor level needs vertical lines)
+		nextAncestors = append(nextAncestors, ancestorsHasMore...)
+		// Determine if current node needs a vertical connector (true if it has siblings below it)
+		connector := !isLast
+		// Add current node's connector state to the ancestor tracking for its children
+		nextAncestors = append(nextAncestors, connector)
+		if err := t.traverseGraph(ctx, child, level+1, false, childIsLast, nextAncestors); err != nil {
 			return err
 		}
-		t.listWriter.UnIndent()
 	}
 	return nil
+}
+
+// buildNesting constructs the visual tree structure prefix for each row in the NESTING column.
+// The function builds a string that represents the tree structure.
+//
+// Parameters:
+//   - style: the tree drawing characters to use
+//   - ancestorsHasMore: per-ancestor flags indicating whether that level has more siblings after the current node
+//   - isLast: whether this is the last sibling at its level
+//   - hasChildren: whether this node has child nodes
+func buildNesting(style TreeStyle, ancestorsHasMore []bool, isLast bool, hasChildren bool) string {
+	var result strings.Builder
+
+	// Draw vertical connectors for each ancestor level
+	// Each ancestor that has more siblings gets a vertical line [style.CharItemVertical], others get spaces
+	verticalWidth := utf8.RuneCountInString(style.CharItemVertical)
+	for _, hasMoreSiblings := range ancestorsHasMore {
+		if hasMoreSiblings {
+			result.WriteString(style.CharItemVertical)
+		} else {
+			result.WriteString(strings.Repeat(" ", verticalWidth))
+		}
+	}
+
+	// Add the branch connector for this node
+	// Use [style.CharItemMiddle] if there are more siblings after this one, [style.CharItemBottom] if this is the last
+	if isLast {
+		result.WriteString(style.CharItemBottom)
+	} else {
+		result.WriteString(style.CharItemMiddle)
+	}
+
+	// Add child indicator if this node has children
+	if hasChildren {
+		result.WriteString(style.CharChildIndicator)
+	}
+
+	return result.String()
 }

--- a/cli/internal/render/graph/tree/renderer_options.go
+++ b/cli/internal/render/graph/tree/renderer_options.go
@@ -3,33 +3,21 @@ package tree
 import (
 	"cmp"
 
-	syncdag "ocm.software/open-component-model/bindings/go/dag/sync"
+	"github.com/jedib0t/go-pretty/v6/table"
 )
 
 // RendererOptions defines the options for the tree Renderer.
 type RendererOptions[T cmp.Ordered] struct {
-	// VertexSerializer serializes a vertex to a string.
+	// VertexSerializer serializes a vertex into a Row.
 	VertexSerializer VertexSerializer[T]
 	// Roots are the root vertices of the tree to render.
 	Roots []T
+	// TableStyle allows customizing the go-pretty table style used by the renderer.
+	TableStyle table.Style
 }
 
 // RendererOption is a function that modifies the RendererOptions.
 type RendererOption[T cmp.Ordered] func(*RendererOptions[T])
-
-// WithVertexSerializer sets the VertexSerializer for the Renderer.
-func WithVertexSerializer[T cmp.Ordered](serializer VertexSerializer[T]) RendererOption[T] {
-	return func(opts *RendererOptions[T]) {
-		opts.VertexSerializer = serializer
-	}
-}
-
-// WithVertexSerializerFunc sets the VertexSerializer based on a function.
-func WithVertexSerializerFunc[T cmp.Ordered](serializerFunc func(*syncdag.Vertex[T]) (string, error)) RendererOption[T] {
-	return func(opts *RendererOptions[T]) {
-		opts.VertexSerializer = VertexSerializerFunc[T](serializerFunc)
-	}
-}
 
 // WithRoots sets the roots for the Renderer.
 func WithRoots[T cmp.Ordered](roots ...T) RendererOption[T] {

--- a/cli/internal/render/graph/tree/renderer_test.go
+++ b/cli/internal/render/graph/tree/renderer_test.go
@@ -11,8 +11,23 @@ import (
 
 	"github.com/stretchr/testify/require"
 	syncdag "ocm.software/open-component-model/bindings/go/dag/sync"
+	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
 	"ocm.software/open-component-model/cli/internal/render"
 )
+
+func withTestAttributes(state syncdag.DiscoveryState, name, version, provider string) map[string]any {
+	return map[string]any{syncdag.AttributeDiscoveryState: state, descriptorAttribute: &descriptor.Descriptor{
+		Component: descriptor.Component{
+			ComponentMeta: descriptor.ComponentMeta{
+				ObjectMeta: descriptor.ObjectMeta{
+					Name:    name,
+					Version: version,
+				},
+			},
+			Provider: descriptor.Provider{Name: provider},
+		},
+	}}
+}
 
 func TestRunRenderLoop(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
@@ -24,9 +39,17 @@ func TestRunRenderLoop(t *testing.T) {
 		buf := &bytes.Buffer{}
 		logWriter := testLogWriter{t}
 		writer := io.MultiWriter(buf, logWriter)
-		vertexSerializer := func(v *syncdag.Vertex[string]) (string, error) {
-			state, _ := v.Attributes.Load(syncdag.AttributeDiscoveryState)
-			return fmt.Sprintf("%s (%s)", v.ID, state.(syncdag.DiscoveryState)), nil
+		vertexSerializer := func(vertex *syncdag.Vertex[string]) (Row, error) {
+			state, _ := vertex.Attributes.Load(syncdag.AttributeDiscoveryState)
+			if d, ok := vertex.MustGetAttribute(descriptorAttribute).(*descriptor.Descriptor); ok {
+				return Row{
+					Component: fmt.Sprintf("%s (%s)", d.Component.Name, state.(syncdag.DiscoveryState)),
+					Version:   d.Component.Version,
+					Provider:  d.Component.Provider.Name,
+					Identity:  fmt.Sprintf("%v", vertex.ID),
+				}, nil
+			}
+			return Row{}, fmt.Errorf("vertex %v does not have a descriptor attribute", vertex.ID)
 		}
 
 		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
@@ -35,7 +58,7 @@ func TestRunRenderLoop(t *testing.T) {
 		refreshRate := 10 * time.Millisecond
 		waitFunc := render.RunRenderLoop(ctx, renderer, render.WithRefreshRate(refreshRate), render.WithRenderOptions(render.WithWriter(writer)))
 
-		r.NoError(d.AddVertex("A", map[string]any{syncdag.AttributeDiscoveryState: syncdag.DiscoveryStateDiscovering}))
+		r.NoError(d.AddVertex("A", withTestAttributes(syncdag.DiscoveryStateDiscovering, "comp-a", "v1.0.0", "acme")))
 
 		// sleep to allow ticker based render loop to start
 		time.Sleep(refreshRate)
@@ -43,7 +66,8 @@ func TestRunRenderLoop(t *testing.T) {
 		// without this, the test would be flaky or fail
 		synctest.Wait()
 		output := buf.String()
-		expected := `── A (discovering)
+		expected := ` NESTING  COMPONENT             VERSION  PROVIDER  IDENTITY 
+ └─       comp-a (discovering)  v1.0.0   acme      A        
 `
 		r.Equal(expected, output)
 		buf.Reset()
@@ -61,43 +85,46 @@ func TestRunRenderLoop(t *testing.T) {
 		buf.Reset()
 
 		// Add B as child of A
-		r.NoError(d.AddVertex("B", map[string]any{syncdag.AttributeDiscoveryState: syncdag.DiscoveryStateDiscovering}))
+		r.NoError(d.AddVertex("B", withTestAttributes(syncdag.DiscoveryStateDiscovering, "comp-b", "v2.0.0", "acme")))
 		r.NoError(d.AddEdge("A", "B"))
 		vB, _ := d.GetVertex("B")
 		time.Sleep(refreshRate)
 		synctest.Wait()
 		output = buf.String()
-		expected = render.EraseNLines(1) + `── A (discovering)
-   ╰─ B (discovering)
+		expected = render.EraseNLines(2) + ` NESTING  COMPONENT             VERSION  PROVIDER  IDENTITY 
+ └─ ●     comp-a (discovering)  v1.0.0   acme      A        
+    └─    comp-b (discovering)  v2.0.0   acme      B        
 `
 		r.Equal(expected, output)
 		buf.Reset()
 
 		// Add C as child of B
-		r.NoError(d.AddVertex("C", map[string]any{syncdag.AttributeDiscoveryState: syncdag.DiscoveryStateDiscovering}))
+		r.NoError(d.AddVertex("C", withTestAttributes(syncdag.DiscoveryStateDiscovering, "comp-c", "v1.5.0", "other")))
 		r.NoError(d.AddEdge("B", "C"))
 		vC, _ := d.GetVertex("C")
 		time.Sleep(refreshRate)
 		synctest.Wait()
 		output = buf.String()
-		expected = render.EraseNLines(2) + `── A (discovering)
-   ╰─ B (discovering)
-      ╰─ C (discovering)
+		expected = render.EraseNLines(3) + ` NESTING   COMPONENT             VERSION  PROVIDER  IDENTITY 
+ └─ ●      comp-a (discovering)  v1.0.0   acme      A        
+    └─ ●   comp-b (discovering)  v2.0.0   acme      B        
+       └─  comp-c (discovering)  v1.5.0   other     C        
 `
 		r.Equal(expected, output)
 		buf.Reset()
 
 		// Add D as another child of A
-		r.NoError(d.AddVertex("D", map[string]any{syncdag.AttributeDiscoveryState: syncdag.DiscoveryStateDiscovering}))
+		r.NoError(d.AddVertex("D", withTestAttributes(syncdag.DiscoveryStateDiscovering, "comp-d", "v3.0.0", "acme")))
 		r.NoError(d.AddEdge("A", "D"))
 		vD, _ := d.GetVertex("D")
 		time.Sleep(refreshRate)
 		synctest.Wait()
 		output = buf.String()
-		expected = render.EraseNLines(3) + `── A (discovering)
-   ├─ B (discovering)
-   │  ╰─ C (discovering)
-   ╰─ D (discovering)
+		expected = render.EraseNLines(4) + ` NESTING   COMPONENT             VERSION  PROVIDER  IDENTITY 
+ └─ ●      comp-a (discovering)  v1.0.0   acme      A        
+    ├─ ●   comp-b (discovering)  v2.0.0   acme      B        
+    │  └─  comp-c (discovering)  v1.5.0   other     C        
+    └─     comp-d (discovering)  v3.0.0   acme      D        
 `
 		r.Equal(expected, output)
 		buf.Reset()
@@ -107,10 +134,11 @@ func TestRunRenderLoop(t *testing.T) {
 		time.Sleep(refreshRate)
 		synctest.Wait()
 		output = buf.String()
-		expected = render.EraseNLines(4) + `── A (discovering)
-   ├─ B (discovering)
-   │  ╰─ C (discovering)
-   ╰─ D (completed)
+		expected = render.EraseNLines(5) + ` NESTING   COMPONENT             VERSION  PROVIDER  IDENTITY 
+ └─ ●      comp-a (discovering)  v1.0.0   acme      A        
+    ├─ ●   comp-b (discovering)  v2.0.0   acme      B        
+    │  └─  comp-c (discovering)  v1.5.0   other     C        
+    └─     comp-d (completed)    v3.0.0   acme      D        
 `
 		r.Equal(expected, output)
 		buf.Reset()
@@ -120,10 +148,11 @@ func TestRunRenderLoop(t *testing.T) {
 		time.Sleep(refreshRate)
 		synctest.Wait()
 		output = buf.String()
-		expected = render.EraseNLines(4) + `── A (discovering)
-   ├─ B (discovering)
-   │  ╰─ C (completed)
-   ╰─ D (completed)
+		expected = render.EraseNLines(5) + ` NESTING   COMPONENT             VERSION  PROVIDER  IDENTITY 
+ └─ ●      comp-a (discovering)  v1.0.0   acme      A        
+    ├─ ●   comp-b (discovering)  v2.0.0   acme      B        
+    │  └─  comp-c (completed)    v1.5.0   other     C        
+    └─     comp-d (completed)    v3.0.0   acme      D        
 `
 		r.Equal(expected, output)
 		buf.Reset()
@@ -133,10 +162,11 @@ func TestRunRenderLoop(t *testing.T) {
 		time.Sleep(refreshRate)
 		synctest.Wait()
 		output = buf.String()
-		expected = render.EraseNLines(4) + `── A (discovering)
-   ├─ B (completed)
-   │  ╰─ C (completed)
-   ╰─ D (completed)
+		expected = render.EraseNLines(5) + ` NESTING   COMPONENT             VERSION  PROVIDER  IDENTITY 
+ └─ ●      comp-a (discovering)  v1.0.0   acme      A        
+    ├─ ●   comp-b (completed)    v2.0.0   acme      B        
+    │  └─  comp-c (completed)    v1.5.0   other     C        
+    └─     comp-d (completed)    v3.0.0   acme      D        
 `
 		r.Equal(expected, output)
 		buf.Reset()
@@ -147,10 +177,31 @@ func TestRunRenderLoop(t *testing.T) {
 		time.Sleep(refreshRate)
 		synctest.Wait()
 		output = buf.String()
-		expected = render.EraseNLines(4) + `── A (completed)
-   ├─ B (completed)
-   │  ╰─ C (completed)
-   ╰─ D (completed)
+		expected = render.EraseNLines(5) + ` NESTING   COMPONENT           VERSION  PROVIDER  IDENTITY 
+ └─ ●      comp-a (completed)  v1.0.0   acme      A        
+    ├─ ●   comp-b (completed)  v2.0.0   acme      B        
+    │  └─  comp-c (completed)  v1.5.0   other     C        
+    └─     comp-d (completed)  v3.0.0   acme      D        
+`
+		r.Equal(expected, output)
+		buf.Reset()
+
+		// Multiple roots
+		r.NoError(d.AddVertex("X", withTestAttributes(syncdag.DiscoveryStateDiscovering, "comp-d", "v3.0.0", "acme")))
+		r.NoError(d.AddVertex("Y", withTestAttributes(syncdag.DiscoveryStateDiscovering, "comp-d", "v3.0.0", "acme")))
+		r.NoError(d.AddVertex("Z", withTestAttributes(syncdag.DiscoveryStateDiscovering, "comp-d", "v3.0.0", "acme")))
+		r.NoError(d.AddEdge("X", "Z"))
+		time.Sleep(refreshRate)
+		synctest.Wait()
+		output = buf.String()
+		expected = render.EraseNLines(5) + ` NESTING   COMPONENT             VERSION  PROVIDER  IDENTITY 
+ ├─ ●      comp-a (completed)    v1.0.0   acme      A        
+ │  ├─ ●   comp-b (completed)    v2.0.0   acme      B        
+ │  │  └─  comp-c (completed)    v1.5.0   other     C        
+ │  └─     comp-d (completed)    v3.0.0   acme      D        
+ ├─ ●      comp-d (discovering)  v3.0.0   acme      X        
+ │  └─     comp-d (discovering)  v3.0.0   acme      Z        
+ └─        comp-d (discovering)  v3.0.0   acme      Y        
 `
 		r.Equal(expected, output)
 
@@ -172,8 +223,9 @@ func TestRenderOnce(t *testing.T) {
 
 	renderer := New(ctx, d)
 
-	r.NoError(d.AddVertex("A"))
-	expected := `── A
+	r.NoError(d.AddVertex("A", withTestAttributes(syncdag.DiscoveryStateDiscovering, "comp-a", "v1.0.0", "acme")))
+	expected := ` NESTING  COMPONENT  VERSION  PROVIDER  IDENTITY 
+ └─       comp-a     v1.0.0   acme      A        
 `
 	r.NoError(render.RenderOnce(ctx, renderer, render.WithWriter(writer)))
 	output := buf.String()
@@ -181,9 +233,10 @@ func TestRenderOnce(t *testing.T) {
 	r.Equal(expected, output)
 
 	// Add B
-	r.NoError(d.AddVertex("B"))
-	expected = `╭─ A
-╰─ B
+	r.NoError(d.AddVertex("B", withTestAttributes(syncdag.DiscoveryStateDiscovering, "comp-b", "v2.0.0", "acme")))
+	expected = ` NESTING  COMPONENT  VERSION  PROVIDER  IDENTITY 
+ ├─       comp-a     v1.0.0   acme      A        
+ └─       comp-b     v2.0.0   acme      B        
 `
 	r.NoError(render.RenderOnce(ctx, renderer, render.WithWriter(writer)))
 	output = buf.String()
@@ -191,8 +244,9 @@ func TestRenderOnce(t *testing.T) {
 	r.Equal(expected, output)
 	// Add B as child of A
 	r.NoError(d.AddEdge("A", "B"))
-	expected = `── A
-   ╰─ B
+	expected = ` NESTING  COMPONENT  VERSION  PROVIDER  IDENTITY 
+ └─ ●     comp-a     v1.0.0   acme      A        
+    └─    comp-b     v2.0.0   acme      B        
 `
 	r.NoError(render.RenderOnce(ctx, renderer, render.WithWriter(writer)))
 	output = buf.String()
@@ -200,25 +254,25 @@ func TestRenderOnce(t *testing.T) {
 	r.Equal(expected, output)
 
 	// Add C as child of B
-	r.NoError(d.AddVertex("C"))
+	r.NoError(d.AddVertex("C", withTestAttributes(syncdag.DiscoveryStateDiscovering, "comp-c", "v1.5.0", "other")))
 	r.NoError(d.AddEdge("B", "C"))
 
 	// Add D as another child of A
-	r.NoError(d.AddVertex("D"))
+	r.NoError(d.AddVertex("D", withTestAttributes(syncdag.DiscoveryStateDiscovering, "comp-d", "v3.0.0", "acme")))
 	r.NoError(d.AddEdge("A", "D"))
 
 	r.NoError(render.RenderOnce(ctx, renderer, render.WithWriter(writer)))
-	expected = `── A
-   ├─ B
-   │  ╰─ C
-   ╰─ D
+	expected = ` NESTING   COMPONENT  VERSION  PROVIDER  IDENTITY 
+ └─ ●      comp-a     v1.0.0   acme      A        
+    ├─ ●   comp-b     v2.0.0   acme      B        
+    │  └─  comp-c     v1.5.0   other     C        
+    └─     comp-d     v3.0.0   acme      D        
 `
 	output = buf.String()
 	buf.Reset()
 	r.Equal(expected, output)
 
 	r.NoError(render.RenderOnce(ctx, renderer, render.WithWriter(writer)))
-	output = buf.String()
 }
 
 type testLogWriter struct{ t *testing.T }

--- a/cli/internal/render/graph/tree/renderer_test.go
+++ b/cli/internal/render/graph/tree/renderer_test.go
@@ -46,7 +46,7 @@ func TestRunRenderLoop(t *testing.T) {
 					Component: fmt.Sprintf("%s (%s)", d.Component.Name, state.(syncdag.DiscoveryState)),
 					Version:   d.Component.Version,
 					Provider:  d.Component.Provider.Name,
-					Identity:  fmt.Sprintf("%v", vertex.ID),
+					Identity:  d.Component.ToIdentity().String(),
 				}, nil
 			}
 			return Row{}, fmt.Errorf("vertex %v does not have a descriptor attribute", vertex.ID)
@@ -66,8 +66,8 @@ func TestRunRenderLoop(t *testing.T) {
 		// without this, the test would be flaky or fail
 		synctest.Wait()
 		output := buf.String()
-		expected := ` NESTING  COMPONENT             VERSION  PROVIDER  IDENTITY 
- └─       comp-a (discovering)  v1.0.0   acme      A        
+		expected := ` NESTING  COMPONENT             VERSION  PROVIDER  IDENTITY                   
+ └─       comp-a (discovering)  v1.0.0   acme      name=comp-a,version=v1.0.0 
 `
 		r.Equal(expected, output)
 		buf.Reset()
@@ -91,9 +91,9 @@ func TestRunRenderLoop(t *testing.T) {
 		time.Sleep(refreshRate)
 		synctest.Wait()
 		output = buf.String()
-		expected = render.EraseNLines(2) + ` NESTING  COMPONENT             VERSION  PROVIDER  IDENTITY 
- └─ ●     comp-a (discovering)  v1.0.0   acme      A        
-    └─    comp-b (discovering)  v2.0.0   acme      B        
+		expected = render.EraseNLines(2) + ` NESTING  COMPONENT             VERSION  PROVIDER  IDENTITY                   
+ └─ ●     comp-a (discovering)  v1.0.0   acme      name=comp-a,version=v1.0.0 
+    └─    comp-b (discovering)  v2.0.0   acme      name=comp-b,version=v2.0.0 
 `
 		r.Equal(expected, output)
 		buf.Reset()
@@ -105,10 +105,10 @@ func TestRunRenderLoop(t *testing.T) {
 		time.Sleep(refreshRate)
 		synctest.Wait()
 		output = buf.String()
-		expected = render.EraseNLines(3) + ` NESTING   COMPONENT             VERSION  PROVIDER  IDENTITY 
- └─ ●      comp-a (discovering)  v1.0.0   acme      A        
-    └─ ●   comp-b (discovering)  v2.0.0   acme      B        
-       └─  comp-c (discovering)  v1.5.0   other     C        
+		expected = render.EraseNLines(3) + ` NESTING   COMPONENT             VERSION  PROVIDER  IDENTITY                   
+ └─ ●      comp-a (discovering)  v1.0.0   acme      name=comp-a,version=v1.0.0 
+    └─ ●   comp-b (discovering)  v2.0.0   acme      name=comp-b,version=v2.0.0 
+       └─  comp-c (discovering)  v1.5.0   other     name=comp-c,version=v1.5.0 
 `
 		r.Equal(expected, output)
 		buf.Reset()
@@ -120,11 +120,11 @@ func TestRunRenderLoop(t *testing.T) {
 		time.Sleep(refreshRate)
 		synctest.Wait()
 		output = buf.String()
-		expected = render.EraseNLines(4) + ` NESTING   COMPONENT             VERSION  PROVIDER  IDENTITY 
- └─ ●      comp-a (discovering)  v1.0.0   acme      A        
-    ├─ ●   comp-b (discovering)  v2.0.0   acme      B        
-    │  └─  comp-c (discovering)  v1.5.0   other     C        
-    └─     comp-d (discovering)  v3.0.0   acme      D        
+		expected = render.EraseNLines(4) + ` NESTING   COMPONENT             VERSION  PROVIDER  IDENTITY                   
+ └─ ●      comp-a (discovering)  v1.0.0   acme      name=comp-a,version=v1.0.0 
+    ├─ ●   comp-b (discovering)  v2.0.0   acme      name=comp-b,version=v2.0.0 
+    │  └─  comp-c (discovering)  v1.5.0   other     name=comp-c,version=v1.5.0 
+    └─     comp-d (discovering)  v3.0.0   acme      name=comp-d,version=v3.0.0 
 `
 		r.Equal(expected, output)
 		buf.Reset()
@@ -134,11 +134,11 @@ func TestRunRenderLoop(t *testing.T) {
 		time.Sleep(refreshRate)
 		synctest.Wait()
 		output = buf.String()
-		expected = render.EraseNLines(5) + ` NESTING   COMPONENT             VERSION  PROVIDER  IDENTITY 
- └─ ●      comp-a (discovering)  v1.0.0   acme      A        
-    ├─ ●   comp-b (discovering)  v2.0.0   acme      B        
-    │  └─  comp-c (discovering)  v1.5.0   other     C        
-    └─     comp-d (completed)    v3.0.0   acme      D        
+		expected = render.EraseNLines(5) + ` NESTING   COMPONENT             VERSION  PROVIDER  IDENTITY                   
+ └─ ●      comp-a (discovering)  v1.0.0   acme      name=comp-a,version=v1.0.0 
+    ├─ ●   comp-b (discovering)  v2.0.0   acme      name=comp-b,version=v2.0.0 
+    │  └─  comp-c (discovering)  v1.5.0   other     name=comp-c,version=v1.5.0 
+    └─     comp-d (completed)    v3.0.0   acme      name=comp-d,version=v3.0.0 
 `
 		r.Equal(expected, output)
 		buf.Reset()
@@ -148,11 +148,11 @@ func TestRunRenderLoop(t *testing.T) {
 		time.Sleep(refreshRate)
 		synctest.Wait()
 		output = buf.String()
-		expected = render.EraseNLines(5) + ` NESTING   COMPONENT             VERSION  PROVIDER  IDENTITY 
- └─ ●      comp-a (discovering)  v1.0.0   acme      A        
-    ├─ ●   comp-b (discovering)  v2.0.0   acme      B        
-    │  └─  comp-c (completed)    v1.5.0   other     C        
-    └─     comp-d (completed)    v3.0.0   acme      D        
+		expected = render.EraseNLines(5) + ` NESTING   COMPONENT             VERSION  PROVIDER  IDENTITY                   
+ └─ ●      comp-a (discovering)  v1.0.0   acme      name=comp-a,version=v1.0.0 
+    ├─ ●   comp-b (discovering)  v2.0.0   acme      name=comp-b,version=v2.0.0 
+    │  └─  comp-c (completed)    v1.5.0   other     name=comp-c,version=v1.5.0 
+    └─     comp-d (completed)    v3.0.0   acme      name=comp-d,version=v3.0.0 
 `
 		r.Equal(expected, output)
 		buf.Reset()
@@ -162,11 +162,11 @@ func TestRunRenderLoop(t *testing.T) {
 		time.Sleep(refreshRate)
 		synctest.Wait()
 		output = buf.String()
-		expected = render.EraseNLines(5) + ` NESTING   COMPONENT             VERSION  PROVIDER  IDENTITY 
- └─ ●      comp-a (discovering)  v1.0.0   acme      A        
-    ├─ ●   comp-b (completed)    v2.0.0   acme      B        
-    │  └─  comp-c (completed)    v1.5.0   other     C        
-    └─     comp-d (completed)    v3.0.0   acme      D        
+		expected = render.EraseNLines(5) + ` NESTING   COMPONENT             VERSION  PROVIDER  IDENTITY                   
+ └─ ●      comp-a (discovering)  v1.0.0   acme      name=comp-a,version=v1.0.0 
+    ├─ ●   comp-b (completed)    v2.0.0   acme      name=comp-b,version=v2.0.0 
+    │  └─  comp-c (completed)    v1.5.0   other     name=comp-c,version=v1.5.0 
+    └─     comp-d (completed)    v3.0.0   acme      name=comp-d,version=v3.0.0 
 `
 		r.Equal(expected, output)
 		buf.Reset()
@@ -177,11 +177,11 @@ func TestRunRenderLoop(t *testing.T) {
 		time.Sleep(refreshRate)
 		synctest.Wait()
 		output = buf.String()
-		expected = render.EraseNLines(5) + ` NESTING   COMPONENT           VERSION  PROVIDER  IDENTITY 
- └─ ●      comp-a (completed)  v1.0.0   acme      A        
-    ├─ ●   comp-b (completed)  v2.0.0   acme      B        
-    │  └─  comp-c (completed)  v1.5.0   other     C        
-    └─     comp-d (completed)  v3.0.0   acme      D        
+		expected = render.EraseNLines(5) + ` NESTING   COMPONENT           VERSION  PROVIDER  IDENTITY                   
+ └─ ●      comp-a (completed)  v1.0.0   acme      name=comp-a,version=v1.0.0 
+    ├─ ●   comp-b (completed)  v2.0.0   acme      name=comp-b,version=v2.0.0 
+    │  └─  comp-c (completed)  v1.5.0   other     name=comp-c,version=v1.5.0 
+    └─     comp-d (completed)  v3.0.0   acme      name=comp-d,version=v3.0.0 
 `
 		r.Equal(expected, output)
 		buf.Reset()
@@ -194,14 +194,14 @@ func TestRunRenderLoop(t *testing.T) {
 		time.Sleep(refreshRate)
 		synctest.Wait()
 		output = buf.String()
-		expected = render.EraseNLines(5) + ` NESTING   COMPONENT             VERSION  PROVIDER  IDENTITY 
- ├─ ●      comp-a (completed)    v1.0.0   acme      A        
- │  ├─ ●   comp-b (completed)    v2.0.0   acme      B        
- │  │  └─  comp-c (completed)    v1.5.0   other     C        
- │  └─     comp-d (completed)    v3.0.0   acme      D        
- ├─ ●      comp-d (discovering)  v3.0.0   acme      X        
- │  └─     comp-d (discovering)  v3.0.0   acme      Z        
- └─        comp-d (discovering)  v3.0.0   acme      Y        
+		expected = render.EraseNLines(5) + ` NESTING   COMPONENT             VERSION  PROVIDER  IDENTITY                   
+ ├─ ●      comp-a (completed)    v1.0.0   acme      name=comp-a,version=v1.0.0 
+ │  ├─ ●   comp-b (completed)    v2.0.0   acme      name=comp-b,version=v2.0.0 
+ │  │  └─  comp-c (completed)    v1.5.0   other     name=comp-c,version=v1.5.0 
+ │  └─     comp-d (completed)    v3.0.0   acme      name=comp-d,version=v3.0.0 
+ ├─ ●      comp-d (discovering)  v3.0.0   acme      name=comp-d,version=v3.0.0 
+ │  └─     comp-d (discovering)  v3.0.0   acme      name=comp-d,version=v3.0.0 
+ └─        comp-d (discovering)  v3.0.0   acme      name=comp-d,version=v3.0.0 
 `
 		r.Equal(expected, output)
 
@@ -224,8 +224,8 @@ func TestRenderOnce(t *testing.T) {
 	renderer := New(ctx, d)
 
 	r.NoError(d.AddVertex("A", withTestAttributes(syncdag.DiscoveryStateDiscovering, "comp-a", "v1.0.0", "acme")))
-	expected := ` NESTING  COMPONENT  VERSION  PROVIDER  IDENTITY 
- └─       comp-a     v1.0.0   acme      A        
+	expected := ` NESTING  COMPONENT  VERSION  PROVIDER  IDENTITY                   
+ └─       comp-a     v1.0.0   acme      name=comp-a,version=v1.0.0 
 `
 	r.NoError(render.RenderOnce(ctx, renderer, render.WithWriter(writer)))
 	output := buf.String()
@@ -234,9 +234,9 @@ func TestRenderOnce(t *testing.T) {
 
 	// Add B
 	r.NoError(d.AddVertex("B", withTestAttributes(syncdag.DiscoveryStateDiscovering, "comp-b", "v2.0.0", "acme")))
-	expected = ` NESTING  COMPONENT  VERSION  PROVIDER  IDENTITY 
- ├─       comp-a     v1.0.0   acme      A        
- └─       comp-b     v2.0.0   acme      B        
+	expected = ` NESTING  COMPONENT  VERSION  PROVIDER  IDENTITY                   
+ ├─       comp-a     v1.0.0   acme      name=comp-a,version=v1.0.0 
+ └─       comp-b     v2.0.0   acme      name=comp-b,version=v2.0.0 
 `
 	r.NoError(render.RenderOnce(ctx, renderer, render.WithWriter(writer)))
 	output = buf.String()
@@ -244,9 +244,9 @@ func TestRenderOnce(t *testing.T) {
 	r.Equal(expected, output)
 	// Add B as child of A
 	r.NoError(d.AddEdge("A", "B"))
-	expected = ` NESTING  COMPONENT  VERSION  PROVIDER  IDENTITY 
- └─ ●     comp-a     v1.0.0   acme      A        
-    └─    comp-b     v2.0.0   acme      B        
+	expected = ` NESTING  COMPONENT  VERSION  PROVIDER  IDENTITY                   
+ └─ ●     comp-a     v1.0.0   acme      name=comp-a,version=v1.0.0 
+    └─    comp-b     v2.0.0   acme      name=comp-b,version=v2.0.0 
 `
 	r.NoError(render.RenderOnce(ctx, renderer, render.WithWriter(writer)))
 	output = buf.String()
@@ -262,11 +262,11 @@ func TestRenderOnce(t *testing.T) {
 	r.NoError(d.AddEdge("A", "D"))
 
 	r.NoError(render.RenderOnce(ctx, renderer, render.WithWriter(writer)))
-	expected = ` NESTING   COMPONENT  VERSION  PROVIDER  IDENTITY 
- └─ ●      comp-a     v1.0.0   acme      A        
-    ├─ ●   comp-b     v2.0.0   acme      B        
-    │  └─  comp-c     v1.5.0   other     C        
-    └─     comp-d     v3.0.0   acme      D        
+	expected = ` NESTING   COMPONENT  VERSION  PROVIDER  IDENTITY                   
+ └─ ●      comp-a     v1.0.0   acme      name=comp-a,version=v1.0.0 
+    ├─ ●   comp-b     v2.0.0   acme      name=comp-b,version=v2.0.0 
+    │  └─  comp-c     v1.5.0   other     name=comp-c,version=v1.5.0 
+    └─     comp-d     v3.0.0   acme      name=comp-d,version=v3.0.0 
 `
 	output = buf.String()
 	buf.Reset()

--- a/cli/internal/render/graph/tree/serializer.go
+++ b/cli/internal/render/graph/tree/serializer.go
@@ -38,7 +38,7 @@ func defaultVertexSerializer[T cmp.Ordered]() VertexSerializer[T] {
 				Component: d.Component.Name,
 				Version:   d.Component.Version,
 				Provider:  d.Component.Provider.Name,
-				Identity:  fmt.Sprintf("%v", vertex.ID),
+				Identity:  d.Component.ToIdentity().String(),
 			}, nil
 		}
 		return Row{}, fmt.Errorf("vertex %v does not have a descriptor attribute", vertex.ID)

--- a/cli/internal/render/graph/tree/serializer.go
+++ b/cli/internal/render/graph/tree/serializer.go
@@ -1,0 +1,46 @@
+package tree
+
+import (
+	"cmp"
+	"fmt"
+
+	syncdag "ocm.software/open-component-model/bindings/go/dag/sync"
+	descruntime "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+)
+
+const (
+	descriptorAttribute = "descriptor"
+)
+
+// Row represents a single rendered row
+type Row struct {
+	Component string
+	Version   string
+	Provider  string
+	Identity  string
+}
+
+// VertexSerializer is an interface that defines a method to serialize a vertex.
+type VertexSerializer[T cmp.Ordered] interface {
+	Serialize(*syncdag.Vertex[T]) (Row, error)
+}
+
+type VertexSerializerFunc[T cmp.Ordered] func(*syncdag.Vertex[T]) (Row, error)
+
+func (f VertexSerializerFunc[T]) Serialize(v *syncdag.Vertex[T]) (Row, error) {
+	return f(v)
+}
+
+func defaultVertexSerializer[T cmp.Ordered]() VertexSerializer[T] {
+	return VertexSerializerFunc[T](func(vertex *syncdag.Vertex[T]) (Row, error) {
+		if d, ok := vertex.MustGetAttribute(descriptorAttribute).(*descruntime.Descriptor); ok {
+			return Row{
+				Component: d.Component.Name,
+				Version:   d.Component.Version,
+				Provider:  d.Component.Provider.Name,
+				Identity:  fmt.Sprintf("%v", vertex.ID),
+			}, nil
+		}
+		return Row{}, fmt.Errorf("vertex %v does not have a descriptor attribute", vertex.ID)
+	})
+}

--- a/cli/internal/render/graph/tree/serializer_options.go
+++ b/cli/internal/render/graph/tree/serializer_options.go
@@ -1,0 +1,21 @@
+package tree
+
+import (
+	"cmp"
+
+	syncdag "ocm.software/open-component-model/bindings/go/dag/sync"
+)
+
+// WithVertexSerializer sets the VertexSerializer for the Renderer.
+func WithVertexSerializer[T cmp.Ordered](serializer VertexSerializer[T]) RendererOption[T] {
+	return func(opts *RendererOptions[T]) {
+		opts.VertexSerializer = serializer
+	}
+}
+
+// WithVertexSerializerFunc sets the VertexSerializer based on a function.
+func WithVertexSerializerFunc[T cmp.Ordered](serializerFunc func(*syncdag.Vertex[T]) (Row, error)) RendererOption[T] {
+	return func(opts *RendererOptions[T]) {
+		opts.VertexSerializer = VertexSerializerFunc[T](serializerFunc)
+	}
+}

--- a/cli/internal/render/graph/tree/style.go
+++ b/cli/internal/render/graph/tree/style.go
@@ -1,0 +1,30 @@
+// Package tree provides functionality to render tree structures
+package tree
+
+import "github.com/jedib0t/go-pretty/v6/table"
+
+// TreeStyle defines the Unicode characters used for rendering tree structures.
+type TreeStyle struct {
+	// CharItemVertical is the character used for vertical lines (│)
+	CharItemVertical string
+	// CharItemMiddle is the character used for middle branch connectors (├─)
+	CharItemMiddle string
+	// CharItemBottom is the character used for bottom branch connectors (└─)
+	CharItemBottom string
+	// CharChildIndicator is the character used to indicate nodes with children (●)
+	CharChildIndicator string
+}
+
+var DefaultTreeStyle = TreeStyle{
+	CharItemVertical:   "│  ",
+	CharItemMiddle:     "├─",
+	CharItemBottom:     "└─",
+	CharChildIndicator: " ●",
+}
+
+func defaultTableStyle() table.Style {
+	style := table.StyleDefault
+	style.Options = table.OptionsNoBordersAndSeparators
+	style.Box.Right = ""
+	return style
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

This change refactored the tree renderer to use a column-aware output format (NESTING, COMPONENT, VERSION, PROVIDER, IDENTITY) combined with the visual tree hierarchy.

```shell
$ ocm cv ... -o tree

 NESTING  COMPONENT            VERSION  PROVIDER      IDENTITY                               
 ├─ ●     ocm.software/root    0.0.2    ocm.software  name=ocm.software/root,version=0.0.2   
 │  └─    ocm.software/leaf-a  0.0.1    ocm.software  name=ocm.software/leaf-a,version=0.0.1 
 └─ ●     ocm.software/root    0.0.1    ocm.software  name=ocm.software/root,version=0.0.1   
    ├─    ocm.software/leaf-a  0.0.1    ocm.software  name=ocm.software/leaf-a,version=0.0.1 
    └─    ocm.software/leaf-b  0.0.1    ocm.software  name=ocm.software/leaf-b,version=0.0.1
``` 

#### Which issue(s) this PR fixes

Fixes https://github.com/open-component-model/ocm-project/issues/607
