### PR TITLE
fix: add missing `$id` properties to JSON schema definitions

### DIFF
--- a/bindings/go/generator/jsonschemagen/generator.go
+++ b/bindings/go/generator/jsonschemagen/generator.go
@@ -47,12 +47,12 @@ func (g *generation) runForRoot(root *universe.TypeInfo) *JSONSchemaDraft202012 
 		defs[key] = full
 	}
 
-	// merge externals exactly once
-	maps.Copy(defs, g.external)
-
 	for _, def := range defs {
 		def.ID = ""
 	}
+
+	// merge externals exactly once
+	maps.Copy(defs, g.external)
 
 	schema.Defs = defs
 	return schema

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFAddComponentVersion.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFAddComponentVersion.schema.json
@@ -32,6 +32,7 @@
   "$defs": {
     "ocm.software.open-component-model.bindings.go.descriptor.v2.Descriptor": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "ocm.software/open-component-model/bindings/go/descriptor/v2/resources/schema-2020-12.json",
       "type": "object",
       "description": "Open Component Model v2 schema",
       "properties": {

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFAddComponentVersionSpec.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFAddComponentVersionSpec.schema.json
@@ -21,6 +21,7 @@
   "$defs": {
     "ocm.software.open-component-model.bindings.go.descriptor.v2.Descriptor": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "ocm.software/open-component-model/bindings/go/descriptor/v2/resources/schema-2020-12.json",
       "type": "object",
       "description": "Open Component Model v2 schema",
       "properties": {

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFGetComponentVersion.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFGetComponentVersion.schema.json
@@ -32,6 +32,7 @@
   "$defs": {
     "ocm.software.open-component-model.bindings.go.descriptor.v2.Descriptor": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "ocm.software/open-component-model/bindings/go/descriptor/v2/resources/schema-2020-12.json",
       "type": "object",
       "description": "Open Component Model v2 schema",
       "properties": {

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFGetComponentVersionOutput.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFGetComponentVersionOutput.schema.json
@@ -17,6 +17,7 @@
   "$defs": {
     "ocm.software.open-component-model.bindings.go.descriptor.v2.Descriptor": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "ocm.software/open-component-model/bindings/go/descriptor/v2/resources/schema-2020-12.json",
       "type": "object",
       "description": "Open Component Model v2 schema",
       "properties": {

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIAddComponentVersion.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIAddComponentVersion.schema.json
@@ -32,6 +32,7 @@
   "$defs": {
     "ocm.software.open-component-model.bindings.go.descriptor.v2.Descriptor": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "ocm.software/open-component-model/bindings/go/descriptor/v2/resources/schema-2020-12.json",
       "type": "object",
       "description": "Open Component Model v2 schema",
       "properties": {

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIAddComponentVersionSpec.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIAddComponentVersionSpec.schema.json
@@ -21,6 +21,7 @@
   "$defs": {
     "ocm.software.open-component-model.bindings.go.descriptor.v2.Descriptor": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "ocm.software/open-component-model/bindings/go/descriptor/v2/resources/schema-2020-12.json",
       "type": "object",
       "description": "Open Component Model v2 schema",
       "properties": {

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIGetComponentVersion.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIGetComponentVersion.schema.json
@@ -32,6 +32,7 @@
   "$defs": {
     "ocm.software.open-component-model.bindings.go.descriptor.v2.Descriptor": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "ocm.software/open-component-model/bindings/go/descriptor/v2/resources/schema-2020-12.json",
       "type": "object",
       "description": "Open Component Model v2 schema",
       "properties": {

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIGetComponentVersionOutput.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIGetComponentVersionOutput.schema.json
@@ -17,6 +17,7 @@
   "$defs": {
     "ocm.software.open-component-model.bindings.go.descriptor.v2.Descriptor": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "ocm.software/open-component-model/bindings/go/descriptor/v2/resources/schema-2020-12.json",
       "type": "object",
       "description": "Open Component Model v2 schema",
       "properties": {

--- a/bindings/go/transform/graph/internal/testutils/schemas/MockCustomSchemaObjectTransformer.schema.json
+++ b/bindings/go/transform/graph/internal/testutils/schemas/MockCustomSchemaObjectTransformer.schema.json
@@ -40,6 +40,7 @@
     },
     "ocm.software.open-component-model.bindings.go.transform.graph.internal.testutils.MockCustomSchemaObject": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "ocm.software/open-component-model/bindings/go/transform/graph/internal/testutils/schemas/custom_schema.json",
       "type": "object",
       "description": "Test schema to validate transformation graph behavior",
       "properties": {

--- a/bindings/go/transform/graph/internal/testutils/schemas/MockCustomSchemaObjectTransformerOutput.schema.json
+++ b/bindings/go/transform/graph/internal/testutils/schemas/MockCustomSchemaObjectTransformerOutput.schema.json
@@ -17,6 +17,7 @@
   "$defs": {
     "ocm.software.open-component-model.bindings.go.transform.graph.internal.testutils.MockCustomSchemaObject": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "ocm.software/open-component-model/bindings/go/transform/graph/internal/testutils/schemas/custom_schema.json",
       "type": "object",
       "description": "Test schema to validate transformation graph behavior",
       "properties": {

--- a/bindings/go/transform/graph/internal/testutils/schemas/MockCustomSchemaObjectTransformerSpec.schema.json
+++ b/bindings/go/transform/graph/internal/testutils/schemas/MockCustomSchemaObjectTransformerSpec.schema.json
@@ -17,6 +17,7 @@
   "$defs": {
     "ocm.software.open-component-model.bindings.go.transform.graph.internal.testutils.MockCustomSchemaObject": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "ocm.software/open-component-model/bindings/go/transform/graph/internal/testutils/schemas/custom_schema.json",
       "type": "object",
       "description": "Test schema to validate transformation graph behavior",
       "properties": {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

For external schemas, because we now deduplicate them, we can go ahead and preserve the ID. That will ensure nested definitions are preserved

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

This relates to our recent refactoring of the schema generator. If we wouldnt do this, jsonschema resolution for the embedded component descriptor would fail
