### PR TITLE
draft: fix: implement atomic file writes for concurrent CTF access

### DIFF
--- a/bindings/go/ctf/filesystem_ctf.go
+++ b/bindings/go/ctf/filesystem_ctf.go
@@ -135,43 +135,63 @@ var ioBufPool = sync.Pool{
 
 // writeFile writes the given raw data to the given name in the CTF.
 // If the directory does not exist, it will be created.
+// Always uses atomic write (temp file + rename) for safe concurrent access.
 func (c *FileSystemCTF) writeFile(name string, raw io.Reader, size int64) (err error) {
+	// Ensure directory exists
 	if c.mkdirFS != nil {
 		if err := c.mkdirFS.MkdirAll(filepath.Dir(name), 0o755); err != nil {
 			return fmt.Errorf("unable to create directory: %w", err)
 		}
 	}
 
-	if c.ofFS == nil {
-		return fmt.Errorf("filesystem does not support opening files for write or creation: %T", c.fs)
+	// Check if this is an OS filesystem
+	osFS, ok := c.fs.(*filesystem.RootFileSystem)
+	if !ok {
+		return fmt.Errorf("atomic writes not supported on non-OS filesystem: %T", c.fs)
 	}
+	targetPath := filepath.Join(osFS.String(), name)
 
-	var file fs.File
-	// If the file does not exist, we create it.
-	// If it exists, we truncate it to make sure that size is correct
-	// and we can write the new data to it.
-	if file, err = c.ofFS.OpenFile(name, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644); err != nil {
-		return fmt.Errorf("unable to open artifact index: %w", err)
+	// Create temp file
+	tempFile, err := os.CreateTemp(filepath.Dir(targetPath), "."+filepath.Base(targetPath)+".*")
+	if err != nil {
+		return fmt.Errorf("unable to create temp file: %w", err)
 	}
+	tempPath := tempFile.Name()
+
+	// Ensure cleanup
 	defer func() {
-		err = errors.Join(err, file.Close())
+		tempFile.Close()
+		if err != nil {
+			os.Remove(tempPath)
+		}
 	}()
 
-	writeable, ok := file.(io.Writer)
-	if !ok {
-		return fmt.Errorf("file %s is read only and cannot be saved", name)
-	}
-
+	// Write content to temp file
 	if size <= blob.SizeUnknown {
 		buf := ioBufPool.Get().(*[]byte)
 		defer ioBufPool.Put(buf)
-		if _, err = io.CopyBuffer(writeable, raw, *buf); err != nil {
-			return fmt.Errorf("unable to write artifact index: %w", err)
+		if _, err = io.CopyBuffer(tempFile, raw, *buf); err != nil {
+			return fmt.Errorf("unable to write content: %w", err)
 		}
 	} else {
-		if _, err = io.CopyN(writeable, raw, size); err != nil {
-			return fmt.Errorf("unable to write artifact index: %w", err)
+		if _, err = io.CopyN(tempFile, raw, size); err != nil {
+			return fmt.Errorf("unable to write content: %w", err)
 		}
+	}
+
+	// Close before chmod and rename
+	if err = tempFile.Close(); err != nil {
+		return fmt.Errorf("unable to close temp file: %w", err)
+	}
+
+	// Make read-only
+	if err = os.Chmod(tempPath, 0444); err != nil {
+		return fmt.Errorf("unable to make temp file readonly: %w", err)
+	}
+
+	// Atomic rename
+	if err = os.Rename(tempPath, targetPath); err != nil {
+		return fmt.Errorf("unable to rename temp file: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
