### PR TITLE
fix: health check for OCM repositories

### DIFF
--- a/bindings/go/oci/repository_test.go
+++ b/bindings/go/oci/repository_test.go
@@ -1558,7 +1558,8 @@ func TestRepositoryHealthCheck(t *testing.T) {
 		// Test health check - should fail for unreachable URL
 		err = repo.CheckHealth(ctx)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to create registry client")
+		// Should fail with ping error containing the domain
+		assert.Contains(t, err.Error(), "failed to ping registry")
 	})
 
 	t.Run("URL resolver health check with malformed URL fails", func(t *testing.T) {
@@ -1574,5 +1575,7 @@ func TestRepositoryHealthCheck(t *testing.T) {
 		// Test health check - should fail for malformed URL
 		err = repo.CheckHealth(ctx)
 		require.Error(t, err)
+		// Should fail with ping error containing the URL
+		assert.Contains(t, err.Error(), "failed to ping registry")
 	})
 }

--- a/bindings/go/oci/resolver/url/resolver_test.go
+++ b/bindings/go/oci/resolver/url/resolver_test.go
@@ -2,6 +2,7 @@ package url_test
 
 import (
 	"context"
+	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
 
 	"ocm.software/open-component-model/bindings/go/oci/resolver/url"
 )
@@ -191,8 +193,9 @@ func TestURLPathResolver_Ping(t *testing.T) {
 		assert.NoError(t, err)
 
 		err = resolver.Ping(ctx)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to create registry client")
+		require.Error(t, err)
+		// Should fail with ping error containing the domain
+		assert.Contains(t, err.Error(), "failed to ping registry")
 	})
 
 	t.Run("ping with malformed URL fails", func(t *testing.T) {
@@ -200,7 +203,9 @@ func TestURLPathResolver_Ping(t *testing.T) {
 		assert.NoError(t, err)
 
 		err = resolver.Ping(ctx)
-		assert.Error(t, err)
+		require.Error(t, err)
+		// Should fail with ping error containing the URL
+		assert.Contains(t, err.Error(), "failed to ping registry")
 	})
 
 	t.Run("ping uses configured base client", func(t *testing.T) {
@@ -243,5 +248,202 @@ func TestURLPathResolver_Ping(t *testing.T) {
 		err = resolver.Ping(ctx)
 		require.NoError(t, err)
 		assert.False(t, transportUsed, "Expected custom transport to be NOT used")
+	})
+
+	t.Run("200 OK succeeds", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "/v2/", r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		resolver, err := url.New(url.WithBaseURL(server.URL[7:]), url.WithPlainHTTP(true))
+		require.NoError(t, err)
+
+		err = resolver.Ping(ctx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("non-200 status fails", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "/v2/", r.URL.Path)
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer server.Close()
+
+		resolver, err := url.New(url.WithBaseURL(server.URL[7:]), url.WithPlainHTTP(true))
+		require.NoError(t, err)
+
+		err = resolver.Ping(ctx)
+		assert.Error(t, err)
+	})
+
+	t.Run("ping with baseURL containing path extracts hostname", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			// When baseURL contains a path but subPath is empty,
+			// Ping should extract hostname and ping /v2/ on registry root
+			assert.Equal(t, "/v2/", r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		// baseURL with path, no subPath - should extract hostname
+		serverHost := server.URL[7:] + "/registry-path"
+		resolver, err := url.New(url.WithBaseURL(serverHost), url.WithPlainHTTP(true))
+		require.NoError(t, err)
+
+		err = resolver.Ping(ctx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("ping with subPath still extracts hostname from baseURL", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			// Even when subPath is set, Ping extracts hostname from baseURL
+			// subPath is ignored for health checks
+			assert.Equal(t, "/v2/", r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		// Both baseURL and subPath set - still extracts hostname
+		serverHost := server.URL[7:]
+		resolver, err := url.New(
+			url.WithBaseURL(serverHost),
+			url.WithSubPath("my-org/my-repo"),
+			url.WithPlainHTTP(true),
+		)
+		require.NoError(t, err)
+
+		err = resolver.Ping(ctx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("ping with https scheme", func(t *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "/v2/", r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		serverHost := server.URL[8:] // Remove "https://"
+		resolver, err := url.New(url.WithBaseURL(serverHost))
+		require.NoError(t, err)
+
+		// Use the test server's client which trusts the test certificate
+		resolver.SetClient(server.Client())
+
+		err = resolver.Ping(ctx)
+		assert.NoError(t, err)
+	})
+
+	t.Run("ping with basic authentication", func(t *testing.T) {
+		authCalled := false
+		expectedUsername := "testuser"
+		expectedPassword := "testpass"
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "/v2/", r.URL.Path)
+
+			auth := r.Header.Get("Authorization")
+			if auth == "" {
+				w.Header().Set("WWW-Authenticate", `Basic realm="test"`)
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+
+			// Verify basic auth credentials
+			if auth[:6] == "Basic " {
+				decoded, err := base64.StdEncoding.DecodeString(auth[6:])
+				require.NoError(t, err)
+				assert.Equal(t, expectedUsername+":"+expectedPassword, string(decoded))
+				authCalled = true
+			}
+
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		serverHost := server.URL[7:]
+		resolver, err := url.New(url.WithBaseURL(serverHost), url.WithPlainHTTP(true))
+		require.NoError(t, err)
+
+		// Create auth client with credentials
+		authClient := &auth.Client{
+			Client: http.DefaultClient,
+			Credential: func(ctx context.Context, registry string) (auth.Credential, error) {
+				return auth.Credential{
+					Username: expectedUsername,
+					Password: expectedPassword,
+				}, nil
+			},
+		}
+		resolver.SetClient(authClient)
+
+		err = resolver.Ping(ctx)
+		assert.NoError(t, err)
+		assert.True(t, authCalled, "Expected authentication to be used")
+	})
+
+	t.Run("ping with bearer token authentication", func(t *testing.T) {
+		tokenFetched := false
+		authUsed := false
+		expectedToken := "test-bearer-token"
+
+		// Token server
+		tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/token", r.URL.Path)
+			tokenFetched = true
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte(`{"token":"` + expectedToken + `","access_token":"` + expectedToken + `"}`))
+			assert.NoError(t, err)
+		}))
+		defer tokenServer.Close()
+
+		// Registry server
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			assert.Equal(t, "/v2/", r.URL.Path)
+
+			authHeader := r.Header.Get("Authorization")
+			if authHeader == "" {
+				w.Header().Set("WWW-Authenticate", `Bearer realm="`+tokenServer.URL+`/token",service="registry",scope="repository:test:pull"`)
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+
+			// Verify bearer token
+			assert.Equal(t, "Bearer "+expectedToken, authHeader)
+			authUsed = true
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		serverHost := server.URL[7:]
+		resolver, err := url.New(url.WithBaseURL(serverHost), url.WithPlainHTTP(true))
+		require.NoError(t, err)
+
+		// Create auth client with credentials
+		authClient := &auth.Client{
+			Client: http.DefaultClient,
+			Credential: func(ctx context.Context, registry string) (auth.Credential, error) {
+				return auth.Credential{
+					Username: "testuser",
+					Password: "testpass",
+				}, nil
+			},
+		}
+		resolver.SetClient(authClient)
+
+		err = resolver.Ping(ctx)
+		assert.NoError(t, err)
+		assert.True(t, tokenFetched, "Expected token to be fetched from auth server")
+		assert.True(t, authUsed, "Expected bearer token to be used in request")
 	})
 }


### PR DESCRIPTION
What this PR does / why we need it:

The previous CheckHealth implementation used the ORAS library's Ping
 method, which only verified registry availability. This change implements a custom HTTP HEAD request that validates the actual OCM repository path, ensuring the repository itself is accessible (not just the underlying registry). This is important because a registry may be reachable while the specific repository requires additional credentials or doesn't exist.

Which issue(s) this PR fixes:

https://github.com/open-component-model/ocm-project/issues/757

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
