### PR TITLE
fix: add mutex lock to avoid race condition in CTF Store

### DIFF
--- a/bindings/go/oci/repository/provider/provider_test.go
+++ b/bindings/go/oci/repository/provider/provider_test.go
@@ -36,43 +36,83 @@ func Test_Provider_Smoke(t *testing.T) {
 		desc.Component.Labels = append(desc.Component.Labels, descriptor.Label{Name: "foo", Value: []byte(`"bar"`)})
 		desc.Component.Provider.Name = "ocm.software/open-component-model/bindings/go/oci/integration/test"
 
-		retrievedDescs := make([]*descriptor.Descriptor, 10)
-		retrievedVersions := make([][]string, 10)
-		eg, ctx := errgroup.WithContext(t.Context())
-		for i := 0; i < 10; i++ {
-			eg.Go(func() error {
-				desc := desc
-				// TODO(fabianburth): introduce file locks to prevent races on
-				//   blobs (https://github.com/open-component-model/ocm-project/issues/694).
-				// we need to force different versions here, otherwise the blob
-				// write will race
-				desc.Component.Version = fmt.Sprintf("v1.0.%d", i)
-				repo, err := prov.GetComponentVersionRepository(ctx, repoSpec, nil)
-				if err != nil {
-					return fmt.Errorf("failed to get component version repository: %v", err)
-				}
-				err = repo.AddComponentVersion(ctx, &desc)
-				if err != nil {
-					return fmt.Errorf("failed to add component version: %v", err)
-				}
-				retrievedDescs[i], err = repo.GetComponentVersion(ctx, desc.Component.Name, desc.Component.Version)
-				if err != nil {
-					return fmt.Errorf("failed to get component version: %v", err)
-				}
-				retrievedVersions[i], err = repo.ListComponentVersions(ctx, desc.Component.Name)
-				if err != nil {
-					return fmt.Errorf("failed to list component versions for index %d: %v", i, err)
-				}
-				return nil
-			})
-		}
-		r.NoError(eg.Wait())
+		t.Run("different versions", func(t *testing.T) {
+			t.Parallel()
 
-		for i := 0; i < 10; i++ {
-			r.Equal(desc.Component.Name, retrievedDescs[i].Component.Name)
-			r.Equal(fmt.Sprintf("v1.0.%d", i), retrievedDescs[i].Component.Version)
-			r.ElementsMatch(retrievedDescs[i].Component.Labels, desc.Component.Labels)
-			r.Contains(retrievedVersions[i], fmt.Sprintf("v1.0.%d", i))
-		}
+			retrievedDescs := make([]*descriptor.Descriptor, 10)
+			retrievedVersions := make([][]string, 10)
+			eg, ctx := errgroup.WithContext(t.Context())
+
+			for i := 0; i < 10; i++ {
+				eg.Go(func() error {
+					d := desc
+					d.Component.Version = fmt.Sprintf("v1.0.%d", i)
+					repo, err := prov.GetComponentVersionRepository(ctx, repoSpec, nil)
+					if err != nil {
+						return fmt.Errorf("failed to get component version repository: %v", err)
+					}
+					err = repo.AddComponentVersion(ctx, &d)
+					if err != nil {
+						return fmt.Errorf("failed to add component version: %v", err)
+					}
+					retrievedDescs[i], err = repo.GetComponentVersion(ctx, d.Component.Name, d.Component.Version)
+					if err != nil {
+						return fmt.Errorf("failed to get component version: %v", err)
+					}
+					retrievedVersions[i], err = repo.ListComponentVersions(ctx, d.Component.Name)
+					if err != nil {
+						return fmt.Errorf("failed to list component versions for index %d: %v", i, err)
+					}
+					return nil
+				})
+			}
+			r.NoError(eg.Wait())
+
+			for i := 0; i < 10; i++ {
+				r.Equal(desc.Component.Name, retrievedDescs[i].Component.Name)
+				r.Equal(fmt.Sprintf("v1.0.%d", i), retrievedDescs[i].Component.Version)
+				r.ElementsMatch(retrievedDescs[i].Component.Labels, desc.Component.Labels)
+				r.Contains(retrievedVersions[i], fmt.Sprintf("v1.0.%d", i))
+			}
+		})
+		t.Run("same version", func(t *testing.T) {
+			t.Parallel()
+
+			retrievedDescs := make([]*descriptor.Descriptor, 10)
+			retrievedVersions := make([][]string, 10)
+			eg, ctx := errgroup.WithContext(t.Context())
+			d := desc
+			d.Component.Version = "v1.0.0"
+			for i := 0; i < 10; i++ {
+				eg.Go(func() error {
+					repo, err := prov.GetComponentVersionRepository(ctx, repoSpec, nil)
+					if err != nil {
+						return fmt.Errorf("failed to get component version repository: %v", err)
+					}
+					err = repo.AddComponentVersion(ctx, &d)
+					if err != nil {
+						return fmt.Errorf("failed to add component version: %v", err)
+					}
+					retrievedDescs[i], err = repo.GetComponentVersion(ctx, d.Component.Name, d.Component.Version)
+					if err != nil {
+						return fmt.Errorf("failed to get component version: %v", err)
+					}
+					retrievedVersions[i], err = repo.ListComponentVersions(ctx, d.Component.Name)
+					if err != nil {
+						return fmt.Errorf("failed to list component versions for index %d: %v", i, err)
+					}
+					return nil
+				})
+			}
+			r.NoError(eg.Wait())
+
+			for i := 0; i < 10; i++ {
+				r.Equal(d.Component.Name, retrievedDescs[i].Component.Name)
+				r.Equal(d.Component.Version, retrievedDescs[i].Component.Version)
+				r.ElementsMatch(retrievedDescs[i].Component.Labels, d.Component.Labels)
+				r.Contains(retrievedVersions[i], d.Component.Version)
+			}
+		})
 	})
+
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
This PR adds mutex locking to the CTF Store to prevent race conditions when multiple goroutines try to access or modify blobs and tags concurrently, specifically when adding the same blob version multiple times.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->
Fixes https://github.com/open-component-model/ocm-project/issues/694

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
