### PR TITLE
fix: remove err handling in getConvertedTypedSpec

### DIFF
--- a/bindings/go/oci/repository/provider/provider.go
+++ b/bindings/go/oci/repository/provider/provider.go
@@ -184,9 +184,7 @@ func (b *CachingComponentVersionRepositoryProvider) GetComponentVersionRepositor
 // to its corresponding object type in the scheme. It ensures that the type is set correctly
 func getConvertedTypedSpec(scheme *runtime.Scheme, repositorySpecification runtime.Typed) (runtime.Typed, error) {
 	repositorySpecification = repositorySpecification.DeepCopyTyped()
-	if _, err := scheme.DefaultType(repositorySpecification); err != nil {
-		return nil, fmt.Errorf("failed to ensure type for repository specification: %w", err)
-	}
+	_, _ = scheme.DefaultType(repositorySpecification)
 	obj, err := scheme.NewObject(repositorySpecification.GetType())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#### What this PR does / why we need it
This PR removed the err handling in getConvertedTypedSpec for the DefaultType parsing

In the new resolvers, repoSpecs are *Raw and this code path will fail 

#### Which issue(s) this PR fixes
Contributes https://github.com/open-component-model/ocm-project/issues/575
