### PR TITLE
feat(oci)!: enhance repository provider with user agent, temp dir, and caching support

### DIFF
--- a/bindings/go/oci/ctf/store.go
+++ b/bindings/go/oci/ctf/store.go
@@ -51,6 +51,7 @@ func NewFromCTF(store ctf.CTF) *Store {
 // - Handle blob operations (Fetch, Exists, Push) through the CTF's blob archive
 // - Emulate an OCM OCI Repository for accessing component versions stored in the CTF
 type Store struct {
+	mu      sync.RWMutex
 	archive ctf.CTF
 }
 
@@ -69,6 +70,7 @@ func (s *Store) StoreForReference(_ context.Context, reference string) (spec.Sto
 	ref := rawRef.(looseref.LooseReference)
 
 	return &Repository{
+		indexMu: &s.mu,
 		archive: s.archive,
 		repo:    ref.Repository,
 	}, nil
@@ -88,7 +90,7 @@ func (s *Store) ComponentVersionReference(ctx context.Context, component, versio
 type Repository struct {
 	archive ctf.CTF
 	repo    string
-	indexMu sync.RWMutex
+	indexMu *sync.RWMutex
 }
 
 // Fetch retrieves a blob from the CTF archive based on its descriptor.

--- a/bindings/go/oci/ctf/store.go
+++ b/bindings/go/oci/ctf/store.go
@@ -152,8 +152,8 @@ func (s *Repository) Push(ctx context.Context, expected ociImageSpecV1.Descripto
 func (s *Repository) Resolve(ctx context.Context, reference string) (ociImageSpecV1.Descriptor, error) {
 	var b blob.ReadOnlyBlob
 
-	s.indexMu.RLock()
-	defer s.indexMu.RUnlock()
+	s.indexMu.Lock()
+	defer s.indexMu.Unlock()
 
 	idx, err := s.archive.GetIndex(ctx)
 	if err != nil {

--- a/bindings/go/oci/go.mod
+++ b/bindings/go/oci/go.mod
@@ -2,6 +2,8 @@ module ocm.software/open-component-model/bindings/go/oci
 
 go 1.25.0
 
+replace ocm.software/open-component-model/bindings/go/ctf => github.com/fabianburth/open-component-model/bindings/go/ctf v0.0.0-20250930092919-8138a3fcda86
+
 require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/nlepage/go-tarfs v1.2.1

--- a/bindings/go/oci/go.sum
+++ b/bindings/go/oci/go.sum
@@ -10,6 +10,7 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/fabianburth/open-component-model/bindings/go/ctf v0.0.0-20250930092919-8138a3fcda86 h1:GDaANsBOKbS6VtlWCV9+nwGPm6eImgV8W6vn4/g7EIs=
 github.com/fabianburth/open-component-model/bindings/go/ctf v0.0.0-20250930092919-8138a3fcda86/go.mod h1:skMxA1l7rZFhKsjn8CysSVG31zjmV95WaFqMVKRjHug=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -62,8 +63,6 @@ ocm.software/open-component-model/bindings/go/blob v0.0.9 h1:XNK04PnqvsE6KHx/04m
 ocm.software/open-component-model/bindings/go/blob v0.0.9/go.mod h1:BjErnbAzzY4mJ6cO/hIFj8Gf/v9zerkIQ1Y1XQEOB5M=
 ocm.software/open-component-model/bindings/go/configuration v0.0.9 h1:bfgPD2G3fgmcbRYw0WXO3Fnx7+0G4gOV54JnYXgQY7w=
 ocm.software/open-component-model/bindings/go/configuration v0.0.9/go.mod h1:VZ8jQ3a6oTWyOpY09C7V3L0CfzKe9i1/Z4uJjLAVjN4=
-ocm.software/open-component-model/bindings/go/ctf v0.2.0 h1:BGZ+irknUVjZkOjL5j5bK5shmGWbOjpszfuETkPndVw=
-ocm.software/open-component-model/bindings/go/ctf v0.2.0/go.mod h1:L9JjTdoWDybr2YY9zXCsCAtNLracxW3aMK2f2TrqYZo=
 ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20251002101013-e0cc2f41d070 h1:NBkyeO+n6kQsvnM+BEmjrGfHlOW9DgXcaV7ENWZOF6w=
 ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20251002101013-e0cc2f41d070/go.mod h1:c1CaRWfjDfQhexg0oDscITPGwO6FgJ4f11kA6qhXZA4=
 ocm.software/open-component-model/bindings/go/descriptor/v2 v2.0.1-alpha3 h1:daGC2XnJEJkukGdhvKxobUH+vF5TKYPlVQ6nl5ASdFM=

--- a/bindings/go/oci/go.sum
+++ b/bindings/go/oci/go.sum
@@ -10,6 +10,7 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/fabianburth/open-component-model/bindings/go/ctf v0.0.0-20250930092919-8138a3fcda86/go.mod h1:skMxA1l7rZFhKsjn8CysSVG31zjmV95WaFqMVKRjHug=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/bindings/go/oci/integration/go.mod
+++ b/bindings/go/oci/integration/go.mod
@@ -2,6 +2,7 @@ module ocm.software/open-component-model/bindings/go/oci/integration
 
 go 1.25.0
 
+replace ocm.software/open-component-model/bindings/go/ctf => github.com/fabianburth/open-component-model/bindings/go/ctf v0.0.0-20250930092919-8138a3fcda86
 require (
 	github.com/nlepage/go-tarfs v1.2.1
 	github.com/opencontainers/go-digest v1.0.0

--- a/bindings/go/oci/integration/go.mod
+++ b/bindings/go/oci/integration/go.mod
@@ -3,6 +3,7 @@ module ocm.software/open-component-model/bindings/go/oci/integration
 go 1.25.0
 
 replace ocm.software/open-component-model/bindings/go/ctf => github.com/fabianburth/open-component-model/bindings/go/ctf v0.0.0-20250930092919-8138a3fcda86
+
 require (
 	github.com/nlepage/go-tarfs v1.2.1
 	github.com/opencontainers/go-digest v1.0.0

--- a/bindings/go/oci/integration/go.sum
+++ b/bindings/go/oci/integration/go.sum
@@ -44,6 +44,7 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/ebitengine/purego v0.8.4 h1:CF7LEKg5FFOsASUj0+QwaXf8Ht6TlFxg09+S9wz0omw=
 github.com/ebitengine/purego v0.8.4/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/fabianburth/open-component-model/bindings/go/ctf v0.0.0-20250930092919-8138a3fcda86/go.mod h1:skMxA1l7rZFhKsjn8CysSVG31zjmV95WaFqMVKRjHug=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/bindings/go/oci/repository/provider/credential_cache.go
+++ b/bindings/go/oci/repository/provider/credential_cache.go
@@ -113,7 +113,7 @@ func (c *storeCache) get(_ context.Context, path string) *oci.Store {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	store, _ := c.store[path]
+	store := c.store[path]
 	return store
 }
 

--- a/bindings/go/oci/repository/provider/credential_cache.go
+++ b/bindings/go/oci/repository/provider/credential_cache.go
@@ -7,6 +7,7 @@ import (
 
 	"oras.land/oras-go/v2/registry/remote/auth"
 
+	oci "ocm.software/open-component-model/bindings/go/oci/ctf"
 	ocirepospecv1 "ocm.software/open-component-model/bindings/go/oci/spec/repository/v1/oci"
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
@@ -101,4 +102,24 @@ func equalCredentials(a, b auth.Credential) bool {
 		a.Password == b.Password &&
 		a.RefreshToken == b.RefreshToken &&
 		a.AccessToken == b.AccessToken
+}
+
+type storeCache struct {
+	mu    sync.RWMutex
+	store map[string]*oci.Store
+}
+
+func (c *storeCache) get(_ context.Context, path string) *oci.Store {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	store, _ := c.store[path]
+	return store
+}
+
+func (c *storeCache) add(_ context.Context, path string, store *oci.Store) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.store[path] = store
 }

--- a/bindings/go/oci/repository/provider/options.go
+++ b/bindings/go/oci/repository/provider/options.go
@@ -1,0 +1,22 @@
+package provider
+
+type Options struct {
+	TempDir   string
+	UserAgent string
+}
+
+type Option func(*Options)
+
+// WithTempDir sets the temporary directory option
+func WithTempDir(dir string) Option {
+	return func(o *Options) {
+		o.TempDir = dir
+	}
+}
+
+// WithUserAgent sets the user agent option
+func WithUserAgent(userAgent string) Option {
+	return func(o *Options) {
+		o.UserAgent = userAgent
+	}
+}

--- a/bindings/go/oci/repository/provider/provider.go
+++ b/bindings/go/oci/repository/provider/provider.go
@@ -9,6 +9,7 @@ import (
 	"oras.land/oras-go/v2/registry/remote/retry"
 
 	"ocm.software/open-component-model/bindings/go/oci"
+	ocictf "ocm.software/open-component-model/bindings/go/oci/ctf"
 	ocirepository "ocm.software/open-component-model/bindings/go/oci/repository"
 	v1 "ocm.software/open-component-model/bindings/go/oci/spec/credentials/identity/v1"
 	repoSpec "ocm.software/open-component-model/bindings/go/oci/spec/repository"
@@ -18,6 +19,8 @@ import (
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
+const DefaultCreator = "ocm.software/open-component-model/bindings/go/oci"
+
 // CachingComponentVersionRepositoryProvider is a caching implementation of the repository.ComponentVersionRepositoryProvider interface.
 // It provides efficient caching mechanisms for repository operations by maintaining:
 // - A credential cache for authentication information
@@ -25,25 +28,42 @@ import (
 // - An authorization cache for auth tokens
 // - A shared HTTP client with retry capabilities
 type CachingComponentVersionRepositoryProvider struct {
+	creator            string
 	scheme             *runtime.Scheme
+	storeCache         *storeCache
 	credentialCache    *credentialCache
 	ociCache           *ociCache
 	authorizationCache auth.Cache
 	httpClient         *http.Client
+	tempDir            string
 }
 
 var _ repository.ComponentVersionRepositoryProvider = (*CachingComponentVersionRepositoryProvider)(nil)
 
 // NewComponentVersionRepositoryProvider creates a new instance of CachingComponentVersionRepositoryProvider
 // with initialized caches and default HTTP client configuration.
-func NewComponentVersionRepositoryProvider() *CachingComponentVersionRepositoryProvider {
-	return &CachingComponentVersionRepositoryProvider{
+func NewComponentVersionRepositoryProvider(opts ...Option) *CachingComponentVersionRepositoryProvider {
+	options := &Options{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	if options.UserAgent == "" {
+		options.UserAgent = DefaultCreator
+	}
+
+	provider := &CachingComponentVersionRepositoryProvider{
+		creator:            options.UserAgent,
 		scheme:             repoSpec.Scheme,
+		storeCache:         &storeCache{store: make(map[string]*ocictf.Store)},
 		credentialCache:    &credentialCache{},
 		ociCache:           &ociCache{scheme: repoSpec.Scheme},
 		authorizationCache: auth.NewCache(),
 		httpClient:         retry.DefaultClient,
+		tempDir:            options.TempDir,
 	}
+
+	return provider
 }
 
 // GetComponentVersionRepositoryCredentialConsumerIdentity implements the repository.ComponentVersionRepositoryProvider interface.
@@ -85,6 +105,8 @@ func (b *CachingComponentVersionRepositoryProvider) GetComponentVersionRepositor
 	opts := []oci.RepositoryOption{
 		oci.WithManifestCache(manifests),
 		oci.WithLayerCache(layers),
+		oci.WithTempDir(b.tempDir),
+		oci.WithCreator(b.creator),
 	}
 
 	switch obj := obj.(type) {
@@ -96,9 +118,25 @@ func (b *CachingComponentVersionRepositoryProvider) GetComponentVersionRepositor
 			Client:     b.httpClient,
 			Cache:      b.authorizationCache,
 			Credential: b.credentialCache.get,
+			Header: map[string][]string{
+				"User-Agent": {b.creator},
+			},
 		}, opts...)
 	case *ctfrepospecv1.Repository:
-		return ocirepository.NewFromCTFRepoV1(ctx, obj, opts...)
+		store := b.storeCache.get(ctx, obj.Path)
+		if store != nil {
+			repo, err := oci.NewRepository(append(opts, ocictf.WithCTF(store))...)
+			if err != nil {
+				return nil, fmt.Errorf("unable to create new repository from cache: %w", err)
+			}
+			return repo, nil
+		}
+		repo, store, err := ocirepository.NewFromCTFRepoV1(ctx, obj, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create ctf repo from spec: %w", err)
+		}
+		b.storeCache.add(ctx, obj.Path, store)
+		return repo, nil
 	default:
 		return nil, fmt.Errorf("unsupported repository specification type %T", obj)
 	}

--- a/bindings/go/oci/repository/repository.go
+++ b/bindings/go/oci/repository/repository.go
@@ -48,7 +48,7 @@ func NewFromCTFRepoV1(ctx context.Context, repository *ctfrepospecv1.Repository,
 		TempDir: repoOpts.TempDir,
 	}
 
-	archive, format, err := ctf.OpenCTFByFileExtension(ctx, ctfOpts)
+	archive, _, err := ctf.OpenCTFByFileExtension(ctx, ctfOpts)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to open ctf archive %q: %w", path, err)
 	}

--- a/bindings/go/oci/repository/repository_test.go
+++ b/bindings/go/oci/repository/repository_test.go
@@ -79,7 +79,7 @@ func TestNewFromCTFRepoV1(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			repo, _, err := NewFromCTFRepoV1(t.Context(), tt.repository)
+			repo, err := NewFromCTFRepoV1(t.Context(), tt.repository)
 			if tt.wantErr {
 				assert.Error(t, err)
 				if tt.errContains != "" {

--- a/bindings/go/oci/repository/repository_test.go
+++ b/bindings/go/oci/repository/repository_test.go
@@ -79,7 +79,7 @@ func TestNewFromCTFRepoV1(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			repo, err := NewFromCTFRepoV1(t.Context(), tt.repository)
+			repo, _, err := NewFromCTFRepoV1(t.Context(), tt.repository)
 			if tt.wantErr {
 				assert.Error(t, err)
 				if tt.errContains != "" {


### PR DESCRIPTION
Taking over https://github.com/open-component-model/open-component-model/pull/963

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
**Core feature:** Implements a `storeCache`, enabling repository caching based on path to enable sharing a lock.
This (hopefully) fixes the current bugs related to race conditions.

- Introduces new options (`WithUserAgent`, `WithTempDir`) for more flexible configuration of repository providers.
- Adds a default `UserAgent` value (`DefaultCreator`).
- Updates `NewFromCTFRepoV1` to return both repository and store, allowing to cache the store.
- Refactors `OpenCTFByFileExtension` for better modularity by separating format detection into `DiscoverCTFFormatFromPath`.

#### Implications
- Improves control over temporary working directories and user agent settings.
- Enhances compatibility and performance when working with CTF archives.
- Existing repository logic adapts seamlessly to changes, maintaining backward compatibility for most use cases.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Contributes to https://github.com/open-component-model/ocm-project/issues/564
