### PR TITLE
chore: adjust top level workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
+      checks: read
     outputs:
       # useful for working directly with modules
       modules_json: ${{ steps.filtered.outputs.modules_json }}


### PR DESCRIPTION
Adjust permission on top-level to make sure that every job only gets the permission it needs by declaring it themselves.