### PR TITLE
feat: type-safety and conversion for runtime

### DIFF
--- a/bindings/go/descriptor/runtime/artifact.go
+++ b/bindings/go/descriptor/runtime/artifact.go
@@ -16,8 +16,11 @@ type Artifact interface {
 	GetElementMeta() ElementMeta
 	// GetType returns the type of the artifact
 	GetType() string
+	SetType(string)
 	// GetAccess returns the access information
 	GetAccess() runtime.Typed
+	// SetAccess sets the access information
+	SetAccess(runtime.Typed)
 }
 
 func (s *Source) GetElementMeta() ElementMeta {
@@ -28,8 +31,16 @@ func (s *Source) GetType() string {
 	return s.Type
 }
 
+func (s *Source) SetType(t string) {
+	s.Type = t
+}
+
 func (s *Source) GetAccess() runtime.Typed {
 	return s.Access
+}
+
+func (s *Source) SetAccess(access runtime.Typed) {
+	s.Access = access
 }
 
 func (r *Resource) GetElementMeta() ElementMeta {
@@ -40,6 +51,14 @@ func (r *Resource) GetType() string {
 	return r.Type
 }
 
+func (r *Resource) SetType(t string) {
+	r.Type = t
+}
+
 func (r *Resource) GetAccess() runtime.Typed {
 	return r.Access
+}
+
+func (r *Resource) SetAccess(access runtime.Typed) {
+	r.Access = access
 }

--- a/bindings/go/descriptor/runtime/typed/artifact.go
+++ b/bindings/go/descriptor/runtime/typed/artifact.go
@@ -1,0 +1,114 @@
+// Package typed defines a type-safe, generic wrapper around OCM artifacts (such as Resource and Source)
+// to ensure compile-time and runtime correctness when working with runtime.Typed access specifications.
+//
+// It bridges generic typed access (in this package) and raw untyped artifact definitions (in the runtime package).
+// The wrapper guarantees that the Access field on any artifact matches the expected Go type
+// and provides safe getter and setter methods.
+package typed
+
+import (
+	"encoding/json"
+	"fmt"
+
+	untyped "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+// Artifact is a [untyped.Artifact] (e.g. [*untyped.Resource] or [*untyped.Source])
+// with a compile-time type parameter for the underlying access in [*untyped.Resource.GetAccess].
+//
+// Type parameters:
+//   - ACCESS: a concrete access type implementing [runtime.Typed] (e.g. *OCIArtifactAccess)
+//   - BASE: the untyped artifact type implementing [untyped.Artifact] (e.g. [*untyped.Resource] or [*untyped.Source])
+//
+// It provides safe getters and setters for common fields and the underlying access specification:
+//
+//		res := runtime.Resource{Access: &OCIArtifactAccess{}}
+//		art, err := typed.FromArtifact[*OCIArtifactAccess](&res)
+//		if err != nil {
+//	   // handle error
+//		}
+//		art.Underlying() // operate as you would normally with untyped artifacts
+//		art.SetAccess(&HELMChart{}) // compile-time error: ACCESS != *OCIArtifactAccess
+type Artifact[ACCESS runtime.Typed, BASE untyped.Artifact] interface {
+	Base() BASE
+	Typed() Access[ACCESS]
+}
+
+type Access[ACCESS runtime.Typed] interface {
+	// GetAccess returns the typed access specification (e.g. *OCIArtifactAccess).
+	GetAccess() ACCESS
+	// SetAccess sets the typed access specification.
+	SetAccess(ACCESS)
+}
+
+// NewArtifact wraps a raw untyped artifact into a type-safe [Artifact] wrapper.
+//
+// It performs a runtime type assertion to ensure the artifact's Access field matches
+// the expected ACCESS type. If the type does not match, it returns an error.
+//
+// Example:
+//
+//	res := runtime.Resource{Access: &OCIArtifactAccess{}}
+//	t, err := typed.FromArtifact[*OCIArtifactAccess](&res)
+//
+//	t.Typed() // returns *OCIArtifactAccess
+//	t.SetAccess(&HELMChart{}) // compile-time error: ACCESS != *OCIArtifactAccess
+//	t.Base() // returns *runtime.Resource
+func NewArtifact[ACCESS runtime.Typed, BASE untyped.Artifact](art BASE) (Artifact[ACCESS, BASE], error) {
+	acc := art.GetAccess()
+	// Validate that the access type (if present) matches the expected ACCESS type parameter.
+	if acc == nil {
+		return nil, fmt.Errorf("artifact has no access specification")
+	}
+	if _, ok := acc.(ACCESS); !ok {
+		return nil, fmt.Errorf("found unexpected access type in artifact: got %T, expected %T", acc, *new(ACCESS))
+	}
+	// Return a new typed wrapper over the artifact.
+	return &artifact[ACCESS, BASE]{underlying: art, access: &access[ACCESS]{art}}, nil
+}
+
+// artifact implements the generic [Artifact] interface.
+//
+// It delegates all field access and mutation to the underlying untyped artifact,
+// while exposing the Access field as the concrete generic type.
+type artifact[ACCESS runtime.Typed, BASE untyped.Artifact] struct {
+	underlying BASE
+	access     Access[ACCESS]
+}
+
+func (r *artifact[ACCESS, BASE]) Base() BASE {
+	return r.underlying
+}
+
+func (r *artifact[ACCESS, BASE]) Typed() Access[ACCESS] {
+	return r.access
+}
+
+// MarshalJSON implements json.Marshaler.
+func (r artifact[ACCESS, BASE]) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.underlying)
+}
+
+func (r *artifact[ACCESS, BASE]) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &r.underlying)
+}
+
+type access[ACCESS runtime.Typed] struct {
+	underlying untyped.Artifact
+}
+
+// GetAccess returns the Access field cast to the generic ACCESS type.
+//
+// Panics if the underlying Access field does not match the ACCESS type.
+// (Which can only happen if the artifact was created through [FromArtifact] and the ACCESS type parameter does
+// not match the actual access type after being modified with Untyped.)
+// This is safe if the artifact was created through [FromArtifact].
+func (r *access[ACCESS]) GetAccess() ACCESS {
+	return r.underlying.GetAccess().(ACCESS)
+}
+
+// SetAccess assigns a new typed access object to the artifact.
+func (r *access[ACCESS]) SetAccess(access ACCESS) {
+	r.underlying.SetAccess(access)
+}

