### PR TITLE
fix: labels, signatures and examples in v2 descriptor and generator

### DIFF
--- a/bindings/go/cel/jsonschema/santhosh-tekuri/v6/conversion_test.go
+++ b/bindings/go/cel/jsonschema/santhosh-tekuri/v6/conversion_test.go
@@ -66,6 +66,21 @@ func TestSchemas(t *testing.T) {
 			},
 		},
 		{
+			file: "bindings/go/cel/jsonschema/santhosh-tekuri/v6/testdata/TrueSchema.schema.json",
+			verify: func(t *testing.T, decl *jsonschema.DeclType) {
+				require.True(t, decl.IsObject())
+				sa := decl.Fields["trueProp"]
+				require.Equal(t, "dyn", sa.Type.TypeName())
+			},
+			exprTests: []struct {
+				expr  string
+				parse IssueAssertionFunc
+				check IssueAssertionFunc
+			}{
+				{"instance.trueProp", NoIssues, NoIssues},
+			},
+		},
+		{
 			file: "bindings/go/cel/jsonschema/santhosh-tekuri/v6/testdata/Formats.schema.json",
 			verify: func(t *testing.T, decl *jsonschema.DeclType) {
 				require.True(t, decl.IsObject())

--- a/bindings/go/cel/jsonschema/santhosh-tekuri/v6/decl_type.go
+++ b/bindings/go/cel/jsonschema/santhosh-tekuri/v6/decl_type.go
@@ -220,6 +220,11 @@ func NewDeclType(s *Schema) *DeclType {
 		return declTypeForSchema(decl.DynType, s)
 	}
 
+	// a true bool schema on schema level is equivalent to the property needing to be present in any form.
+	if s.Schema != nil && s.Schema.Bool != nil && *s.Schema.Bool {
+		return declTypeForSchema(decl.DynType, s)
+	}
+
 	return nil
 }
 

--- a/bindings/go/cel/jsonschema/santhosh-tekuri/v6/testdata/TrueSchema.schema.json
+++ b/bindings/go/cel/jsonschema/santhosh-tekuri/v6/testdata/TrueSchema.schema.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "test/TrueSchema.schema.json",
+  "type": "object",
+  "properties": {
+    "trueProp": true
+  },
+  "required": ["trueProp"]
+}

--- a/bindings/go/descriptor/v2/resources/schema-2020-12.json
+++ b/bindings/go/descriptor/v2/resources/schema-2020-12.json
@@ -43,18 +43,7 @@
           "description": "Name of the label",
           "$ref": "#/$defs/nonEmptyString"
         },
