### PR TITLE
fix: add cel native type check to structural compatibility check

### DIFF
--- a/bindings/go/cel/jsonschema/decl/check/structural_compatibility.go
+++ b/bindings/go/cel/jsonschema/decl/check/structural_compatibility.go
@@ -30,6 +30,10 @@ const (
 // The provider is required for introspecting struct field information.
 // Returns true if types are compatible, false otherwise. If false, the error describes why.
 func AreTypesStructurallyCompatible(output, expected *cel.Type, provider *provider.DeclTypeProvider) (bool, error) {
+	if expected.IsAssignableType(output) {
+		return true, nil
+	}
+
 	if output == nil || expected == nil {
 		return false, fmt.Errorf("nil type(s): output=%v, expected=%v", output, expected)
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Add cel native type check to structural compatibility check. If the cel native type check determines the types are assignable, we can skip the structural type comparison.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Contributes to https://github.com/open-component-model/ocm-project/issues/536