### PR TITLE
feat(registry): add MustRegisterScheme for panic on registration failure

### DIFF
--- a/bindings/go/runtime/registry.go
+++ b/bindings/go/runtime/registry.go
@@ -112,6 +112,12 @@ func (r *Scheme) RegisterScheme(scheme *Scheme) error {
 	return nil
 }
 
+func (r *Scheme) MustRegisterScheme(scheme *Scheme) {
+	if err := r.RegisterScheme(scheme); err != nil {
+		panic(err)
+	}
+}
+
 // RegisterSchemeType adds a single type from the given scheme to the current scheme
 func (r *Scheme) RegisterSchemeType(scheme *Scheme, typ Type) error {
 	r.mu.Lock()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
This function simplifies scheme registration by panicking on error, ensuring that the caller handles scheme registration correctly.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Contributes to https://github.com/open-component-model/ocm-project/issues/760
