### PR TITLE
fix(oci): missing unversioned legacy registration

### DIFF
--- a/bindings/go/oci/spec/repository/scheme.go
+++ b/bindings/go/oci/spec/repository/scheme.go
@@ -34,6 +34,12 @@ func MustAddToScheme(scheme *runtime.Scheme) {
 
 func MustAddLegacyToScheme(scheme *runtime.Scheme) {
 	ociRepository := &oci.Repository{}
-	scheme.MustRegisterWithAlias(ociRepository, runtime.NewVersionedType(oci.LegacyRegistryType, oci.Version))
-	scheme.MustRegisterWithAlias(ociRepository, runtime.NewVersionedType(oci.LegacyRegistryType2, oci.Version))
+	scheme.MustRegisterWithAlias(ociRepository,
+		runtime.NewVersionedType(oci.LegacyRegistryType, oci.Version),
+		runtime.NewUnversionedType(oci.LegacyRegistryType),
+	)
+	scheme.MustRegisterWithAlias(ociRepository,
+		runtime.NewVersionedType(oci.LegacyRegistryType2, oci.Version),
+		runtime.NewUnversionedType(oci.LegacyRegistryType2),
+	)
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Related to the migration effort: https://github.com/open-component-model/open-component-model/pull/1188

The legacy unversioned registration is missing here because old ocm doesn't have versions from time to time.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
