### PR TITLE
fix(ci): update go_modules task to use interleaved output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
             const { execSync } = require('child_process');
             
             // Get all Go modules using task
-            const modulesOutput = execSync('task go_modules', { encoding: 'utf-8' });
+            const modulesOutput = execSync('task go_modules --output interleaved', { encoding: 'utf-8' });
             const modules = modulesOutput.split('\n').filter(Boolean);
             
             // Generate filters for paths-filter


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

if we dont do this the output of the modules will be prefixed as our other tasks so it will not be possible to parse it just by new line.