### PR TITLE
fix(bug): default spec type before plug-in look-up

### DIFF
--- a/bindings/go/plugin/manager/registries/componentlister/registry.go
+++ b/bindings/go/plugin/manager/registries/componentlister/registry.go
@@ -156,6 +156,7 @@ func (r *ComponentListerRegistry) GetComponentListerCredentialConsumerIdentity(c
 	defer r.mu.Unlock()
 
 	// Check if this is an internal plugin first
+	_, _ = r.scheme.DefaultType(repositorySpecification)
 	typ := repositorySpecification.GetType()
 	if ok := r.scheme.IsRegistered(typ); ok {
 		p, ok := r.internalComponentListerPlugins[typ]

--- a/bindings/go/plugin/manager/registries/componentversionrepository/registry.go
+++ b/bindings/go/plugin/manager/registries/componentversionrepository/registry.go
@@ -145,6 +145,7 @@ func (r *RepositoryRegistry) GetComponentVersionRepositoryCredentialConsumerIden
 	defer r.mu.RUnlock()
 
 	// Check if this is an internal plugin first
+	_, _ = r.scheme.DefaultType(repositorySpecification)
 	typ := repositorySpecification.GetType()
 	if ok := r.scheme.IsRegistered(typ); ok {
 		p, ok := r.internalComponentVersionRepositoryPlugins[typ]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

The fix is required for the two registries to be able to correctly look up plug-ins, before trying to determine `CredentialConsumerIdentity`.

#### Which issue(s) this PR fixes

Contributes to open-component-model/ocm-project#674