### PR TITLE
chore: Bump blackduck shared worklfow version

### DIFF
--- a/.github/workflows/trigger-blackduck-scan.yaml
+++ b/.github/workflows/trigger-blackduck-scan.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   trigger-scan:
-    uses: open-component-model/.github/.github/workflows/blackduck-scan.yaml@4d92996d08b23740927f7027f1dd53ecf69e8dc4
+    uses: open-component-model/.github/.github/workflows/blackduck-scan.yaml@443ddc4d2a066dcdee4fcad1ee639011bf0f4126
     with:
       # required to be able to differentiate between PRs and pushes in the called workflow (rapid or full scan)
       event_type: ${{ github.event_name }} 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
bump share workflow version 
