### PR TITLE
fix(cmd): improve error message for rendering components

### DIFF
--- a/cli/cmd/get/component-version/cmd.go
+++ b/cli/cmd/get/component-version/cmd.go
@@ -221,7 +221,7 @@ func processComponentReference(cmd *cobra.Command,
 	}
 
 	if err := renderComponents(cmd, repoProvider, roots, output, displayMode, recursive); err != nil {
-		return fmt.Errorf("failed to render components recursively: %w", err)
+		return fmt.Errorf("failed to render components: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Error message reported recursive rendering independent of the value of actual `recursive` flag.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
