### PR TITLE
chore: change base image

### DIFF
--- a/cli/Containerfile
+++ b/cli/Containerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static-debian12
+FROM gcr.io/distroless/static-debian12@sha256:87bce11be0af225e4ca761c40babb06d6d559f5767fbf7dc3c47f0f1a466b92c
 ARG TARGETOS
 ARG TARGETARCH
 COPY tmp/bin/ocm-${TARGETOS}-${TARGETARCH} /ocm


### PR DESCRIPTION
On-behalf-of: Gerald Morrison (SAP) <gerald.morrison@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
change base image to distroless to get CA certificates included
