### PR TITLE
chore: correct typo: CGO_ENABLED instead of GCO_ENABLED

### DIFF
--- a/cli/Taskfile.yml
+++ b/cli/Taskfile.yml
@@ -102,7 +102,7 @@ tasks:
       - tmp/resources/ocm-{{ .GOOS }}-{{ .GOARCH }}.yaml
     cmds:
       - cmd: |
-          GCO_ENABLED=0 GOOS={{ .GOOS }} GOARCH={{ .GOARCH }} go build \
+          CGO_ENABLED=0 GOOS={{ .GOOS }} GOARCH={{ .GOARCH }} go build \
             -ldflags "-s -w -X ocm.software/open-component-model/cli/cmd/version.BuildVersion={{ .VERSION }}" \
             -o {{ .TASKFILE_DIR }}/tmp/bin/ocm-{{ .GOOS }}-{{ .GOARCH }}
       - |


### PR DESCRIPTION
On-behalf-of: Gerald Morrison (SAP) <gerald.morrison@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
correct typo: CGO_ENABLED instead of GCO_ENABLED
