### PR TITLE
fix(renovate): update schedule and minimum release age settings and fixup automerge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,11 @@
   'git-submodules': {
     enabled: true,
   },
-  'minimumReleaseAge': '14 days',
+  'schedule': [
+    '* * * * 0' // At every minute on Sunday it is allowed to created branches
+  ],
+  'updateNotScheduled': true, // Update branches that have already been created
+  'minimumReleaseAge': '28 days',
   'branchPrefix': 'renovate/',
   'gitAuthor': 'ocmbot[bot] <125909804+ocmbot[bot]@users.noreply.github.com>',
   'gitIgnoredAuthors': [
@@ -22,10 +26,8 @@
   ],
   prConcurrentLimit: 0,
   prHourlyLimit: 0,
-  patch: {
-    automerge: true,
-    automergeType: "pr"
-  },
+  automerge: true,
+  automergeType: "pr",
   separateMinorPatch: true,
   separateMultipleMajor: true,
   packageRules: [


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

this reduces the amount of branch creations we receive as main update will only update branches and not create new PRs.

Fresh PRs / new updates are *created once per week*.
Existing PRs / old updates (not yet merged) are *updated automatically on every commit*

Also automerge is now enabled for all PRs as we have had good experience with it (still approval is required)

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


