### PR TITLE
fix: pin the node version to 1.34 so it does not upgrade to an unsupported version

### DIFF
--- a/kubernetes/controller/test/e2e/hacks/setup.sh
+++ b/kubernetes/controller/test/e2e/hacks/setup.sh
@@ -42,11 +42,13 @@ if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true
     registry:2
 fi
 
+KIND_NODE_IMAGE="kindest/node:v1.34.0"
+
 # Create kind cluster with
 # - Port mappings for additional cluster OCI registries (replication tests).
 # - Containerd config patches to add registry mirrors and configs for the internal registries.
 # - http-alias and insecure_skip_verify.
-cat <<EOF | kind create cluster --config=-
+cat <<EOF | kind create cluster --image=${KIND_NODE_IMAGE} --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:


### PR DESCRIPTION


On-behalf-of: Gergely Brautigam <gergely.brautigam@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
