### PR TITLE
fix: allow "resources" field to accept null values in schema

### DIFF
--- a/bindings/go/descriptor/v2/resources/schema-2020-12.json
+++ b/bindings/go/descriptor/v2/resources/schema-2020-12.json
@@ -592,10 +592,17 @@
         },
         "resources": {
           "description": "Resources created by the component or third parties",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/resourceDefinition"
-          }
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/resourceDefinition"
+              }
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "examples": [


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

allows null for the resource array in the descriptor. we forgot that so a constructor without resources works, but a descriptor doesnt.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
