### PR TITLE
chore(ci): remove markdown linter

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -8,16 +8,6 @@ on:
       - '**/*.md'
 
 jobs:
-  markdown-lint:
-    runs-on: ubuntu-latest
-    name: Lint Markdown
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-      - uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e # v20
-        with:
-          globs: '**/*.md'
-          separator: ","
-          config: .github/config/.markdownlint-cli2.yaml
   verify-links:
     name: Verify links
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
The benefits of markdown linter are non tangible and the effort to get a valid docs PR are significant. 


#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
