### PR TITLE
fix: revert changing the CLI image to debian

### DIFF
--- a/cli/Containerfile
+++ b/cli/Containerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static-debian12@sha256:87bce11be0af225e4ca761c40babb06d6d559f5767fbf7dc3c47f0f1a466b92c
+FROM scratch
 ARG TARGETOS
 ARG TARGETARCH
 COPY tmp/bin/ocm-${TARGETOS}-${TARGETARCH} /ocm


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Fixes the CLI multi-arch build failure https://github.com/open-component-model/open-component-model/actions/runs/18870829587/job/53849807183

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
