### PR TITLE
feat: rename GraphResolver to Resolver

### DIFF
--- a/bindings/go/credentials/graph.go
+++ b/bindings/go/credentials/graph.go
@@ -27,7 +27,7 @@ type Options struct {
 // ToGraph creates a new credential graph from the provided configuration and options.
 // It initializes the graph structure and ingests the configuration into the graph.
 // Returns an error if the configuration cannot be properly ingested.
-func ToGraph(ctx context.Context, config *cfgRuntime.Config, opts Options) (GraphResolver, error) {
+func ToGraph(ctx context.Context, config *cfgRuntime.Config, opts Options) (Resolver, error) {
 	g := &Graph{
 		syncedDag:                newSyncedDag(),
 		credentialPluginProvider: opts.CredentialPluginProvider,

--- a/bindings/go/credentials/graph_test.go
+++ b/bindings/go/credentials/graph_test.go
@@ -148,7 +148,7 @@ const invalidRecursionYAML = testYAML + `
         secretId: "recursive-creds"
 `
 
-func GetGraph(t testing.TB, yaml string) (credentials.GraphResolver, error) {
+func GetGraph(t testing.TB, yaml string) (credentials.Resolver, error) {
 	t.Helper()
 	r := require.New(t)
 	scheme := runtime.NewScheme()

--- a/bindings/go/credentials/interface.go
+++ b/bindings/go/credentials/interface.go
@@ -13,10 +13,10 @@ var ErrNotFound = errors.New("credentials not found")
 // ErrUnknown is a generic error indicating an unknown failure during credential resolution.
 var ErrUnknown = errors.New("unknown error occurred")
 
-// GraphResolver defines the interface for resolving credentials based on a given identity.
+// Resolver defines the interface for resolving credentials based on a given identity.
 // It provides a method to resolve credentials and returns them as a map of strings.
 // In case of an error it will either return ErrNotFound when no credentials could be found
 // or another error indicating the failure reason wrapped by ErrUnknown.
-type GraphResolver interface {
+type Resolver interface {
 	Resolve(ctx context.Context, identity runtime.Identity) (map[string]string, error)
 }


### PR DESCRIPTION
Part of the PR 
https://github.com/open-component-model/open-component-model/pull/1191

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

- Renames the `GraphResolver` interface to `Resolver` in `credentials`

#### Which issue(s) this PR fixes
Contributes: https://github.com/open-component-model/ocm-project/issues/737
