### PR TITLE
feat(workflows): add GitHub Actions workflow for CLI release candidates

### DIFF
--- a/.github/workflows/release-candidate-cli.yml
+++ b/.github/workflows/release-candidate-cli.yml
@@ -1,0 +1,298 @@
+name: Create CLI Release Candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to cut to, must match regex releases/v0.[0-9]+"
+        required: true
+        type: string
+      dry_run:
+        description: "Perform dry run without pushing tags"
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  release-cli:
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+      attestations: write
+    environment:
+      name: ocm-release
+    env:
+      REGISTRY: ghcr.io
+      COMPONENT_PATH: cli
+    name: Create Release Candidate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: ${{ env.COMPONENT_PATH }}
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute new RC version
+        id: compute
+        uses: actions/github-script@v8
+        env:
+          BRANCH: ${{ github.event.inputs.branch }}
+          COMPONENT_PATH: ${{ env.COMPONENT_PATH }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { execSync } = require("child_process");
+            const fs = require("fs");
+            const branch = process.env.BRANCH;
+            const path = process.env.COMPONENT_PATH || ".";
+            const prefix = `${path}/v`;
+
+            if (!fs.existsSync(`${path}/go.mod`)) {
+              core.setFailed(`No go.mod found in ${path}`);
+              return;
+            }
+
+            const branchMatch = branch.match(/^releases\/v(0\.\d+)/);
+            if (!branchMatch) {
+              core.setFailed(`Branch '${branch}' missing base version`);
+              return;
+            }
+            const baseVersion = branchMatch[1];
+
+            const run = (cmd) => {
+              try { return execSync(cmd).toString().trim(); } catch { return ""; }
+            };
+
+            // fix: remove refs/tags/ prefix from patterns
+            const latestStable = run(`git tag --list '${prefix}${baseVersion}.*' | grep -v '-' | sort -V | tail -n1`);
+            const latestRC = run(`git tag --list '${prefix}${baseVersion}.*-rc.*' | sort -V | tail -n1`);
+
+            let version = latestStable ? latestStable.replace(prefix, "").replace(/^v/, "") : `${baseVersion}.0`;
+            const [major, minor, patchRaw] = version.split(".").map(x => parseInt(x, 10));
+            let [maj, min, pat] = [major, minor, patchRaw];
+            let bump = "none";
+            let rc = 1;
+
+            if (latestStable && (!latestRC || run(`printf '%s\n%s\n' '${latestStable}' '${latestRC}' | sort -V | tail -n1`) === latestStable)) {
+              bump = "patch";
+              pat++;
+              rc = 1;
+              core.info(`Last tag was stable (${latestStable}), bumping patch.`);
+            } else if (latestRC) {
+              const rcMatch = latestRC.match(/-rc\.(\d+)$/);
+              if (rcMatch) rc = parseInt(rcMatch[1]) + 1;
+              core.info(`Continuing RC sequence after ${latestRC}.`);
+            } else {
+              core.info("No previous tags found, starting with .0.");
+              bump = "none";
+              pat = 0;
+              rc = 1;
+            }
+
+            const base = `${maj}.${min}.${pat}`;
+            const newVersion = `${base}-rc.${rc}`;
+            const newTag = `${prefix}${newVersion}`;
+
+            core.setOutput("new_tag", newTag);
+            core.setOutput("new_version", newVersion);
+            core.setOutput("base_version", base);
+            core.info(`🆕 Next RC tag: ${newTag}`);
+            core.info(`🔧 Build version (without RC): ${base}`);
+
+      - name: Generate changelog with git-cliff
+        uses: orhun/git-cliff-action@v4
+        id: git-cliff
+        env:
+          TAG: ${{ steps.compute.outputs.new_tag }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          config: ${{ env.COMPONENT_PATH }}/cliff.toml
+          args: |
+            --include-path "${{ env.COMPONENT_PATH }}/**" \
+            --tag "${{ env.TAG }}" \
+            -o "$RUNNER_TEMP/CHANGELOG.md" \
+            --use-branch-tags \
+            --latest
+
+      - name: Summarize changelog
+        id: summarize
+        uses: actions/github-script@v8
+        env:
+          CHANGELOG_FILE: ${{ runner.temp }}/CHANGELOG.md
+          TAG: ${{ steps.compute.outputs.new_tag }}
+        with:
+          script: |
+            const fs = require("fs");
+            const log = fs.existsSync(process.env.CHANGELOG_FILE)
+              ? fs.readFileSync(process.env.CHANGELOG_FILE, "utf8").trim()
+              : "No changelog.";
+            const encoded = Buffer.from(log).toString("base64");
+            core.setOutput("changelog_b64", encoded);
+            await core.summary.addRaw(log).write();
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and verify CTF
+        run: |
+          task cli:generate/ctf VERSION=${{ steps.compute.outputs.base_version }}
+          task cli:verify/ctf
+
+      - name: Generate artifact attestation for binaries
+        uses: actions/attest-build-provenance@v3
+        continue-on-error: true
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          subject-path: ${{ env.COMPONENT_PATH }}/tmp/bin/ocm-*
+
+      - id: committer
+        name: Determine Committer used for pushing Tag
+        if: ${{ github.event.inputs.dry_run == 'false' }}
+        run: |
+          echo "name=${{ github.actor }}" >> "$GITHUB_OUTPUT" 
+          echo "email=${{ github.actor }}@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+      - name: Setup git config
+        if: ${{ github.event.inputs.dry_run == 'false' }}
+        run: | 
+          git config --global user.name "${{ steps.committer.outputs.name }}" 
+          git config --global user.email "${{ steps.committer.outputs.email }}"
+
+      - name: Create and push RC tag
+        if: ${{ github.event.inputs.dry_run == 'false' }}
+        id: tag
+        uses: actions/github-script@v8
+        env:
+          TAG: ${{ steps.compute.outputs.new_tag }}
+          CHANGELOG_B64: ${{ steps.summarize.outputs.changelog_b64 }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { execSync } = require("child_process");
+            const tag = process.env.TAG;
+            const msg = Buffer.from(process.env.CHANGELOG_B64, "base64").toString("utf8");
+            try { execSync(`git rev-parse "refs/tags/${tag}"`); core.info(`Tag ${tag} exists`); core.setOutput("pushed","false"); return; } catch {}
+            require("fs").writeFileSync(".tagmsg", msg);
+            execSync(`git tag -a "${tag}" -F .tagmsg`);
+            execSync(`git push origin "refs/tags/${tag}"`);
+            core.setOutput("pushed","true");
+            core.info(`✅ Created RC tag ${tag}`);
+
+      - name: Create GitHub prerelease
+        id: create_release
+        if: ${{ steps.tag.outputs.pushed == 'true' }}
+        uses: actions/github-script@v8
+        env:
+          TAG: ${{ steps.compute.outputs.new_tag }}
+          CHANGELOG_B64: ${{ steps.summarize.outputs.changelog_b64 }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const tag = process.env.TAG;
+            const body = Buffer.from(process.env.CHANGELOG_B64, "base64").toString("utf8");
+            const res = await github.rest.repos.createRelease({
+              owner, repo, tag_name: tag,
+              name: `CLI ${tag.split("/")[1]}`,
+              body, prerelease: true
+            });
+            core.setOutput("upload_url", res.data.upload_url);
+      - name: Upload CLI artifacts
+        if: ${{ steps.create_release.outputs.upload_url }}
+        uses: actions/github-script@v8
+        env:
+          UPLOAD_URL: ${{ steps.create_release.outputs.upload_url }}
+          ARTIFACTS: ${{ env.COMPONENT_PATH }}/tmp/bin,${{ env.COMPONENT_PATH }}/tmp/oci/cli.tar
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+      
+            const items = process.env.ARTIFACTS.split(",").map(d => d.trim()).filter(Boolean);
+            const template = process.env.UPLOAD_URL;
+      
+            const uploadFile = async (file) => {
+              if (!fs.existsSync(file)) {
+                core.info(`File ${file} not found, skipping.`);
+                return;
+              }
+              if (fs.lstatSync(file).isSymbolicLink()) {
+                core.info(`Skipping symlink ${file}`);
+                return;
+              }
+      
+              const name = path.basename(file);
+              const data = fs.readFileSync(file);
+              const uploadUrl = template.replace("{?name,label}", `?name=${encodeURIComponent(name)}`);
+      
+              core.info(`Uploading ${file} → ${uploadUrl}`);
+      
+              await github.request({
+                method: "POST",
+                url: uploadUrl,
+                headers: {
+                  "content-type": "application/octet-stream",
+                  "content-length": data.length,
+                },
+                data,
+              });
+      
+              core.info(`Uploaded ${file}`);
+            };
+      
+            for (const item of items) {
+              if (!fs.existsSync(item)) {
+                core.info(`Path ${item} does not exist, skipping.`);
+                continue;
+              }
+      
+              const stat = fs.lstatSync(item);
+              if (stat.isDirectory()) {
+                const files = fs.readdirSync(item);
+                for (const f of files) {
+                  await uploadFile(path.join(item, f));
+                }
+              } else if (stat.isFile()) {
+                await uploadFile(item);
+              } else {
+                core.info(`Skipping ${item}, not a file or directory.`);
+              }
+            }
+
+      - name: Setup ORAS
+        if: ${{ steps.tag.outputs.pushed == 'true' }}
+        uses: oras-project/setup-oras@v1
+      - name: Log in to GHCR
+        if: ${{ steps.tag.outputs.pushed == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ steps.committer.outputs.name }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push OCI layout to GHCR
+        id: push-oci-layout
+        if: ${{ steps.tag.outputs.pushed == 'true' }}
+        run: |
+          oras cp \
+            --from-oci-layout "${{ github.workspace }}/${{ env.COMPONENT_PATH }}/tmp/oci/cli.tar:${{ steps.compute.outputs.base_version }}" \
+            "${{ env.REGISTRY }}/${{ github.repository_owner }}/cli:${{ steps.compute.outputs.new_version }}"
+          echo "digest=$(oras resolve "${{ env.REGISTRY }}/${{ github.repository_owner }}/cli:${{ steps.compute.outputs.new_version }}")" >> "$GITHUB_OUTPUT"
+
+      - name: Generate artifact attestation for OCI Image
+        uses: actions/attest-build-provenance@v3
+        continue-on-error: true
+        with:
+          subject-digest: ${{ steps.push-oci-layout.outputs.digest }}
+          subject-name: "${{ env.REGISTRY }}/${{ github.repository_owner }}/cli"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          push-to-registry: true

--- a/cli/cliff.toml
+++ b/cli/cliff.toml
@@ -1,0 +1,82 @@
+# git-cliff ~ configuration file
+# https://git-cliff.org/docs/configuration
+
+
+[changelog]
+# A Tera template to be rendered for each release in the changelog.
+# See https://keats.github.io/tera/docs/#introduction
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+            {% if commit.breaking %}[**breaking**] {% endif %}\
+            {{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}
+"""
+# Remove leading and trailing whitespaces from the changelog's body.
+trim = true
+# Render body even when there are no releases to process.
+render_always = true
+# An array of regex based postprocessors to modify the changelog.
+postprocessors = [
+    # Replace the placeholder <REPO> with a URL.
+    #{ pattern = '<REPO>', replace = "https://github.com/orhun/git-cliff" },
+]
+# render body even when there are no releases to process
+# render_always = true
+# output file path
+# output = "test.md"
+
+[git]
+# Parse commits according to the conventional commits specification.
+# See https://www.conventionalcommits.org
+conventional_commits = true
+# Exclude commits that do not match the conventional commits specification.
+filter_unconventional = true
+# Require all commits to be conventional.
+# Takes precedence over filter_unconventional.
+require_conventional = false
+# Split commits on newlines, treating each line as an individual commit.
+split_commits = false
+# An array of regex based parsers to modify commit messages prior to further processing.
+commit_preprocessors = [
+    # Replace issue numbers with link templates to be updated in `changelog.postprocessors`.
+    #{ pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](<REPO>/issues/${2}))"},
+    # Check spelling of the commit message using https://github.com/crate-ci/typos.
+    # If the spelling is incorrect, it will be fixed automatically.
+    #{ pattern = '.*', replace_command = 'typos --write-changes -' },
+]
+# Prevent commits that are breaking from being excluded by commit parsers.
+protect_breaking_commits = true
+# An array of regex based parsers for extracting data from the commit message.
+# Assigns commits to groups.
+# Optionally sets the commit's scope and can decide to exclude commits from further processing.
+commit_parsers = [
+    { message = "^feat", group = "<!-- 0 -->🚀 Features" },
+    { message = "^chore\\(deps.*\\)", group = "<!-- 2 -->📚 Dependencies" },
+    { message = "^fix\\(deps.*\\)", group = "<!-- 2 -->📚 Dependencies" },
+    { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^chore|^ci", group = "<!-- 7 -->⚙️ Miscellaneous Tasks" },
+]
+# Exclude commits that are not matched by any commit parser.
+filter_commits = false
+# An array of link parsers for extracting external references, and turning them into URLs, using regex.
+link_parsers = []
+# Include only the tags that belong to the current branch.
+use_branch_tags = false
+# Order releases topologically instead of chronologically.
+topo_order = false
+# Order releases topologically instead of chronologically.
+topo_order_commits = true
+# Order of commits in each group/release within the changelog.
+# Allowed values: newest, oldest
+sort_commits = "oldest"
+# Process submodules commits
+recurse_submodules = false


### PR DESCRIPTION
#### What this does
- Introduces a new GitHub Actions workflow file, `release-candidate-cli.yml`, to automate the creation of CLI release candidates.
- Allows triggering the workflow manually via `workflow_dispatch` with branch and dry run inputs.
- Includes automated version computation, changelog generation, artifact building, artifact attestation, GitHub prerelease creation, and OCI image push to GHCR.

#### Why this is needed
This workflow streamlines the process of creating CLI release candidates by automating critical steps, ensuring reproducibility and reducing manual effort. It also standardizes versioning and artifact publishing for better release management.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

fix https://github.com/open-component-model/ocm-project/issues/699
