### PR TITLE
fix: 799 broken constructor resource parsing for type, version & access

### DIFF
--- a/bindings/go/constructor/spec/v1/resources/schema-2020-12.json
+++ b/bindings/go/constructor/spec/v1/resources/schema-2020-12.json
@@ -333,8 +333,16 @@
       "$ref": "#/$defs/commonResourceProperties",
       "oneOf": [
         {
-          "required": ["version", "relation", "access"],
+          "required": [
+            "type",
+            "version",
+            "access"
+          ],
           "properties": {
+            "type": {
+              "description": "Type of the resource",
+              "$ref": "#/$defs/ocmType"
+            },
             "version": {
               "description": "Version of the resource",
               "$ref": "#/$defs/relaxedSemver"
@@ -358,27 +366,27 @@
           }
         },
         {
-          "required": ["relation", "input"],
+          "required": [
+            "type",
+            "input"
+          ],
           "properties": {
+            "input": {
+              "description": "Input specification for the resource",
+              "$ref": "#/$defs/input"
+            },
             "relation": {
-              "description": "Relation of the resource to the component (always must be local for input types)",
-              "type": "string",
+              "description": "Relation of the resource to the component (local only)",
               "const": "local"
             },
-            "input": {
-              "description": "Input specification for the resource",
-              "$ref": "#/$defs/input"
-            }
-          }
-        },
-        {
-          "required": ["input"],
-          "properties": {
-            "input": {
-              "description": "Input specification for the resource",
-              "$ref": "#/$defs/input"
+            "type": {
+              "description": "Type of the resource",
+              "$ref": "#/$defs/ocmType"
             },
-            "relation": false
+            "version": {
+              "description": "Version of the resource",
+              "$ref": "#/$defs/relaxedSemver"
+            }
           }
         }
       ]

--- a/bindings/go/constructor/spec/v1/schema_test.go
+++ b/bindings/go/constructor/spec/v1/schema_test.go
@@ -26,6 +26,7 @@ func TestComponentConstructorSchema(t *testing.T) {
 					{
 						"name": "resource1",
 						"type": "plain",
+						"version": "1.0.0",
 						"relation": "local",
 						"input": {
 							"type": "file",
@@ -133,24 +134,6 @@ func TestComponentConstructorSchema(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "resource with input only (valid implied local)",
-			json: `{
-				"name": "github.com/acme.org/component",
-				"version": "1.0.0",
-				"provider": { "name": "acme" },
-				"resources": [
-					{
-						"name": "res1",
-						"type": "plain",
-						"input": {
-							"type": "file"
-						}
-					}
-				]
-			}`,
-			wantErr: false,
-		},
-		{
 			name: "valid component reference with string label",
 			json: `{
 				"name": "github.com/acme.org/component",
@@ -220,6 +203,40 @@ func TestComponentConstructorSchema(t *testing.T) {
 				]
 			}`,
 			wantErr: true,
+		},
+		{
+			name: "example component constructor from ocm docs",
+			json: `{
+  "components": [
+    {
+      "name": "github.com/acme.org/helloworld",
+      "version": "1.0.0",
+      "provider": {
+        "name": "acme.org"
+      },
+      "resources": [
+        {
+          "name": "mylocalfile",
+          "type": "blob",
+          "input": {
+            "type": "file",
+            "path": "./my-local-resource.txt"
+          }
+        },
+        {
+          "name": "image",
+          "type": "ociImage",
+          "version": "1.0.0",
+          "access": {
+            "type": "ociArtifact",
+            "imageReference": "ghcr.io/stefanprodan/podinfo:6.9.1"
+          }
+        }
+      ]
+    }
+  ]
+}`,
+			wantErr: false,
 		},
 	}
 


### PR DESCRIPTION
#### What this PR does / why we need it
This PR fixes the oversight in the schema.json integration for constructor parsing.
As per the [getting-started docs](https://ocm.software/dev/docs/getting-started/) we should be allowed to parse this constructor

```yml
# specify a schema to validate the configuration and get auto-completion in your editor
# yaml-language-server: $schema=https://ocm.software/schemas/configuration-schema.yaml
components:
- name: github.com/acme.org/helloworld
  # version needs to follow "relaxed" SemVer
  version: 1.0.0
  provider:
    name: acme.org
  resources:
    # local file resource
    - name: mylocalfile
      type: blob
      input:
        type: file
        path: ./my-local-resource.txt
    # remote image resource
    - name: image
      type: ociImage
      version: 1.0.0
      access:
        type: ociArtifact
        imageReference: ghcr.io/stefanprodan/podinfo:6.9.1
```

After checking old ocm [schema](https://github.com/open-component-model/ocm/blob/main/resources/component-descriptor-v2-schema.yaml#L237) we should require to suport these properties:

```yml
      - 'name'
      - 'version' # for local resources, this must match component's version
      - 'type'
      - 'relation'
      - 'access'
```

#### Which issue(s) this PR fixes
Fixes: https://github.com/open-component-model/ocm-project/issues/799
