### PR TITLE
fix: ensure verbose logs during tests for better diagnostics

### DIFF
--- a/cli/cmd/internal/test/test.go
+++ b/cli/cmd/internal/test/test.go
@@ -87,6 +87,14 @@ func OCM(tb testing.TB, opts ...Option) (*cobra.Command, error) {
 		return nil, fmt.Errorf("failed to set format: %w", err)
 	}
 
+	// ensure verbose logs during tests for better diagnostics
+	lf := instance.PersistentFlags().Lookup(log.LevelFlagName)
+	if lf != nil {
+		if err := lf.Value.Set(log.LevelDebug); err != nil {
+			return nil, fmt.Errorf("failed to set log level: %w", err)
+		}
+	}
+
 	instance.SetArgs(opt.args)
 	return instance.ExecuteContextC(tb.Context())
 }


### PR DESCRIPTION
What this PR does / why we need it:

Sets log level to DEBUG for ocm cli tests as some tests verify DEBUG level log entries.