### PR TITLE
chore(task): remove `go work sync` from `init/work`

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -143,7 +143,6 @@ tasks:
       - go work init
       - for: { var: GO_MODULES }
         cmd: 'go work use {{.ITEM}}'
-      - go work sync
 
   generate:
     desc: "Run all Code Generators in the project"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
I believe `go work sync` is typically undesired in our use case. Removing this will reduce noise from the change list.

NOTE: there might be situations where the dependency versions of modules are incompatible, then it would have to be called manually

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