--- a/bindings/go/descriptor/runtime/typed/artifact_test.go
+++ b/bindings/go/descriptor/runtime/typed/artifact_test.go
@@ -1,0 +1,55 @@
+package typed_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	untyped "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+	"ocm.software/open-component-model/bindings/go/descriptor/runtime/typed"
+	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+// MockAccess implements runtime.Typed for testing and supports JSON marshalling.
+type MockAccess struct {
+	Type string `json:"type"`
+}
+
+func (m *MockAccess) GetType() runtime.Type {
+	return runtime.NewUnversionedType(m.Type)
+}
+
+func (m *MockAccess) SetType(t runtime.Type) {
+	m.Type = t.String()
+}
+
+func (m *MockAccess) DeepCopyTyped() runtime.Typed {
+	cp := *m
+	return &cp
+}
+
+func TestResource_GettersAndSetters(t *testing.T) {
+	acc := &MockAccess{Type: "mockType"}
+
+	r, err := typed.NewArtifact[*MockAccess](&untyped.Resource{})
+	assert.Error(t, err)
+
+	r, err = typed.NewArtifact[*MockAccess](&untyped.Resource{Access: acc})
+	assert.NoError(t, err)
+
+	r.Base().SetType("resourceType")
+	r.Typed().SetAccess(acc)
+
+	assert.Equal(t, "resourceType", r.Base().GetType())
+	assert.Equal(t, acc, r.Base().GetAccess())
+	assert.Equal(t, "mockType", r.Base().GetAccess().GetType().String())
+
+	assert.Equal(t, acc, r.Typed().GetAccess())
+}
+
+// Simulate a custom JSON field by using Labels or a dummy map (since untyped.Resource has fixed fields).
+// Here we embed the custom field through an auxiliary struct.
+type WithCustom struct {
+	untyped.Resource `json:",inline"`
+	Custom           string `json:"custom"`
+}

--- a/bindings/go/descriptor/v2/descriptor.go
+++ b/bindings/go/descriptor/v2/descriptor.go
@@ -78,6 +78,20 @@ const (
 	ExternalRelation ResourceRelation = "external"
 )
 