-        "value": {
-          "oneOf": [
-            {
-              "description": "Value of the label",
-              "$ref": "#/$defs/nonEmptyString"
-            },
-            {
-              "type": "object",
-              "description": "an arbitrarily complex structured value"
-            }
-          ]
-        },
+        "value": true,
         "version": {
           "oneOf": [
             {
@@ -206,15 +195,15 @@
       "properties": {
         "hashAlgorithm": {
           "description": "Algorithm used for hashing",
-          "$ref": "#/$defs/nonEmptyString"
+          "type": "string"
         },
         "normalisationAlgorithm": {
           "description": "Algorithm used for normalizing content before hashing",
-          "$ref": "#/$defs/nonEmptyString"
+          "type": "string"
         },
         "value": {
           "description": "The actual hash value",
-          "$ref": "#/$defs/nonEmptyString"
+          "type": "string"
         }
       }
     },

--- a/bindings/go/generator/jsonschemagen/schema.go
+++ b/bindings/go/generator/jsonschemagen/schema.go
@@ -40,10 +40,10 @@ type JSONSchemaDraft202012 struct {
 	MaxItems    *int  `json:"maxItems,omitempty"`
 	UniqueItems *bool `json:"uniqueItems,omitempty"`
 
-	MinProperties *int                              `json:"minProperties,omitempty"`
-	MaxProperties *int                              `json:"maxProperties,omitempty"`
-	Properties    map[string]*JSONSchemaDraft202012 `json:"properties,omitempty"`
-	Enum          []any                             `json:"enum,omitempty"`
+	MinProperties *int                     `json:"minProperties,omitempty"`
+	MaxProperties *int                     `json:"maxProperties,omitempty"`
+	Properties    map[string]*SchemaOrBool `json:"properties,omitempty"`
+	Enum          []any                    `json:"enum,omitempty"`
 
 	Required             []string      `json:"required,omitempty"`
 	AdditionalProperties *SchemaOrBool `json:"additionalProperties,omitempty"`
@@ -232,8 +232,8 @@ func applyMarkers(
 	}
 }
 
-func (g *generation) buildStructProperties(st *ast.StructType, ti *universe.TypeInfo) map[string]*JSONSchemaDraft202012 {
-	props := make(map[string]*JSONSchemaDraft202012)
+func (g *generation) buildStructProperties(st *ast.StructType, ti *universe.TypeInfo) map[string]*SchemaOrBool {
+	props := make(map[string]*SchemaOrBool)
 
 	for _, field := range st.Fields.List {
 		if len(field.Names) == 0 {
@@ -255,7 +255,7 @@ func (g *generation) buildStructProperties(st *ast.StructType, ti *universe.Type
 			sch.Deprecated = Ptr(true)
 		}
 
-		props[name] = sch
+		props[name] = &SchemaOrBool{Schema: sch}
 	}
 	return props
 }
@@ -276,7 +276,7 @@ func (g *generation) buildStructRequired(st *ast.StructType) []string {
 }
 
 func (g *generation) inlineAnonymousStruct(st *ast.StructType, ctx *universe.TypeInfo) *JSONSchemaDraft202012 {
-	props := map[string]*JSONSchemaDraft202012{}
+	props := map[string]*SchemaOrBool{}
 	var req []string
 
 	for _, field := range st.Fields.List {
@@ -299,7 +299,7 @@ func (g *generation) inlineAnonymousStruct(st *ast.StructType, ctx *universe.Typ
 			sch.Deprecated = Ptr(true)
 		}
 
-		props[name] = sch
+		props[name] = &SchemaOrBool{Schema: sch}
 		if !slices.Contains(opts, "omitempty") {
 			req = append(req, name)
 		}

--- a/bindings/go/generator/jsonschemagen/schema_test.go
+++ b/bindings/go/generator/jsonschemagen/schema_test.go
@@ -197,25 +197,25 @@ func TestGenerate_MixedFieldTypes(t *testing.T) {
 	require.Contains(t, props, "opt") // tag name for OmOpt
 
 	// Name is string
-	require.Equal(t, "string", props["Name"].Type)
+	require.Equal(t, "string", props["Name"].Schema.Type)
 
 	// PtrRef should be a $ref to local
-	require.Equal(t, "#/$defs/"+universe.Definition(local.Key), props["PtrRef"].Ref)
+	require.Equal(t, "#/$defs/"+universe.Definition(local.Key), props["PtrRef"].Schema.Ref)
 
 	// SelRef should be a $ref to external
-	require.Equal(t, "#/$defs/"+universe.Definition(external.Key), props["SelRef"].Ref)
+	require.Equal(t, "#/$defs/"+universe.Definition(external.Key), props["SelRef"].Schema.Ref)
 
 	// Arr items integer
-	require.Equal(t, "array", props["Arr"].Type)
-	require.Equal(t, "integer", props["Arr"].Items.Type)
+	require.Equal(t, "array", props["Arr"].Schema.Type)
+	require.Equal(t, "integer", props["Arr"].Schema.Items.Type)
 
 	// M additionalProperties is a $ref to local
-	require.NotNil(t, props["M"].AdditionalProperties)
-	require.Equal(t, "#/$defs/"+universe.Definition(local.Key), props["M"].AdditionalProperties.Schema.Ref)
+	require.NotNil(t, props["M"].Schema.AdditionalProperties)
+	require.Equal(t, "#/$defs/"+universe.Definition(local.Key), props["M"].Schema.AdditionalProperties.Schema.Ref)
 
 	// Inline should be object with property X
-	require.Equal(t, "object", props["Inline"].Type)
-	require.Contains(t, props["Inline"].Properties, "X")
+	require.Equal(t, "object", props["Inline"].Schema.Type)
+	require.Contains(t, props["Inline"].Schema.Properties, "X")
 
 	// Required should include Name, PtrRef, SelRef, Arr, M, Inline but not opt (omitempty) nor Omit
 	req := s.Required
@@ -248,10 +248,10 @@ func TestSelectorResolutionMissingImportFallsBackToAny(t *testing.T) {
 	p, ok := s.Properties["SelRef"]
 	require.True(t, ok)
 	// should be anyObjectSchema fallback
-	require.Equal(t, "object", p.Type)
-	require.NotNil(t, p.AdditionalProperties)
-	require.NotNil(t, p.AdditionalProperties.Bool)
-	require.True(t, *p.AdditionalProperties.Bool)
+	require.Equal(t, "object", p.Schema.Type)
+	require.NotNil(t, p.Schema.AdditionalProperties)
+	require.NotNil(t, p.Schema.AdditionalProperties.Bool)
+	require.True(t, *p.Schema.AdditionalProperties.Bool)
 
 	// defs should NOT contain the external type
 	_, exists := s.Defs[universe.Definition(external.Key)]
@@ -289,7 +289,7 @@ func TestGenerate_CircularReferencesDoesNotLoopAndFlattensDefs(t *testing.T) {
 	require.NotNil(t, bSch)
 	propA, ok := bSch.Properties["A"]
 	require.True(t, ok)
-	require.Equal(t, "#/$defs/"+universe.Definition(A.Key), propA.Ref)
+	require.Equal(t, "#/$defs/"+universe.Definition(A.Key), propA.Schema.Ref)
 }
 
 func TestBuiltinRuntimeSchemas(t *testing.T) {
@@ -310,7 +310,7 @@ func TestBuiltinRuntimeSchemas(t *testing.T) {
 	require.NotNil(t, rawSch.AdditionalProperties.Bool)
 	require.True(t, *rawSch.AdditionalProperties.Bool)
 	require.Contains(t, rawSch.Required, "type")
-	require.Equal(t, "#/$defs/ocm.software.open-component-model.bindings.go.runtime.Type", rawSch.Properties["type"].Ref)
+	require.Equal(t, "#/$defs/ocm.software.open-component-model.bindings.go.runtime.Type", rawSch.Properties["type"].Schema.Ref)
 
 	// Type
 	typTI := &universe.TypeInfo{

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFAddComponentVersion.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFAddComponentVersion.schema.json
@@ -265,15 +265,15 @@
           "description": "Specification of digest information including hashing algorithm and value",
           "properties": {
             "hashAlgorithm": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "Algorithm used for hashing"
             },
             "normalisationAlgorithm": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "Algorithm used for normalizing content before hashing"
             },
             "value": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "The actual hash value"
             }
           },
@@ -308,18 +308,7 @@
               "type": "boolean",
               "description": "Indicates whether the label should be included in the signature"
             },
-            "value": {
-              "oneOf": [
-                {
-                  "$ref": "#/$defs/nonEmptyString",
-                  "description": "Value of the label"
-                },
-                {
-                  "type": "object",
-                  "description": "an arbitrarily complex structured value"
-                }
-              ]
-            },
+            "value": true,
             "version": {
               "oneOf": [
                 {

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFAddComponentVersionSpec.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFAddComponentVersionSpec.schema.json
@@ -254,15 +254,15 @@
           "description": "Specification of digest information including hashing algorithm and value",
           "properties": {
             "hashAlgorithm": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "Algorithm used for hashing"
             },
             "normalisationAlgorithm": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "Algorithm used for normalizing content before hashing"
             },
             "value": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "The actual hash value"
             }
           },
@@ -297,18 +297,7 @@
               "type": "boolean",
               "description": "Indicates whether the label should be included in the signature"
             },
-            "value": {
-              "oneOf": [
-                {
-                  "$ref": "#/$defs/nonEmptyString",
-                  "description": "Value of the label"
-                },
-                {
-                  "type": "object",
-                  "description": "an arbitrarily complex structured value"
-                }
-              ]
-            },
+            "value": true,
             "version": {
               "oneOf": [
                 {

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFGetComponentVersion.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFGetComponentVersion.schema.json
@@ -265,15 +265,15 @@
           "description": "Specification of digest information including hashing algorithm and value",
           "properties": {
             "hashAlgorithm": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "Algorithm used for hashing"
             },
             "normalisationAlgorithm": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "Algorithm used for normalizing content before hashing"
             },
             "value": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "The actual hash value"
             }
           },
@@ -308,18 +308,7 @@
               "type": "boolean",
               "description": "Indicates whether the label should be included in the signature"
             },
-            "value": {
-              "oneOf": [
-                {
-                  "$ref": "#/$defs/nonEmptyString",
-                  "description": "Value of the label"
-                },
-                {
-                  "type": "object",
-                  "description": "an arbitrarily complex structured value"
-                }
-              ]
-            },
+            "value": true,
             "version": {
               "oneOf": [
                 {

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFGetComponentVersionOutput.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFGetComponentVersionOutput.schema.json
@@ -250,15 +250,15 @@
           "description": "Specification of digest information including hashing algorithm and value",
           "properties": {
             "hashAlgorithm": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "Algorithm used for hashing"
             },
             "normalisationAlgorithm": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "Algorithm used for normalizing content before hashing"
             },
             "value": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "The actual hash value"
             }
           },
@@ -293,18 +293,7 @@
               "type": "boolean",
               "description": "Indicates whether the label should be included in the signature"
             },
-            "value": {
-              "oneOf": [
-                {
-                  "$ref": "#/$defs/nonEmptyString",
-                  "description": "Value of the label"
-                },
-                {
-                  "type": "object",
-                  "description": "an arbitrarily complex structured value"
-                }
-              ]
-            },
+            "value": true,
             "version": {
               "oneOf": [
                 {

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIAddComponentVersion.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIAddComponentVersion.schema.json
@@ -265,15 +265,15 @@
           "description": "Specification of digest information including hashing algorithm and value",
           "properties": {
             "hashAlgorithm": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "Algorithm used for hashing"
             },
             "normalisationAlgorithm": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "Algorithm used for normalizing content before hashing"
             },
             "value": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "The actual hash value"
             }
           },
@@ -308,18 +308,7 @@
               "type": "boolean",
               "description": "Indicates whether the label should be included in the signature"
             },
-            "value": {
-              "oneOf": [
-                {
-                  "$ref": "#/$defs/nonEmptyString",
-                  "description": "Value of the label"
-                },
-                {
-                  "type": "object",
-                  "description": "an arbitrarily complex structured value"
-                }
-              ]
-            },
+            "value": true,
             "version": {
               "oneOf": [
                 {

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIAddComponentVersionSpec.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIAddComponentVersionSpec.schema.json
@@ -254,15 +254,15 @@
           "description": "Specification of digest information including hashing algorithm and value",
           "properties": {
             "hashAlgorithm": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "Algorithm used for hashing"
             },
             "normalisationAlgorithm": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "Algorithm used for normalizing content before hashing"
             },
             "value": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "The actual hash value"
             }
           },
@@ -297,18 +297,7 @@
               "type": "boolean",
               "description": "Indicates whether the label should be included in the signature"
             },
-            "value": {
-              "oneOf": [
-                {
-                  "$ref": "#/$defs/nonEmptyString",
-                  "description": "Value of the label"
-                },
-                {
-                  "type": "object",
-                  "description": "an arbitrarily complex structured value"
-                }
-              ]
-            },
+            "value": true,
             "version": {
               "oneOf": [
                 {

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIGetComponentVersion.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIGetComponentVersion.schema.json
@@ -265,15 +265,15 @@
           "description": "Specification of digest information including hashing algorithm and value",
           "properties": {
             "hashAlgorithm": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "Algorithm used for hashing"
             },
             "normalisationAlgorithm": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "Algorithm used for normalizing content before hashing"
             },
             "value": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "The actual hash value"
             }
           },
@@ -308,18 +308,7 @@
               "type": "boolean",
               "description": "Indicates whether the label should be included in the signature"
             },
-            "value": {
-              "oneOf": [
-                {
-                  "$ref": "#/$defs/nonEmptyString",
-                  "description": "Value of the label"
-                },
-                {
-                  "type": "object",
-                  "description": "an arbitrarily complex structured value"
-                }
-              ]
-            },
+            "value": true,
             "version": {
               "oneOf": [
                 {

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIGetComponentVersionOutput.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIGetComponentVersionOutput.schema.json
@@ -250,15 +250,15 @@
           "description": "Specification of digest information including hashing algorithm and value",
           "properties": {
             "hashAlgorithm": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "Algorithm used for hashing"
             },
             "normalisationAlgorithm": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "Algorithm used for normalizing content before hashing"
             },
             "value": {
-              "$ref": "#/$defs/nonEmptyString",
+              "type": "string",
               "description": "The actual hash value"
             }
           },
@@ -293,18 +293,7 @@
               "type": "boolean",
               "description": "Indicates whether the label should be included in the signature"
             },
-            "value": {
-              "oneOf": [
-                {
-                  "$ref": "#/$defs/nonEmptyString",
-                  "description": "Value of the label"
-                },
-                {
-                  "type": "object",
-                  "description": "an arbitrarily complex structured value"
-                }
-              ]
-            },
+            "value": true,
             "version": {
               "oneOf": [
                 {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

labels in ocmv2 are defined as arbitrary objects. as such we need to set the jsonschema "true" value instead of a one of since it can literally be translated to any type.

Also makes it so that signature objects with empty strings set can still be parsed.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes both the descriptor v2 schema as well as our jsonschema decl type generation
