### PR TITLE
chore: update descriptor json schema

### DIFF
--- a/bindings/go/descriptor/v2/resources/schema-2020-12.json
+++ b/bindings/go/descriptor/v2/resources/schema-2020-12.json
@@ -163,10 +163,17 @@
         },
         "labels": {
           "description": "Labels associated with the source",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/label"
-          }
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/label"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "access": {
           "description": "Access specification for the source",
@@ -310,10 +317,17 @@
         },
         "resourceDigests": {
           "description": "Digest information for resources in the component",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/nestedDigestSpec"
-          }
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/nestedDigestSpec"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },
@@ -328,10 +342,17 @@
         },
         "labels": {
           "description": "Labels for further identification of the source",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/label"
-          }
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/label"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },
@@ -364,10 +385,17 @@
         },
         "labels": {
           "description": "Labels associated with the reference",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/label"
-          }
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/label"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "digest": {
           "description": "Optional digest of the referenced component",
@@ -412,10 +440,17 @@
         },
         "srcRefs": {
           "description": "References to sources that produced this resource",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/srcRef"
-          }
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/srcRef"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "relation": {
           "description": "Relation of the resource to the component (local or external)",
@@ -427,10 +462,17 @@
         },
         "labels": {
           "description": "Labels associated with the resource",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/label"
-          }
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/label"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "access": {
           "description": "Access specification for the resource",
@@ -484,10 +526,17 @@
         },
         "repositoryContexts": {
           "description": "Previous repositories of the component",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/repositoryContext"
-          }
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/repositoryContext"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "provider": {
           "description": "Provider type of the component in the origin's context",
@@ -495,24 +544,45 @@
         },
         "labels": {
           "description": "Labels associated with the component",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/label"
-          }
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/label"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "sources": {
           "description": "Sources that produced the component",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/sourceDefinition"
-          }
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/sourceDefinition"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "componentReferences": {
           "description": "References to other component versions",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/componentReference"
-          }
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/componentReference"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "resources": {
           "description": "Resources created by the component or third parties",
@@ -606,10 +676,17 @@
     },
     "nestedDigests": {
       "description": "Digest information for nested components",
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/nestedComponentDigests"
-      }
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/nestedComponentDigests"
+          }
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
In legacy ocm, we already updated the descriptor schema to allow for null. This is to accomodate the behaviours of different marshalling frameworks. 

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Port from https://github.com/open-component-model/ocm-project/issues/680: https://github.com/open-component-model/ocm/commit/f8add45a24f16b1d81a55d4c307f8f58d16b5a65