### PR TITLE
chore: add type property to access

### DIFF
--- a/bindings/go/descriptor/v2/resources/schema-2020-12.json
+++ b/bindings/go/descriptor/v2/resources/schema-2020-12.json
@@ -132,7 +132,13 @@
       "description": "Base type for access specifications",
       "required": [
         "type"
-      ]
+      ],
+      "properties": {
+        "type": {
+          "description": "Type of the access method",
+          "$ref": "#/$defs/ocmType"
+        }
+      }
     },
     "sourceDefinition": {
       "type": "object",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
For each property listed in the required section of a json schema, the json schema linter requires a corresponding property.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
