### PR TITLE
chore: update renovate config to bump go dependencies and monorepo more frequently

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,7 +15,7 @@
     enabled: true,
   },
   'schedule': [
-    '* * * * 0' // At every minute on Sunday it is allowed to created branches
+    '* * * * 0' // At every minute on Sunday it is allowed to create branches
   ],
   'updateNotScheduled': true, // Update branches that have already been created
   'minimumReleaseAge': '28 days',
@@ -31,6 +31,12 @@
   separateMinorPatch: true,
   separateMultipleMajor: true,
   packageRules: [
+    {
+      "matchDatasources": ["golang-version"],
+      "rangeStrategy": "bump",
+      "groupName": "Golang versions",
+      "groupSlug": "golang-versions"
+    },
     {
       matchManagers: [
         'gomod',
@@ -110,6 +116,9 @@
       matchPackageNames: [
         'ocm.software/open-component-model/**',
       ],
+      'schedule': [
+        '* 22,0-6 * * *' // At every minute past hour 22 and every hour from 0 through 6.
+      ]
     },
   ],
   customDatasources: {

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,7 +1,7 @@
 name: Renovate OCM
 on:
   schedule:
-    - cron: '0 0 * * 0' # Every Sunday at midnight UTC
+    - cron: '0 0 * * *' # At 00:0, every day
   workflow_dispatch:
     inputs:
       repoCache:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
chore: update renovate config to bump go dependencies and monorepo more frequently

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