+// Artifact defines a common interface for both Source and Resource types.
+// It provides methods to access common metadata and properties.
+type Artifact interface {
+	// GetElementMeta returns the element metadata
+	GetElementMeta() ElementMeta
+	// GetType returns the type of the artifact
+	GetType() string
+	SetType(string)
+	// GetAccess returns the access information
+	GetAccess() runtime.Typed
+	// SetAccess sets the access information
+	SetAccess(runtime.Typed)
+}
+
 // A Resource is a delivery artifact, intended for deployment into a runtime environment, or describing additional content,
 // relevant for a deployment mechanism.
 // For example, installation procedures or meta-model descriptions controlling orchestration and/or deployment mechanisms.
@@ -102,6 +116,30 @@ type Resource struct {
 	CreationTime *Timestamp `json:"creationTime,omitempty"`
 }
 
+func (r *Resource) SetAccess(typed runtime.Typed) {
+	r.Access = runtime.AsRaw(typed)
+}
+
+func (r *Resource) GetAccess() runtime.Typed {
+	return r.Access
+}
+
+func (r *Resource) GetType() string {
+	return r.Type
+}
+
+func (r *Resource) SetType(t string) {
+	r.Type = t
+}
+
+func (r *Resource) GetElementMeta() ElementMeta {
+	return r.ElementMeta
+}
+
+func (r *Resource) SetElementMeta(m ElementMeta) {
+	r.ElementMeta = m
+}
+
 // A Source is an artifact which describes the sources that were used to generate one or more of the resources.
 // Source elements do not have specific additional formal attributes.
 // See https://github.com/open-component-model/ocm-spec/blob/main/doc/01-model/02-elements-toplevel.md#sources
@@ -110,6 +148,30 @@ type Source struct {
 	ElementMeta `json:",inline"`
 	Type        string       `json:"type"`
 	Access      *runtime.Raw `json:"access"`
+}
+
+func (s *Source) SetAccess(typed runtime.Typed) {
+	s.Access = runtime.AsRaw(typed)
+}
+
+func (s *Source) GetAccess() runtime.Typed {
+	return s.Access
+}
+
+func (s *Source) GetType() string {
+	return s.Type
+}
+
+func (s *Source) SetType(t string) {
+	s.Type = t
+}
+
+func (s *Source) GetElementMeta() ElementMeta {
+	return s.ElementMeta
+}
+
+func (s *Source) SetElementMeta(m ElementMeta) {
+	s.ElementMeta = m
 }
 
 // Reference describes the reference to another component in the registry.

--- a/bindings/go/runtime/raw.go
+++ b/bindings/go/runtime/raw.go
@@ -60,3 +60,19 @@ func (u *Raw) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+// defaultUnsafeConverter is a global permissive converter for unknown types.
+// It is a permissive converter that ignores type registration.
+var defaultUnsafeConverter Converter = NewScheme(WithAllowUnknown())
+
+// AsRaw returns a new Raw representation of any Typed object.
+// It panics if the object is not properly Typed or cannot be converted.
+func AsRaw(typed Typed) *Raw {
+	target := &Raw{}
+	if raw, ok := typed.(*Raw); ok {
+		raw.DeepCopyInto(target)
+	} else if err := defaultUnsafeConverter.Convert(typed, target); err != nil {
+		panic(fmt.Errorf("failed to convert access to runtime.Raw via default conversion: %w", err))
+	}
+	return target
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

- Introduced typed `Artifact` abstraction for compile-time type guarantees. Can be used in contracts and in implementations to become type safe on artifacts containing accesses.
- Implemented getters and setters for typed and untyped access, streamlining Artifact abstraction
- Enhanced `runtime/registry` with safer conversion handling and stricter JSON field validation to avoid breaking when encountering wrong field combinations
- Wrote `AsRaw` that can be the new canonical way to convert Typed Objects to Raw representations (instead of the cumbersome NewScheme().Convert() helper). Also added that in the v2 package to make setting them easier. Decoding still requires a scheme.


#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

fixes some longstanding issues we had with our type system on accesses:

1. It was not possible to have type safety on resources / sources / artifacts, only accesses. Now this has been fixed
2. It was not possible to easily do conversion to Raw which made writing v2 descriptor testing very cumbersome. Now this has been fixed
3. It was not possible to check if the conversion from Raw => Typed accidentally used wrong field mappings due to unknown fields being ignored. Now we decode into the Type more strictly.

Note: hacked this on a weekend to see how I could implement better type safety. This can be used for a first glance but probably needs a dedicated issue as well.