### PR TITLE
feat(helm): add helm chart with updated E2E test workflow

### DIFF
--- a/.github/workflows/kubernetes-controller.yml
+++ b/.github/workflows/kubernetes-controller.yml
@@ -23,10 +23,50 @@ concurrency:
   group: e2e-${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  E2E:
-    name: E2E
+  verify-chart:
+    name: Verify Chart
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Setup Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
+      - name: Install Task
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4
+        with:
+          version: v3.14.0
+      - name: Generate values schema
+        working-directory: kubernetes/controller
+        run: task helm/schema
+      - name: Generate chart documentation
+        working-directory: kubernetes/controller
+        run: task helm/docs
+      - name: Lint chart
+        working-directory: kubernetes/controller
+        run: task helm/lint
+      - name: Render chart templates
+        working-directory: kubernetes/controller
+        run: task helm/template
+      - name: Verify no uncommitted changes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::Uncommitted changes detected after running helm tasks"
+            git status
+            git diff
+            exit 1
+          fi
+          echo "No uncommitted changes detected"
+  E2E:
+    name: E2E with Helm
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: verify-chart
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -35,39 +75,34 @@ jobs:
             kubernetes/controller
             .github/workflows/kubernetes-controller.yml
             Taskfile.yml
-
       - name: Setup Go (required for CLI build)
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
           go-version-file: kubernetes/controller/go.mod
           cache: false
-
       - name: Install Task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set up docker
         uses: docker/setup-docker-action@e43656e248c0bd0647d3f5c195d116aacf6fcaf4 # v4
-
       - name: Setup ocm
         uses: open-component-model/ocm-setup-action@655f3525fd283ca7d22e6b2ceec42324331df401 # v1.0.0
-
       - name: Setup Flux CLI
         uses: fluxcd/flux2/action@8454b02a32e48d775b9f563cb51fdcb1787b5b93 # v2.7.5
-
-      - name: Setup Local E2E Test Cluster
+      - name: Install Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4
+        with:
+          version: v3.14.0
+      - name: Create kind cluster with dependencies
         run: task kubernetes/controller:test/e2e/setup/local
-
-      - name: Run
-        run: task kubernetes/controller:test/e2e
-
+      - name: Run E2E tests with Helm chart
+        run: task kubernetes/controller:test/e2e/helm
       - name: Cleanup unused cache
         shell: bash
         run: |
-          docker system prune --force        
-
+          docker system prune --force
   publish_latest:
     name: "Publish Latest Image"
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -109,11 +144,20 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build & Push
+      - name: Build & Push Controller Image
         env:
           # create an additional tag that is easy to pin to and reference
           CONTROLLER_IMG: "ghcr.io/open-component-model/kubernetes/controller:${{ steps.version.outputs.version }} ghcr.io/open-component-model/kubernetes/controller:latest"
         run: task kubernetes/controller:docker-build/multi-arch PUSH=true
+      - name: Install Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4
+        with:
+          version: v3.14.0
+      - name: Package and Push Helm Chart
+        working-directory: kubernetes/controller
+        run: |
+          helm package chart/ --app-version "${{ steps.version.outputs.version }}"
+          helm push ocm-k8s-toolkit-*.tgz oci://ghcr.io/open-component-model/charts
       - name: Cleanup unused cache
         shell: bash
         run: |

--- a/kubernetes/controller/PROJECT
+++ b/kubernetes/controller/PROJECT
@@ -5,6 +5,10 @@
 domain: ocm.software
 layout:
 - go.kubebuilder.io/v4
+plugins:
+  helm.kubebuilder.io/v2-alpha:
+    manifests: dist/install.yaml
+    output: .
 projectName: ocm-k8s-toolkit
 repo: ocm.software/open-component-model/kubernetes/controller
 resources:

--- a/kubernetes/controller/Taskfile.yml
+++ b/kubernetes/controller/Taskfile.yml
@@ -80,6 +80,13 @@ tasks:
         vars:
           IGNORE_NOT_FOUND: "true"
 
+  test/e2e/helm:
+    dotenv: ['{{.TASKFILE_DIR}}/test/e2e/hacks/.env']
+    cmds:
+      - task: helm/install
+      - PROJECT_DIR='{{.TASKFILE_DIR}}' go test '{{.TASKFILE_DIR}}/test/e2e/' -v -timeout 30m -ginkgo.v
+      - task: helm/uninstall
+
   # Build
   build:
     deps: [manifests, generate, fmt, vet]
@@ -204,3 +211,70 @@ tasks:
     internal: true
     dir: config/manager
     cmd: '"{{.KUSTOMIZE}}" edit set image ghcr.io/open-component-model/kubernetes/controller={{.CONTROLLER_IMG}}'
+
+  # Helm chart tasks
+  helm/schema:
+    desc: "Generate JSON schema from chart values.yaml"
+    deps: [helm-schema-plugin]
+    dir: chart
+    cmd: 'helm schema -f values.yaml -o values.schema.json'
+    sources:
+      - chart/values.yaml
+    generates:
+      - chart/values.schema.json
+
+  helm/lint:
+    desc: "Lint the Helm chart"
+    cmd: 'helm lint chart/'
+
+  helm/template:
+    desc: "Render Helm chart templates with test values"
+    cmd: 'helm template ocm-k8s-toolkit chart/ --namespace ocm-k8s-toolkit-system -f chart/test-values.yaml'
+
+  helm/install:
+    desc: "Install the Helm chart"
+    cmds:
+      - |
+        helm install ocm-k8s-toolkit chart/ \
+          -f chart/test-values.yaml \
+          --namespace ocm-k8s-toolkit-system \
+          --create-namespace \
+          --wait \
+          --timeout 120s
+
+  helm/uninstall:
+    desc: "Uninstall the Helm chart"
+    cmd: 'helm uninstall ocm-k8s-toolkit --namespace ocm-k8s-toolkit-system --ignore-not-found'
+
+  helm/docs:
+    desc: "Generate Helm chart documentation"
+    deps: [helm-docs-tool]
+    dir: chart
+    cmd: 'helm-docs'
+    sources:
+      - chart/values.yaml
+      - chart/README.md
+    generates:
+      - chart/README.md
+
+  helm-docs-tool:
+    internal: true
+    silent: true
+    desc: "Install helm-docs if not present"
+    cmd: |
+      if ! command -v helm-docs &> /dev/null; then
+        go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
+      fi
+    status:
+      - command -v helm-docs
+
+  helm-schema-plugin:
+    internal: true
+    silent: true
+    desc: "Install helm-values-schema-json plugin if not present"
+    cmd: |
+      if ! helm plugin list | grep -q "schema"; then
+        helm plugin install https://github.com/losisin/helm-values-schema-json
+      fi
+    status:
+      - helm plugin list | grep -q "schema"

--- a/kubernetes/controller/chart/.helmignore
+++ b/kubernetes/controller/chart/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building Helm packages.
+# Operating system files
+.DS_Store
+
+# Version control directories
+.git/
+.gitignore
+.bzr/
+.hg/
+.hgignore
+.svn/
+
+# Backup and temporary files
+*.swp
+*.tmp
+*.bak
+*.orig
+*~
+
+# IDE and editor-related files
+.idea/
+.vscode/
+
+# Helm chart artifacts
+dist/chart/*.tgz

--- a/kubernetes/controller/chart/Chart.yaml
+++ b/kubernetes/controller/chart/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: ocm-k8s-toolkit
+description: A Helm chart for deploying the OCM Kubernetes Toolkit controller
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+kubeVersion: ">=1.26.0-0"
+home: https://ocm.software
+sources:
+  - https://github.com/open-component-model/open-component-model
+maintainers:
+  - name: OCM Team
+    url: https://github.com/open-component-model
+keywords:
+  - ocm
+  - open-component-model
+  - kubernetes
+  - controller
+  - artifact-management

--- a/kubernetes/controller/chart/README.md
+++ b/kubernetes/controller/chart/README.md
@@ -1,0 +1,126 @@
+# ocm-k8s-toolkit
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+
+A Helm chart for deploying the OCM Kubernetes Toolkit controller
+
+**Homepage:** <https://ocm.software>
+
+## Description
+
+The OCM Kubernetes Toolkit controller manages OCM (Open Component Model) resources in Kubernetes clusters.
+It provides controllers for:
+- **Repository** - OCM repository references
+- **Component** - OCM component version tracking
+- **Resource** - OCM resource extraction
+- **Deployer** - Resource deployment automation
+
+## Installation
+
+```bash
+helm install ocm-k8s-toolkit oci://ghcr.io/open-component-model/charts/ocm-k8s-toolkit \
+  --namespace ocm-system \
+  --create-namespace
+```
+
+## Upgrading
+
+```bash
+helm upgrade ocm-k8s-toolkit oci://ghcr.io/open-component-model/charts/ocm-k8s-toolkit \
+  --namespace ocm-system
+```
+
+## Uninstallation
+
+```bash
+helm uninstall ocm-k8s-toolkit --namespace ocm-system
+```
+
+> **Note:** CRDs are kept by default when uninstalling. To remove them:
+> ```bash
+> kubectl delete crd components.delivery.ocm.software deployers.delivery.ocm.software repositories.delivery.ocm.software resources.delivery.ocm.software
+> ```
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| OCM Team |  | <https://github.com/open-component-model> |
+
+## Source Code
+
+* <https://github.com/open-component-model/open-component-model>
+
+## Requirements
+
+Kubernetes: `>=1.26.0-0`
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| certManager.enable | bool | `false` | Enable cert-manager for TLS certificates |
+| crd.enable | bool | `true` | Install CRDs with the chart |
+| crd.keep | bool | `true` | Keep CRDs when uninstalling |
+| manager.affinity | object | `{}` | Pod affinity rules |
+| manager.cache.deployerDownloadSize | int | `1000` | Maximum size of the deployer download object LRU cache |
+| manager.cache.ocmContextSize | int | `100` | Maximum number of active OCM contexts kept alive |
+| manager.cache.ocmSessionSize | int | `100` | Maximum number of active OCM sessions kept alive |
+| manager.concurrency.resource | int | `4` | Number of active resource controller workers |
+| manager.env | list | `[]` | Environment variables for the controller |
+| manager.events.address | string | `""` | Address of the events receiver (optional) |
+| manager.extraArgs | list | `[]` | Extra arguments to pass to the controller |
+| manager.healthProbe.bindAddress | string | `":8081"` | Address the health probe endpoint binds to |
+| manager.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| manager.image.repository | string | `"ghcr.io/open-component-model/kubernetes/controller"` | Controller image repository |
+| manager.image.tag | string | `"latest"` | Controller image tag |
+| manager.imagePullSecrets | list | `[]` | Image pull secrets for the controller |
+| manager.leaderElection.enabled | bool | `true` | Enable leader election for controller manager |
+| manager.livenessProbe.initialDelaySeconds | int | `15` | Initial delay before starting liveness probes |
+| manager.livenessProbe.path | string | `"/healthz"` | Path for the liveness probe |
+| manager.livenessProbe.periodSeconds | int | `20` | Period between liveness probes |
+| manager.livenessProbe.port | int | `8081` | Port for the liveness probe |
+| manager.logging.development | bool | `false` | Enable development mode (console encoder, debug level, warn stacktrace) |
+| manager.logging.encoder | string | `"json"` | Log encoding: 'json' or 'console' |
+| manager.logging.level | string | `"info"` | Zap log level: 'debug', 'info', 'error', 'panic' or integer > 0 |
+| manager.metricsServer.bindAddress | string | `"0"` | Address the metric endpoint binds to. Set to "0" to disable |
+| manager.metricsServer.enableHttp2 | bool | `false` | Enable HTTP/2 for metrics and webhook servers |
+| manager.metricsServer.secure | bool | `false` | Serve metrics endpoint securely |
+| manager.nodeSelector | object | `{}` | Node selector for pod scheduling |
+| manager.podSecurityContext | object | `{"runAsNonRoot":true}` | Pod-level security context |
+| manager.readinessProbe.initialDelaySeconds | int | `5` | Initial delay before starting readiness probes |
+| manager.readinessProbe.path | string | `"/readyz"` | Path for the readiness probe |
+| manager.readinessProbe.periodSeconds | int | `10` | Period between readiness probes |
+| manager.readinessProbe.port | int | `8081` | Port for the readiness probe |
+| manager.replicas | int | `1` | Number of controller manager replicas |
+| manager.resolver.workerCount | int | `10` | Number of active resolver workers |
+| manager.resolver.workerQueueLength | int | `100` | Maximum work items in queue for component version resolution |
+| manager.resources | object | `{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"10m","memory":"64Mi"}}` | Resource limits and requests |
+| manager.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | Container-level security context |
+| manager.tolerations | list | `[]` | Pod tolerations |
+| metrics.enable | bool | `false` | Enable metrics endpoint with RBAC protection |
+| metrics.port | int | `8443` | Metrics server port |
+| prometheus.enable | bool | `false` | Enable Prometheus ServiceMonitor (requires prometheus-operator) |
+| rbacHelpers.enable | bool | `false` | Install convenience admin/editor/viewer roles for CRDs |
+
+## Development
+
+Run these tasks from the `kubernetes/controller` directory.
+
+### Required tasks before committing
+
+After modifying `values.yaml`, run these tasks to regenerate artifacts:
+
+```bash
+task helm/schema    # Regenerate values.schema.json
+task helm/docs      # Regenerate README.md
+task helm/lint      # Validate chart syntax
+```
+
+### Other useful tasks
+
+```bash
+task helm/template  # Render templates locally
+task helm/install   # Install chart to current cluster
+task helm/uninstall # Remove chart from cluster
+```

--- a/kubernetes/controller/chart/README.md.gotmpl
+++ b/kubernetes/controller/chart/README.md.gotmpl
@@ -1,0 +1,73 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+## Description
+
+The OCM Kubernetes Toolkit controller manages OCM (Open Component Model) resources in Kubernetes clusters.
+It provides controllers for:
+- **Repository** - OCM repository references
+- **Component** - OCM component version tracking
+- **Resource** - OCM resource extraction
+- **Deployer** - Resource deployment automation
+
+## Installation
+
+```bash
+helm install ocm-k8s-toolkit oci://ghcr.io/open-component-model/charts/ocm-k8s-toolkit \
+  --namespace ocm-system \
+  --create-namespace
+```
+
+## Upgrading
+
+```bash
+helm upgrade ocm-k8s-toolkit oci://ghcr.io/open-component-model/charts/ocm-k8s-toolkit \
+  --namespace ocm-system
+```
+
+## Uninstallation
+
+```bash
+helm uninstall ocm-k8s-toolkit --namespace ocm-system
+```
+
+> **Note:** CRDs are kept by default when uninstalling. To remove them:
+> ```bash
+> kubectl delete crd components.delivery.ocm.software deployers.delivery.ocm.software repositories.delivery.ocm.software resources.delivery.ocm.software
+> ```
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+## Development
+
+Run these tasks from the `kubernetes/controller` directory.
+
+### Required tasks before committing
+
+After modifying `values.yaml`, run these tasks to regenerate artifacts:
+
+```bash
+task helm/schema    # Regenerate values.schema.json
+task helm/docs      # Regenerate README.md
+task helm/lint      # Validate chart syntax
+```
+
+### Other useful tasks
+
+```bash
+task helm/template  # Render templates locally
+task helm/install   # Install chart to current cluster
+task helm/uninstall # Remove chart from cluster
+```

--- a/kubernetes/controller/chart/templates/_helpers.tpl
+++ b/kubernetes/controller/chart/templates/_helpers.tpl
@@ -1,0 +1,50 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ocm-k8s-toolkit.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ocm-k8s-toolkit.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Namespace for generated references.
+Always uses the Helm release namespace.
+*/}}
+{{- define "ocm-k8s-toolkit.namespaceName" -}}
+{{- .Release.Namespace }}
+{{- end }}
+
+{{/*
+Resource name with proper truncation for Kubernetes 63-character limit.
+Takes a dict with:
+  - .suffix: Resource name suffix (e.g., "metrics", "webhook")
+  - .context: Template context (root context with .Values, .Release, etc.)
+Dynamically calculates safe truncation to ensure total name length <= 63 chars.
+*/}}
+{{- define "ocm-k8s-toolkit.resourceName" -}}
+{{- $fullname := include "ocm-k8s-toolkit.fullname" .context }}
+{{- $suffix := .suffix }}
+{{- $maxLen := sub 62 (len $suffix) | int }}
+{{- if gt (len $fullname) $maxLen }}
+{{- printf "%s-%s" (trunc $maxLen $fullname | trimSuffix "-") $suffix | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" $fullname $suffix | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}

--- a/kubernetes/controller/chart/templates/crd/components.delivery.ocm.software.yaml
+++ b/kubernetes/controller/chart/templates/crd/components.delivery.ocm.software.yaml
@@ -1,0 +1,353 @@
+{{- if .Values.crd.enable }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+    annotations:
+        controller-gen.kubebuilder.io/version: v0.20.0
+    name: components.delivery.ocm.software
+spec:
+    group: delivery.ocm.software
+    names:
+        kind: Component
+        listKind: ComponentList
+        plural: components
+        singular: component
+    scope: Namespaced
+    versions:
+        - additionalPrinterColumns:
+            - description: Indicates if the Resource is Ready
+              jsonPath: .status.conditions[?(@.type=="Ready")].message
+              name: Ready
+              priority: 1
+              type: string
+            - description: Displays the Age of the Resource
+              jsonPath: .metadata.creationTimestamp
+              name: Age
+              type: date
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+                description: Component is the Schema for the components API.
+                properties:
+                    apiVersion:
+                        description: |-
+                            APIVersion defines the versioned schema of this representation of an object.
+                            Servers should convert recognized schemas to the latest internal value, and
+                            may reject unrecognized values.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                    kind:
+                        description: |-
+                            Kind is a string value representing the REST resource this object represents.
+                            Servers may infer this from the endpoint the client submits requests to.
+                            Cannot be updated.
+                            In CamelCase.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                    metadata:
+                        type: object
+                    spec:
+                        description: ComponentSpec defines the desired state of Component.
+                        properties:
+                            component:
+                                description: Component is the name of the ocm component.
+                                type: string
+                            downgradePolicy:
+                                default: Deny
+                                description: |-
+                                    DowngradePolicy specifies whether the component may be
+                                    downgraded. The property is an enum with the 3 states: `Enforce`, `Allow`,
+                                    `Deny`, with `Deny` being the default.
+                                    `Deny` means never allow downgrades (thus, never fetch components with a
+                                    version lower than the version currently deployed).
+                                    `Allow` means that the component will be checked for a label with the
+                                    `ocm.software/ocm-k8s-toolkit/downgradePolicy` which may specify a semver
+                                    constraint down to which version downgrades are allowed.
+                                    `Enforce` means always allow downgrades.
+                                enum:
+                                    - Allow
+                                    - Deny
+                                    - Enforce
+                                type: string
+                            interval:
+                                description: |-
+                                    Interval at which the repository will be checked for new component
+                                    versions.
+                                type: string
+                            ocmConfig:
+                                description: |-
+                                    OCMConfig defines references to secrets, config maps or ocm api
+                                    objects providing configuration data including credentials.
+                                items:
+                                    description: |-
+                                        OCMConfiguration defines a configuration applied to the reconciliation of an
+                                        ocm k8s object as well as the policy for its propagation of this
+                                        configuration.
+                                    properties:
+                                        apiVersion:
+                                            description: API version of the referent, if not specified the Kubernetes preferred version will be used.
+                                            type: string
+                                        kind:
+                                            description: Kind of the referent.
+                                            type: string
+                                        name:
+                                            description: Name of the referent.
+                                            type: string
+                                        namespace:
+                                            description: Namespace of the referent, when not specified it acts as LocalObjectReference.
+                                            type: string
+                                        policy:
+                                            default: Propagate
+                                            description: |-
+                                                Policy affects the propagation behavior of the configuration. If set to
+                                                ConfigurationPolicyPropagate other ocm api objects can reference this
+                                                object to reuse this configuration.
+                                            enum:
+                                                - Propagate
+                                                - DoNotPropagate
+                                            type: string
+                                    required:
+                                        - kind
+                                        - name
+                                        - policy
+                                    type: object
+                                    x-kubernetes-validations:
+                                        - message: apiVersion must be one of "v1" with kind "Secret" or "ConfigMap" or "delivery.ocm.software/v1alpha1" with the kind of an OCM kubernetes object
+                                          rule: ((!has(self.apiVersion) || self.apiVersion == "" || self.apiVersion == "v1") && (self.kind == "Secret" || self.kind == "ConfigMap")) || (self.apiVersion == "delivery.ocm.software/v1alpha1" && (self.kind == "Repository" || self.kind == "Component" || self.kind == "Resource" || self.kind == "Replication"))
+                                type: array
+                            repositoryRef:
+                                description: RepositoryRef is a reference to a Repository.
+                                properties:
+                                    name:
+                                        default: ""
+                                        description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            semver:
+                                description: Semver defines the constraint of the fetched version. '>=v0.1'.
+                                type: string
+                            semverFilter:
+                                description: |-
+                                    SemverFilter is a regex pattern to filter the versions within the Semver
+                                    range.
+                                type: string
+                            suspend:
+                                description: |-
+                                    Suspend tells the controller to suspend the reconciliation of this
+                                    Component.
+                                type: boolean
+                            verify:
+                                description: |-
+                                    Verify contains a signature name specifying the component signature to be
+                                    verified as well as the trusted public keys (or certificates containing
+                                    the public keys) used to verify the signature.
+                                items:
+                                    properties:
+                                        secretRef:
+                                            description: |-
+                                                Public Key Secret Format
+                                                A secret containing public keys for signature verification is expected to be of the structure:
+
+                                                 Data:
+                                                	  <Signature-Name>: <PublicKey/Certificate>
+
+                                                Additionally, to prepare for a common ocm secret management, it might make sense to introduce a specific secret type
+                                                for these secrets.
+                                            properties:
+                                                name:
+                                                    default: ""
+                                                    description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        signature:
+                                            type: string
+                                        value:
+                                            description: Value defines a PEM/base64 encoded public key value.
+                                            type: string
+                                    required:
+                                        - signature
+                                    type: object
+                                type: array
+                        required:
+                            - component
+                            - interval
+                            - repositoryRef
+                            - semver
+                        type: object
+                    status:
+                        description: ComponentStatus defines the observed state of Component.
+                        properties:
+                            component:
+                                description: |-
+                                    Component specifies the concrete version of the component that was
+                                    fetched after based on the semver constraints during the last successful
+                                    reconciliation.
+                                properties:
+                                    component:
+                                        type: string
+                                    digest:
+                                        description: Digest information of the Component, if available as per OCM specification.
+                                        properties:
+                                            hashAlgorithm:
+                                                description: |-
+                                                    HashAlgorithm specifies the hashing algorithm applied after normalization.
+                                                    The choice of algorithm impacts compatibility across verifiers.
+
+                                                    See specification reference:
+                                                      - https://github.com/open-component-model/ocm-spec/blob/main/doc/04-extensions/04-algorithms/digest-algorithms.md
+                                                type: string
+                                            normalisationAlgorithm:
+                                                description: |-
+                                                    NormalisationAlgorithm defines how the component descriptor or artifact
+                                                    is transformed into a stable byte representation before hashing.
+                                                    Normalization ensures reproducibility by excluding volatile fields
+                                                    such as transport-related access specifications.
+
+                                                    See specification references:
+                                                      - https://github.com/open-component-model/ocm-spec/blob/main/doc/04-extensions/04-algorithms/component-descriptor-normalization-algorithms.md
+                                                      - https://github.com/open-component-model/ocm-spec/blob/main/doc/04-extensions/04-algorithms/artifact-normalization-types.md
+                                                type: string
+                                            value:
+                                                description: |-
+                                                    Value is the encoded digest result produced from the normalized representation.
+                                                    Typically hex or base64 encoded, depending on the algorithm specification.
+                                                type: string
+                                        required:
+                                            - hashAlgorithm
+                                            - normalisationAlgorithm
+                                            - value
+                                        type: object
+                                    repositorySpec:
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    version:
+                                        type: string
+                                required:
+                                    - component
+                                    - repositorySpec
+                                    - version
+                                type: object
+                            conditions:
+                                description: Conditions holds the conditions for the Component.
+                                items:
+                                    description: Condition contains details for one aspect of the current state of this API Resource.
+                                    properties:
+                                        lastTransitionTime:
+                                            description: |-
+                                                lastTransitionTime is the last time the condition transitioned from one status to another.
+                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                                            format: date-time
+                                            type: string
+                                        message:
+                                            description: |-
+                                                message is a human readable message indicating details about the transition.
+                                                This may be an empty string.
+                                            maxLength: 32768
+                                            type: string
+                                        observedGeneration:
+                                            description: |-
+                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                                with respect to the current state of the instance.
+                                            format: int64
+                                            minimum: 0
+                                            type: integer
+                                        reason:
+                                            description: |-
+                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                                Producers of specific condition types may define expected values and meanings for this field,
+                                                and whether the values are considered a guaranteed API.
+                                                The value should be a CamelCase string.
+                                                This field may not be empty.
+                                            maxLength: 1024
+                                            minLength: 1
+                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                            type: string
+                                        status:
+                                            description: status of the condition, one of True, False, Unknown.
+                                            enum:
+                                                - "True"
+                                                - "False"
+                                                - Unknown
+                                            type: string
+                                        type:
+                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                            maxLength: 316
+                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                            type: string
+                                    required:
+                                        - lastTransitionTime
+                                        - message
+                                        - reason
+                                        - status
+                                        - type
+                                    type: object
+                                type: array
+                            effectiveOCMConfig:
+                                description: |-
+                                    EffectiveOCMConfig specifies the entirety of config maps and secrets
+                                    whose configuration data was applied to the Component reconciliation,
+                                    in the order the configuration data was applied.
+                                items:
+                                    description: |-
+                                        OCMConfiguration defines a configuration applied to the reconciliation of an
+                                        ocm k8s object as well as the policy for its propagation of this
+                                        configuration.
+                                    properties:
+                                        apiVersion:
+                                            description: API version of the referent, if not specified the Kubernetes preferred version will be used.
+                                            type: string
+                                        kind:
+                                            description: Kind of the referent.
+                                            type: string
+                                        name:
+                                            description: Name of the referent.
+                                            type: string
+                                        namespace:
+                                            description: Namespace of the referent, when not specified it acts as LocalObjectReference.
+                                            type: string
+                                        policy:
+                                            default: Propagate
+                                            description: |-
+                                                Policy affects the propagation behavior of the configuration. If set to
+                                                ConfigurationPolicyPropagate other ocm api objects can reference this
+                                                object to reuse this configuration.
+                                            enum:
+                                                - Propagate
+                                                - DoNotPropagate
+                                            type: string
+                                    required:
+                                        - kind
+                                        - name
+                                        - policy
+                                    type: object
+                                    x-kubernetes-validations:
+                                        - message: apiVersion must be one of "v1" with kind "Secret" or "ConfigMap" or "delivery.ocm.software/v1alpha1" with the kind of an OCM kubernetes object
+                                          rule: ((!has(self.apiVersion) || self.apiVersion == "" || self.apiVersion == "v1") && (self.kind == "Secret" || self.kind == "ConfigMap")) || (self.apiVersion == "delivery.ocm.software/v1alpha1" && (self.kind == "Repository" || self.kind == "Component" || self.kind == "Resource" || self.kind == "Replication"))
+                                type: array
+                            observedGeneration:
+                                description: |-
+                                    ObservedGeneration is the last observed generation of the ComponentStatus
+                                    object.
+                                format: int64
+                                type: integer
+                        type: object
+                required:
+                    - spec
+                type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+{{- end }}

--- a/kubernetes/controller/chart/templates/crd/deployers.delivery.ocm.software.yaml
+++ b/kubernetes/controller/chart/templates/crd/deployers.delivery.ocm.software.yaml
@@ -1,0 +1,252 @@
+{{- if .Values.crd.enable }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+    annotations:
+        controller-gen.kubebuilder.io/version: v0.20.0
+    name: deployers.delivery.ocm.software
+spec:
+    group: delivery.ocm.software
+    names:
+        kind: Deployer
+        listKind: DeployerList
+        plural: deployers
+        singular: deployer
+    scope: Cluster
+    versions:
+        - name: v1alpha1
+          schema:
+            openAPIV3Schema:
+                description: Deployer is the Schema for the deployers API.
+                properties:
+                    apiVersion:
+                        description: |-
+                            APIVersion defines the versioned schema of this representation of an object.
+                            Servers should convert recognized schemas to the latest internal value, and
+                            may reject unrecognized values.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                    kind:
+                        description: |-
+                            Kind is a string value representing the REST resource this object represents.
+                            Servers may infer this from the endpoint the client submits requests to.
+                            Cannot be updated.
+                            In CamelCase.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                    metadata:
+                        type: object
+                    spec:
+                        description: DeployerSpec defines the desired state of Deployer.
+                        properties:
+                            ocmConfig:
+                                description: |-
+                                    OCMConfig defines references to secrets, config maps or ocm api
+                                    objects providing configuration data including credentials.
+                                items:
+                                    description: |-
+                                        OCMConfiguration defines a configuration applied to the reconciliation of an
+                                        ocm k8s object as well as the policy for its propagation of this
+                                        configuration.
+                                    properties:
+                                        apiVersion:
+                                            description: API version of the referent, if not specified the Kubernetes preferred version will be used.
+                                            type: string
+                                        kind:
+                                            description: Kind of the referent.
+                                            type: string
+                                        name:
+                                            description: Name of the referent.
+                                            type: string
+                                        namespace:
+                                            description: Namespace of the referent, when not specified it acts as LocalObjectReference.
+                                            type: string
+                                        policy:
+                                            default: Propagate
+                                            description: |-
+                                                Policy affects the propagation behavior of the configuration. If set to
+                                                ConfigurationPolicyPropagate other ocm api objects can reference this
+                                                object to reuse this configuration.
+                                            enum:
+                                                - Propagate
+                                                - DoNotPropagate
+                                            type: string
+                                    required:
+                                        - kind
+                                        - name
+                                        - policy
+                                    type: object
+                                    x-kubernetes-validations:
+                                        - message: apiVersion must be one of "v1" with kind "Secret" or "ConfigMap" or "delivery.ocm.software/v1alpha1" with the kind of an OCM kubernetes object
+                                          rule: ((!has(self.apiVersion) || self.apiVersion == "" || self.apiVersion == "v1") && (self.kind == "Secret" || self.kind == "ConfigMap")) || (self.apiVersion == "delivery.ocm.software/v1alpha1" && (self.kind == "Repository" || self.kind == "Component" || self.kind == "Resource" || self.kind == "Replication"))
+                                type: array
+                            resourceRef:
+                                description: ResourceRef is the k8s resource name of an OCM resource containing the ResourceGroupDefinition.
+                                properties:
+                                    name:
+                                        type: string
+                                    namespace:
+                                        type: string
+                                required:
+                                    - name
+                                type: object
+                            suspend:
+                                description: |-
+                                    Suspend tells the controller to suspend the reconciliation of this
+                                    Resource.
+                                type: boolean
+                        required:
+                            - resourceRef
+                        type: object
+                    status:
+                        description: DeployerStatus defines the observed state of Deployer.
+                        properties:
+                            conditions:
+                                description: Conditions holds the conditions for the Deployer.
+                                items:
+                                    description: Condition contains details for one aspect of the current state of this API Resource.
+                                    properties:
+                                        lastTransitionTime:
+                                            description: |-
+                                                lastTransitionTime is the last time the condition transitioned from one status to another.
+                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                                            format: date-time
+                                            type: string
+                                        message:
+                                            description: |-
+                                                message is a human readable message indicating details about the transition.
+                                                This may be an empty string.
+                                            maxLength: 32768
+                                            type: string
+                                        observedGeneration:
+                                            description: |-
+                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                                with respect to the current state of the instance.
+                                            format: int64
+                                            minimum: 0
+                                            type: integer
+                                        reason:
+                                            description: |-
+                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                                Producers of specific condition types may define expected values and meanings for this field,
+                                                and whether the values are considered a guaranteed API.
+                                                The value should be a CamelCase string.
+                                                This field may not be empty.
+                                            maxLength: 1024
+                                            minLength: 1
+                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                            type: string
+                                        status:
+                                            description: status of the condition, one of True, False, Unknown.
+                                            enum:
+                                                - "True"
+                                                - "False"
+                                                - Unknown
+                                            type: string
+                                        type:
+                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                            maxLength: 316
+                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                            type: string
+                                    required:
+                                        - lastTransitionTime
+                                        - message
+                                        - reason
+                                        - status
+                                        - type
+                                    type: object
+                                type: array
+                            deployed:
+                                description: |-
+                                    Deployed contains references to the objects that have been deployed by the Deployer through
+                                    the Resource.
+                                items:
+                                    description: |-
+                                        DeployedObjectReference is a reference to an object that has been deployed by the Deployer.
+                                        It contains the API version, kind, name, and optionally the namespace of the deployed object.
+                                    properties:
+                                        apiVersion:
+                                            description: API version of the referent.
+                                            type: string
+                                        kind:
+                                            description: |-
+                                                Kind of the referent.
+                                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                            type: string
+                                        name:
+                                            description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                        namespace:
+                                            description: |-
+                                                Namespace of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                            type: string
+                                        uid:
+                                            description: |-
+                                                UID of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                            type: string
+                                    required:
+                                        - apiVersion
+                                        - kind
+                                        - name
+                                    type: object
+                                type: array
+                            effectiveOCMConfig:
+                                description: |-
+                                    EffectiveOCMConfig specifies the entirety of config maps and secrets
+                                    whose configuration data was applied to the Resource reconciliation,
+                                    in the order the configuration data was applied.
+                                items:
+                                    description: |-
+                                        OCMConfiguration defines a configuration applied to the reconciliation of an
+                                        ocm k8s object as well as the policy for its propagation of this
+                                        configuration.
+                                    properties:
+                                        apiVersion:
+                                            description: API version of the referent, if not specified the Kubernetes preferred version will be used.
+                                            type: string
+                                        kind:
+                                            description: Kind of the referent.
+                                            type: string
+                                        name:
+                                            description: Name of the referent.
+                                            type: string
+                                        namespace:
+                                            description: Namespace of the referent, when not specified it acts as LocalObjectReference.
+                                            type: string
+                                        policy:
+                                            default: Propagate
+                                            description: |-
+                                                Policy affects the propagation behavior of the configuration. If set to
+                                                ConfigurationPolicyPropagate other ocm api objects can reference this
+                                                object to reuse this configuration.
+                                            enum:
+                                                - Propagate
+                                                - DoNotPropagate
+                                            type: string
+                                    required:
+                                        - kind
+                                        - name
+                                        - policy
+                                    type: object
+                                    x-kubernetes-validations:
+                                        - message: apiVersion must be one of "v1" with kind "Secret" or "ConfigMap" or "delivery.ocm.software/v1alpha1" with the kind of an OCM kubernetes object
+                                          rule: ((!has(self.apiVersion) || self.apiVersion == "" || self.apiVersion == "v1") && (self.kind == "Secret" || self.kind == "ConfigMap")) || (self.apiVersion == "delivery.ocm.software/v1alpha1" && (self.kind == "Repository" || self.kind == "Component" || self.kind == "Resource" || self.kind == "Replication"))
+                                type: array
+                            observedGeneration:
+                                description: |-
+                                    ObservedGeneration is the last observed generation of the Deployer
+                                    object.
+                                format: int64
+                                type: integer
+                        type: object
+                type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+{{- end }}

--- a/kubernetes/controller/chart/templates/crd/repositories.delivery.ocm.software.yaml
+++ b/kubernetes/controller/chart/templates/crd/repositories.delivery.ocm.software.yaml
@@ -1,0 +1,229 @@
+{{- if .Values.crd.enable }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+    annotations:
+        controller-gen.kubebuilder.io/version: v0.20.0
+    name: repositories.delivery.ocm.software
+spec:
+    group: delivery.ocm.software
+    names:
+        kind: Repository
+        listKind: RepositoryList
+        plural: repositories
+        singular: repository
+    scope: Namespaced
+    versions:
+        - additionalPrinterColumns:
+            - description: Indicates if the Resource is Ready
+              jsonPath: .status.conditions[?(@.type=="Ready")].message
+              name: Ready
+              priority: 1
+              type: string
+            - description: Displays the Age of the Resource
+              jsonPath: .metadata.creationTimestamp
+              name: Age
+              type: date
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+                description: Repository is the Schema for the repositories API.
+                properties:
+                    apiVersion:
+                        description: |-
+                            APIVersion defines the versioned schema of this representation of an object.
+                            Servers should convert recognized schemas to the latest internal value, and
+                            may reject unrecognized values.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                    kind:
+                        description: |-
+                            Kind is a string value representing the REST resource this object represents.
+                            Servers may infer this from the endpoint the client submits requests to.
+                            Cannot be updated.
+                            In CamelCase.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                    metadata:
+                        type: object
+                    spec:
+                        description: RepositorySpec defines the desired state of Repository.
+                        properties:
+                            interval:
+                                description: |-
+                                    Interval at which the ocm repository specified by the RepositorySpec
+                                    validated.
+                                type: string
+                            ocmConfig:
+                                description: |-
+                                    OCMConfig defines references to secrets, config maps or ocm api
+                                    objects providing configuration data including credentials.
+                                items:
+                                    description: |-
+                                        OCMConfiguration defines a configuration applied to the reconciliation of an
+                                        ocm k8s object as well as the policy for its propagation of this
+                                        configuration.
+                                    properties:
+                                        apiVersion:
+                                            description: API version of the referent, if not specified the Kubernetes preferred version will be used.
+                                            type: string
+                                        kind:
+                                            description: Kind of the referent.
+                                            type: string
+                                        name:
+                                            description: Name of the referent.
+                                            type: string
+                                        namespace:
+                                            description: Namespace of the referent, when not specified it acts as LocalObjectReference.
+                                            type: string
+                                        policy:
+                                            default: Propagate
+                                            description: |-
+                                                Policy affects the propagation behavior of the configuration. If set to
+                                                ConfigurationPolicyPropagate other ocm api objects can reference this
+                                                object to reuse this configuration.
+                                            enum:
+                                                - Propagate
+                                                - DoNotPropagate
+                                            type: string
+                                    required:
+                                        - kind
+                                        - name
+                                        - policy
+                                    type: object
+                                    x-kubernetes-validations:
+                                        - message: apiVersion must be one of "v1" with kind "Secret" or "ConfigMap" or "delivery.ocm.software/v1alpha1" with the kind of an OCM kubernetes object
+                                          rule: ((!has(self.apiVersion) || self.apiVersion == "" || self.apiVersion == "v1") && (self.kind == "Secret" || self.kind == "ConfigMap")) || (self.apiVersion == "delivery.ocm.software/v1alpha1" && (self.kind == "Repository" || self.kind == "Component" || self.kind == "Resource" || self.kind == "Replication"))
+                                type: array
+                            repositorySpec:
+                                description: |-
+                                    RepositorySpec is the config of an ocm repository containing component
+                                    versions. This config has to be a valid ocm repository implementation
+                                    specification
+                                    https://github.com/open-component-model/ocm-spec/blob/main/doc/04-extensions/03-storage-backends/README.md.
+                                x-kubernetes-preserve-unknown-fields: true
+                            suspend:
+                                description: |-
+                                    Suspend tells the controller to suspend the reconciliation of this
+                                    Repository.
+                                type: boolean
+                        required:
+                            - interval
+                            - repositorySpec
+                        type: object
+                    status:
+                        description: RepositoryStatus defines the observed state of Repository.
+                        properties:
+                            conditions:
+                                description: Conditions holds the conditions for the Repository.
+                                items:
+                                    description: Condition contains details for one aspect of the current state of this API Resource.
+                                    properties:
+                                        lastTransitionTime:
+                                            description: |-
+                                                lastTransitionTime is the last time the condition transitioned from one status to another.
+                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                                            format: date-time
+                                            type: string
+                                        message:
+                                            description: |-
+                                                message is a human readable message indicating details about the transition.
+                                                This may be an empty string.
+                                            maxLength: 32768
+                                            type: string
+                                        observedGeneration:
+                                            description: |-
+                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                                with respect to the current state of the instance.
+                                            format: int64
+                                            minimum: 0
+                                            type: integer
+                                        reason:
+                                            description: |-
+                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                                Producers of specific condition types may define expected values and meanings for this field,
+                                                and whether the values are considered a guaranteed API.
+                                                The value should be a CamelCase string.
+                                                This field may not be empty.
+                                            maxLength: 1024
+                                            minLength: 1
+                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                            type: string
+                                        status:
+                                            description: status of the condition, one of True, False, Unknown.
+                                            enum:
+                                                - "True"
+                                                - "False"
+                                                - Unknown
+                                            type: string
+                                        type:
+                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                            maxLength: 316
+                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                            type: string
+                                    required:
+                                        - lastTransitionTime
+                                        - message
+                                        - reason
+                                        - status
+                                        - type
+                                    type: object
+                                type: array
+                            effectiveOCMConfig:
+                                description: |-
+                                    EffectiveOCMConfig specifies the entirety of config maps and secrets
+                                    whose configuration data was applied to the Repository reconciliation,
+                                    in the order the configuration data was applied.
+                                items:
+                                    description: |-
+                                        OCMConfiguration defines a configuration applied to the reconciliation of an
+                                        ocm k8s object as well as the policy for its propagation of this
+                                        configuration.
+                                    properties:
+                                        apiVersion:
+                                            description: API version of the referent, if not specified the Kubernetes preferred version will be used.
+                                            type: string
+                                        kind:
+                                            description: Kind of the referent.
+                                            type: string
+                                        name:
+                                            description: Name of the referent.
+                                            type: string
+                                        namespace:
+                                            description: Namespace of the referent, when not specified it acts as LocalObjectReference.
+                                            type: string
+                                        policy:
+                                            default: Propagate
+                                            description: |-
+                                                Policy affects the propagation behavior of the configuration. If set to
+                                                ConfigurationPolicyPropagate other ocm api objects can reference this
+                                                object to reuse this configuration.
+                                            enum:
+                                                - Propagate
+                                                - DoNotPropagate
+                                            type: string
+                                    required:
+                                        - kind
+                                        - name
+                                        - policy
+                                    type: object
+                                    x-kubernetes-validations:
+                                        - message: apiVersion must be one of "v1" with kind "Secret" or "ConfigMap" or "delivery.ocm.software/v1alpha1" with the kind of an OCM kubernetes object
+                                          rule: ((!has(self.apiVersion) || self.apiVersion == "" || self.apiVersion == "v1") && (self.kind == "Secret" || self.kind == "ConfigMap")) || (self.apiVersion == "delivery.ocm.software/v1alpha1" && (self.kind == "Repository" || self.kind == "Component" || self.kind == "Resource" || self.kind == "Replication"))
+                                type: array
+                            observedGeneration:
+                                description: |-
+                                    ObservedGeneration is the last observed generation of the Repository
+                                    object.
+                                format: int64
+                                type: integer
+                        type: object
+                required:
+                    - spec
+                type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+{{- end }}

--- a/kubernetes/controller/chart/templates/crd/resources.delivery.ocm.software.yaml
+++ b/kubernetes/controller/chart/templates/crd/resources.delivery.ocm.software.yaml
@@ -1,0 +1,424 @@
+{{- if .Values.crd.enable }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+    annotations:
+        controller-gen.kubebuilder.io/version: v0.20.0
+    name: resources.delivery.ocm.software
+spec:
+    group: delivery.ocm.software
+    names:
+        kind: Resource
+        listKind: ResourceList
+        plural: resources
+        singular: resource
+    scope: Namespaced
+    versions:
+        - additionalPrinterColumns:
+            - description: Indicates if the Resource is Ready
+              jsonPath: .status.conditions[?(@.type=="Ready")].message
+              name: Ready
+              priority: 1
+              type: string
+            - description: Displays the Age of the Resource
+              jsonPath: .metadata.creationTimestamp
+              name: Age
+              type: date
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+                description: Resource is the Schema for the resources API.
+                properties:
+                    apiVersion:
+                        description: |-
+                            APIVersion defines the versioned schema of this representation of an object.
+                            Servers should convert recognized schemas to the latest internal value, and
+                            may reject unrecognized values.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                    kind:
+                        description: |-
+                            Kind is a string value representing the REST resource this object represents.
+                            Servers may infer this from the endpoint the client submits requests to.
+                            Cannot be updated.
+                            In CamelCase.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                    metadata:
+                        type: object
+                    spec:
+                        description: ResourceSpec defines the desired state of Resource.
+                        properties:
+                            additionalStatusFields:
+                                additionalProperties:
+                                    type: string
+                                description: |-
+                                    AdditionalStatusFields are additional fields that can be used to
+                                    extend the status of the Resource with custom expressions.
+                                type: object
+                            componentRef:
+                                description: ComponentRef is a reference to a Component.
+                                properties:
+                                    name:
+                                        default: ""
+                                        description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            interval:
+                                description: Interval at which the resource is checked for updates.
+                                type: string
+                            ocmConfig:
+                                description: |-
+                                    OCMConfig defines references to secrets, config maps or ocm api
+                                    objects providing configuration data including credentials.
+                                items:
+                                    description: |-
+                                        OCMConfiguration defines a configuration applied to the reconciliation of an
+                                        ocm k8s object as well as the policy for its propagation of this
+                                        configuration.
+                                    properties:
+                                        apiVersion:
+                                            description: API version of the referent, if not specified the Kubernetes preferred version will be used.
+                                            type: string
+                                        kind:
+                                            description: Kind of the referent.
+                                            type: string
+                                        name:
+                                            description: Name of the referent.
+                                            type: string
+                                        namespace:
+                                            description: Namespace of the referent, when not specified it acts as LocalObjectReference.
+                                            type: string
+                                        policy:
+                                            default: Propagate
+                                            description: |-
+                                                Policy affects the propagation behavior of the configuration. If set to
+                                                ConfigurationPolicyPropagate other ocm api objects can reference this
+                                                object to reuse this configuration.
+                                            enum:
+                                                - Propagate
+                                                - DoNotPropagate
+                                            type: string
+                                    required:
+                                        - kind
+                                        - name
+                                        - policy
+                                    type: object
+                                    x-kubernetes-validations:
+                                        - message: apiVersion must be one of "v1" with kind "Secret" or "ConfigMap" or "delivery.ocm.software/v1alpha1" with the kind of an OCM kubernetes object
+                                          rule: ((!has(self.apiVersion) || self.apiVersion == "" || self.apiVersion == "v1") && (self.kind == "Secret" || self.kind == "ConfigMap")) || (self.apiVersion == "delivery.ocm.software/v1alpha1" && (self.kind == "Repository" || self.kind == "Component" || self.kind == "Resource" || self.kind == "Replication"))
+                                type: array
+                            resource:
+                                description: Resource identifies the ocm resource to be fetched.
+                                properties:
+                                    byReference:
+                                        description: |-
+                                            ResourceReference defines a reference to a resource akin to the OCM Specification.
+                                            For more details see dedicated guide in the Specification:
+                                            https://github.com/open-component-model/ocm-spec/blob/main/doc/05-guidelines/03-references.md#references
+                                        properties:
+                                            referencePath:
+                                                items:
+                                                    additionalProperties:
+                                                        type: string
+                                                    description: |-
+                                                        Identity is a map that represents a set of attributes that uniquely identity
+                                                        arbitrary resources. It is used in various places in Open Component Model to uniquely
+                                                        identity objects such as resources or components.
+                                                    type: object
+                                                type: array
+                                            resource:
+                                                additionalProperties:
+                                                    type: string
+                                                description: |-
+                                                    Identity is a map that represents a set of attributes that uniquely identity
+                                                    arbitrary resources. It is used in various places in Open Component Model to uniquely
+                                                    identity objects such as resources or components.
+                                                type: object
+                                        required:
+                                            - resource
+                                        type: object
+                                required:
+                                    - byReference
+                                type: object
+                            skipVerify:
+                                description: |-
+                                    SkipVerify indicates whether the resource should be verified or not.
+                                    A verification requires the resource to be downloaded, which can be
+                                    expensive for large resources.
+                                type: boolean
+                            suspend:
+                                description: |-
+                                    Suspend tells the controller to suspend the reconciliation of this
+                                    Resource.
+                                type: boolean
+                        required:
+                            - componentRef
+                            - interval
+                            - resource
+                        type: object
+                    status:
+                        description: ResourceStatus defines the observed state of Resource.
+                        properties:
+                            additional:
+                                additionalProperties:
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            component:
+                                properties:
+                                    component:
+                                        type: string
+                                    digest:
+                                        description: Digest information of the Component, if available as per OCM specification.
+                                        properties:
+                                            hashAlgorithm:
+                                                description: |-
+                                                    HashAlgorithm specifies the hashing algorithm applied after normalization.
+                                                    The choice of algorithm impacts compatibility across verifiers.
+
+                                                    See specification reference:
+                                                      - https://github.com/open-component-model/ocm-spec/blob/main/doc/04-extensions/04-algorithms/digest-algorithms.md
+                                                type: string
+                                            normalisationAlgorithm:
+                                                description: |-
+                                                    NormalisationAlgorithm defines how the component descriptor or artifact
+                                                    is transformed into a stable byte representation before hashing.
+                                                    Normalization ensures reproducibility by excluding volatile fields
+                                                    such as transport-related access specifications.
+
+                                                    See specification references:
+                                                      - https://github.com/open-component-model/ocm-spec/blob/main/doc/04-extensions/04-algorithms/component-descriptor-normalization-algorithms.md
+                                                      - https://github.com/open-component-model/ocm-spec/blob/main/doc/04-extensions/04-algorithms/artifact-normalization-types.md
+                                                type: string
+                                            value:
+                                                description: |-
+                                                    Value is the encoded digest result produced from the normalized representation.
+                                                    Typically hex or base64 encoded, depending on the algorithm specification.
+                                                type: string
+                                        required:
+                                            - hashAlgorithm
+                                            - normalisationAlgorithm
+                                            - value
+                                        type: object
+                                    repositorySpec:
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    version:
+                                        type: string
+                                required:
+                                    - component
+                                    - repositorySpec
+                                    - version
+                                type: object
+                            conditions:
+                                description: Conditions holds the conditions for the Resource.
+                                items:
+                                    description: Condition contains details for one aspect of the current state of this API Resource.
+                                    properties:
+                                        lastTransitionTime:
+                                            description: |-
+                                                lastTransitionTime is the last time the condition transitioned from one status to another.
+                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                                            format: date-time
+                                            type: string
+                                        message:
+                                            description: |-
+                                                message is a human readable message indicating details about the transition.
+                                                This may be an empty string.
+                                            maxLength: 32768
+                                            type: string
+                                        observedGeneration:
+                                            description: |-
+                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                                with respect to the current state of the instance.
+                                            format: int64
+                                            minimum: 0
+                                            type: integer
+                                        reason:
+                                            description: |-
+                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                                Producers of specific condition types may define expected values and meanings for this field,
+                                                and whether the values are considered a guaranteed API.
+                                                The value should be a CamelCase string.
+                                                This field may not be empty.
+                                            maxLength: 1024
+                                            minLength: 1
+                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                            type: string
+                                        status:
+                                            description: status of the condition, one of True, False, Unknown.
+                                            enum:
+                                                - "True"
+                                                - "False"
+                                                - Unknown
+                                            type: string
+                                        type:
+                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                            maxLength: 316
+                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                            type: string
+                                    required:
+                                        - lastTransitionTime
+                                        - message
+                                        - reason
+                                        - status
+                                        - type
+                                    type: object
+                                type: array
+                            effectiveOCMConfig:
+                                description: |-
+                                    EffectiveOCMConfig specifies the entirety of config maps and secrets
+                                    whose configuration data was applied to the Resource reconciliation,
+                                    in the order the configuration data was applied.
+                                items:
+                                    description: |-
+                                        OCMConfiguration defines a configuration applied to the reconciliation of an
+                                        ocm k8s object as well as the policy for its propagation of this
+                                        configuration.
+                                    properties:
+                                        apiVersion:
+                                            description: API version of the referent, if not specified the Kubernetes preferred version will be used.
+                                            type: string
+                                        kind:
+                                            description: Kind of the referent.
+                                            type: string
+                                        name:
+                                            description: Name of the referent.
+                                            type: string
+                                        namespace:
+                                            description: Namespace of the referent, when not specified it acts as LocalObjectReference.
+                                            type: string
+                                        policy:
+                                            default: Propagate
+                                            description: |-
+                                                Policy affects the propagation behavior of the configuration. If set to
+                                                ConfigurationPolicyPropagate other ocm api objects can reference this
+                                                object to reuse this configuration.
+                                            enum:
+                                                - Propagate
+                                                - DoNotPropagate
+                                            type: string
+                                    required:
+                                        - kind
+                                        - name
+                                        - policy
+                                    type: object
+                                    x-kubernetes-validations:
+                                        - message: apiVersion must be one of "v1" with kind "Secret" or "ConfigMap" or "delivery.ocm.software/v1alpha1" with the kind of an OCM kubernetes object
+                                          rule: ((!has(self.apiVersion) || self.apiVersion == "" || self.apiVersion == "v1") && (self.kind == "Secret" || self.kind == "ConfigMap")) || (self.apiVersion == "delivery.ocm.software/v1alpha1" && (self.kind == "Repository" || self.kind == "Component" || self.kind == "Resource" || self.kind == "Replication"))
+                                type: array
+                            observedGeneration:
+                                description: |-
+                                    ObservedGeneration is the last observed generation of the Resource
+                                    object.
+                                format: int64
+                                type: integer
+                            resource:
+                                properties:
+                                    access:
+                                        type: object
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    digest:
+                                        description: |-
+                                            Digest defines the hash-based fingerprint of a component descriptor or artifact.
+                                            It combines the hashing algorithm, normalization procedure, and the resulting value.
+                                            Digests are used as canonical identifiers for verifying integrity.
+
+                                            See specification reference:
+                                              - https://github.com/open-component-model/ocm-spec/blob/main/doc/01-model/03-elements-sub.md#digest-info
+                                        properties:
+                                            hashAlgorithm:
+                                                description: |-
+                                                    HashAlgorithm specifies the hashing algorithm applied after normalization.
+                                                    The choice of algorithm impacts compatibility across verifiers.
+
+                                                    See specification reference:
+                                                      - https://github.com/open-component-model/ocm-spec/blob/main/doc/04-extensions/04-algorithms/digest-algorithms.md
+                                                type: string
+                                            normalisationAlgorithm:
+                                                description: |-
+                                                    NormalisationAlgorithm defines how the component descriptor or artifact
+                                                    is transformed into a stable byte representation before hashing.
+                                                    Normalization ensures reproducibility by excluding volatile fields
+                                                    such as transport-related access specifications.
+
+                                                    See specification references:
+                                                      - https://github.com/open-component-model/ocm-spec/blob/main/doc/04-extensions/04-algorithms/component-descriptor-normalization-algorithms.md
+                                                      - https://github.com/open-component-model/ocm-spec/blob/main/doc/04-extensions/04-algorithms/artifact-normalization-types.md
+                                                type: string
+                                            value:
+                                                description: |-
+                                                    Value is the encoded digest result produced from the normalized representation.
+                                                    Typically hex or base64 encoded, depending on the algorithm specification.
+                                                type: string
+                                        required:
+                                            - hashAlgorithm
+                                            - normalisationAlgorithm
+                                            - value
+                                        type: object
+                                    extraIdentity:
+                                        additionalProperties:
+                                            type: string
+                                        type: object
+                                    labels:
+                                        items:
+                                            properties:
+                                                merge:
+                                                    description: |-
+                                                        MergeAlgorithm optionally describes the desired merge handling used to
+                                                        merge the label value during a transfer.
+                                                    properties:
+                                                        algorithm:
+                                                            description: |-
+                                                                Algorithm optionally described the Merge algorithm used to
+                                                                merge the label value during a transfer.
+                                                            type: string
+                                                        config:
+                                                            description: Config contains optional config for the merge algorithm.
+                                                            x-kubernetes-preserve-unknown-fields: true
+                                                    required:
+                                                        - algorithm
+                                                    type: object
+                                                name:
+                                                    description: Name is the unique name of the label.
+                                                    type: string
+                                                signing:
+                                                    description: Signing describes whether the label should be included into the signature
+                                                    type: boolean
+                                                value:
+                                                    description: Value is the json/yaml data of the label
+                                                    x-kubernetes-preserve-unknown-fields: true
+                                                version:
+                                                    description: Version is the optional specification version of the attribute value
+                                                    type: string
+                                            required:
+                                                - name
+                                                - value
+                                            type: object
+                                        type: array
+                                    name:
+                                        type: string
+                                    type:
+                                        type: string
+                                    version:
+                                        type: string
+                                required:
+                                    - access
+                                    - name
+                                    - type
+                                type: object
+                        type: object
+                required:
+                    - spec
+                type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+{{- end }}

--- a/kubernetes/controller/chart/templates/manager/manager.yaml
+++ b/kubernetes/controller/chart/templates/manager/manager.yaml
@@ -1,0 +1,144 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "ocm-k8s-toolkit.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        control-plane: controller-manager
+    name: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "controller-manager" "context" $) }}
+    namespace: {{ .Release.Namespace }}
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            control-plane: controller-manager
+    template:
+        metadata:
+            annotations:
+                kubectl.kubernetes.io/default-container: manager
+            labels:
+                control-plane: controller-manager
+        spec:
+            {{- with .Values.manager.tolerations }}
+            tolerations: {{ toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.manager.affinity }}
+            affinity: {{ toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.manager.nodeSelector }}
+            nodeSelector: {{ toYaml . | nindent 16 }}
+            {{- end }}
+            containers:
+                - args:
+                    {{- /* Health probe */}}
+                    - --health-probe-bind-address={{ .Values.manager.healthProbe.bindAddress | default ":8081" }}
+                    {{- /* Metrics */}}
+                    {{- if .Values.manager.metricsServer.bindAddress }}
+                    - --metrics-bind-address={{ .Values.manager.metricsServer.bindAddress }}
+                    {{- end }}
+                    {{- if .Values.manager.metricsServer.secure }}
+                    - --metrics-secure
+                    {{- end }}
+                    {{- if .Values.manager.metricsServer.enableHttp2 }}
+                    - --enable-http2
+                    {{- end }}
+                    {{- /* Leader election */}}
+                    {{- if .Values.manager.leaderElection.enabled }}
+                    - --leader-elect
+                    {{- end }}
+                    {{- /* Concurrency */}}
+                    {{- with .Values.manager.concurrency }}
+                    {{- if .resource }}
+                    - --resource-controller-concurrency={{ .resource }}
+                    {{- end }}
+                    {{- end }}
+                    {{- /* Resolver */}}
+                    {{- with .Values.manager.resolver }}
+                    {{- if .workerCount }}
+                    - --resolver-worker-count={{ .workerCount }}
+                    {{- end }}
+                    {{- if .workerQueueLength }}
+                    - --resolver-worker-queue-length={{ .workerQueueLength }}
+                    {{- end }}
+                    {{- end }}
+                    {{- /* Cache */}}
+                    {{- with .Values.manager.cache }}
+                    {{- if .ocmContextSize }}
+                    - --ocm-context-cache-size={{ .ocmContextSize }}
+                    {{- end }}
+                    {{- if .ocmSessionSize }}
+                    - --ocm-session-cache-size={{ .ocmSessionSize }}
+                    {{- end }}
+                    {{- if .deployerDownloadSize }}
+                    - --deployer-download-cache-size={{ .deployerDownloadSize }}
+                    {{- end }}
+                    {{- end }}
+                    {{- /* Events */}}
+                    {{- if .Values.manager.events.address }}
+                    - --events-addr={{ .Values.manager.events.address }}
+                    {{- end }}
+                    {{- /* Logging */}}
+                    {{- with .Values.manager.logging }}
+                    {{- if .level }}
+                    - --zap-log-level={{ .level }}
+                    {{- end }}
+                    {{- if .development }}
+                    - --zap-devel
+                    {{- end }}
+                    {{- if .encoder }}
+                    - --zap-encoder={{ .encoder }}
+                    {{- end }}
+                    {{- end }}
+                    {{- /* Extra args */}}
+                    {{- range .Values.manager.extraArgs }}
+                    - {{ . }}
+                    {{- end }}
+                  command:
+                    - /manager
+                  image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
+                  imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
+                  livenessProbe:
+                    httpGet:
+                        path: {{ .Values.manager.livenessProbe.path }}
+                        port: {{ .Values.manager.livenessProbe.port }}
+                    initialDelaySeconds: {{ .Values.manager.livenessProbe.initialDelaySeconds }}
+                    periodSeconds: {{ .Values.manager.livenessProbe.periodSeconds }}
+                  name: manager
+                  ports:
+                    - containerPort: 9090
+                      name: http
+                      protocol: TCP
+                  readinessProbe:
+                    httpGet:
+                        path: {{ .Values.manager.readinessProbe.path }}
+                        port: {{ .Values.manager.readinessProbe.port }}
+                    initialDelaySeconds: {{ .Values.manager.readinessProbe.initialDelaySeconds }}
+                    periodSeconds: {{ .Values.manager.readinessProbe.periodSeconds }}
+                  resources:
+                    {{- if .Values.manager.resources }}
+                    {{- toYaml .Values.manager.resources | nindent 20 }}
+                    {{- else }}
+                    {}
+                    {{- end }}
+                  securityContext:
+                    {{- if .Values.manager.securityContext }}
+                    {{- toYaml .Values.manager.securityContext | nindent 20 }}
+                    {{- else }}
+                    {}
+                    {{- end }}
+                  volumeMounts:
+                    - mountPath: /data
+                      name: data
+            securityContext:
+              {{- if .Values.manager.podSecurityContext }}
+              {{- toYaml .Values.manager.podSecurityContext | nindent 14 }}
+              {{- else }}
+              {}
+              {{- end }}
+            serviceAccountName: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "controller-manager" "context" $) }}
+            terminationGracePeriodSeconds: 10
+            volumes:
+                - emptyDir: {}
+                  name: data

--- a/kubernetes/controller/chart/templates/monitoring/servicemonitor.yaml
+++ b/kubernetes/controller/chart/templates/monitoring/servicemonitor.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.prometheus.enable }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "ocm-k8s-toolkit.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    control-plane: controller-manager
+  name: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "controller-manager-metrics-monitor" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpoints:
+    - path: /metrics
+      port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        {{- if .Values.certManager.enable }}
+        serverName: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "controller-manager-metrics-service" "context" $) }}.{{ .Release.Namespace }}.svc
+        # Apply secure TLS configuration with cert-manager
+        insecureSkipVerify: false
+        ca:
+          secret:
+            name: metrics-server-cert
+            key: ca.crt
+        cert:
+          secret:
+            name: metrics-server-cert
+            key: tls.crt
+        keySecret:
+          name: metrics-server-cert
+            key: tls.key
+        {{- else }}
+        # Development/Test mode (insecure configuration)
+        insecureSkipVerify: true
+        {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "ocm-k8s-toolkit.name" . }}
+      control-plane: controller-manager
+{{- end }}

--- a/kubernetes/controller/chart/templates/rbac/component-editor-role.yaml
+++ b/kubernetes/controller/chart/templates/rbac/component-editor-role.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.rbacHelpers.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "ocm-k8s-toolkit.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    name: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "component-editor-role" "context" $) }}
+rules:
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - components
+      verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - components/status
+      verbs:
+        - get
+{{- end }}

--- a/kubernetes/controller/chart/templates/rbac/component-viewer-role.yaml
+++ b/kubernetes/controller/chart/templates/rbac/component-viewer-role.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.rbacHelpers.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "ocm-k8s-toolkit.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    name: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "component-viewer-role" "context" $) }}
+rules:
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - components
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - components/status
+      verbs:
+        - get
+{{- end }}

--- a/kubernetes/controller/chart/templates/rbac/controller-manager.yaml
+++ b/kubernetes/controller/chart/templates/rbac/controller-manager.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "ocm-k8s-toolkit.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    name: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "controller-manager" "context" $) }}
+    namespace: {{ .Release.Namespace }}

--- a/kubernetes/controller/chart/templates/rbac/deployer-editor-role.yaml
+++ b/kubernetes/controller/chart/templates/rbac/deployer-editor-role.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.rbacHelpers.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "ocm-k8s-toolkit.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    name: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "deployer-editor-role" "context" $) }}
+rules:
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - deployers
+      verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - deployers/status
+      verbs:
+        - get
+{{- end }}

--- a/kubernetes/controller/chart/templates/rbac/deployer-viewer-role.yaml
+++ b/kubernetes/controller/chart/templates/rbac/deployer-viewer-role.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.rbacHelpers.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "ocm-k8s-toolkit.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    name: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "deployer-viewer-role" "context" $) }}
+rules:
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - deployers
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - deployers/status
+      verbs:
+        - get
+{{- end }}

--- a/kubernetes/controller/chart/templates/rbac/leader-election-role.yaml
+++ b/kubernetes/controller/chart/templates/rbac/leader-election-role.yaml
@@ -1,0 +1,42 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "ocm-k8s-toolkit.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    name: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "leader-election-role" "context" $) }}
+    namespace: {{ .Release.Namespace }}
+rules:
+    - apiGroups:
+        - ""
+      resources:
+        - configmaps
+      verbs:
+        - get
+        - list
+        - watch
+        - create
+        - update
+        - patch
+        - delete
+    - apiGroups:
+        - coordination.k8s.io
+      resources:
+        - leases
+      verbs:
+        - get
+        - list
+        - watch
+        - create
+        - update
+        - patch
+        - delete
+    - apiGroups:
+        - ""
+      resources:
+        - events
+      verbs:
+        - create
+        - patch

--- a/kubernetes/controller/chart/templates/rbac/leader-election-rolebinding.yaml
+++ b/kubernetes/controller/chart/templates/rbac/leader-election-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "ocm-k8s-toolkit.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    name: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "leader-election-rolebinding" "context" $) }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "leader-election-role" "context" $) }}
+subjects:
+    - kind: ServiceAccount
+      name: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "controller-manager" "context" $) }}
+      namespace: {{ .Release.Namespace }}

--- a/kubernetes/controller/chart/templates/rbac/manager-role.yaml
+++ b/kubernetes/controller/chart/templates/rbac/manager-role.yaml
@@ -1,0 +1,72 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "manager-role" "context" $) }}
+rules:
+    - apiGroups:
+        - ""
+      resources:
+        - configmaps
+        - secrets
+        - serviceaccounts
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - ""
+      resources:
+        - events
+      verbs:
+        - create
+        - patch
+    - apiGroups:
+        - ""
+      resources:
+        - serviceaccounts/token
+      verbs:
+        - create
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - components
+        - deployers
+        - repositories
+        - resources
+      verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - components/finalizers
+        - deployers/finalizers
+        - repositories/finalizers
+      verbs:
+        - update
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - components/status
+        - deployers/status
+        - repositories/status
+        - resources/status
+      verbs:
+        - get
+        - patch
+        - update
+    - apiGroups:
+        - kro.run
+      resources:
+        - resourcegraphdefinitions
+      verbs:
+        - create
+        - list
+        - patch
+        - update
+        - watch

--- a/kubernetes/controller/chart/templates/rbac/manager-rolebinding.yaml
+++ b/kubernetes/controller/chart/templates/rbac/manager-rolebinding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "ocm-k8s-toolkit.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    name: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "manager-rolebinding" "context" $) }}
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "manager-role" "context" $) }}
+subjects:
+    - kind: ServiceAccount
+      name: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "controller-manager" "context" $) }}
+      namespace: {{ .Release.Namespace }}

--- a/kubernetes/controller/chart/templates/rbac/replication-editor-role.yaml
+++ b/kubernetes/controller/chart/templates/rbac/replication-editor-role.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.rbacHelpers.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "ocm-k8s-toolkit.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    name: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "replication-editor-role" "context" $) }}
+rules:
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - replications
+      verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - replications/status
+      verbs:
+        - get
+{{- end }}

--- a/kubernetes/controller/chart/templates/rbac/replication-viewer-role.yaml
+++ b/kubernetes/controller/chart/templates/rbac/replication-viewer-role.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.rbacHelpers.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "ocm-k8s-toolkit.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    name: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "replication-viewer-role" "context" $) }}
+rules:
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - replications
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - replications/status
+      verbs:
+        - get
+{{- end }}

--- a/kubernetes/controller/chart/templates/rbac/repository-editor-role.yaml
+++ b/kubernetes/controller/chart/templates/rbac/repository-editor-role.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.rbacHelpers.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "ocm-k8s-toolkit.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    name: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "repository-editor-role" "context" $) }}
+rules:
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - repositories
+      verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - repositories/status
+      verbs:
+        - get
+{{- end }}

--- a/kubernetes/controller/chart/templates/rbac/repository-viewer-role.yaml
+++ b/kubernetes/controller/chart/templates/rbac/repository-viewer-role.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.rbacHelpers.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "ocm-k8s-toolkit.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    name: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "repository-viewer-role" "context" $) }}
+rules:
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - repositories
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - repositories/status
+      verbs:
+        - get
+{{- end }}

--- a/kubernetes/controller/chart/templates/rbac/resource-editor-role.yaml
+++ b/kubernetes/controller/chart/templates/rbac/resource-editor-role.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.rbacHelpers.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "ocm-k8s-toolkit.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    name: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "resource-editor-role" "context" $) }}
+rules:
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - resources
+      verbs:
+        - create
+        - delete
+        - get
+        - list
+        - patch
+        - update
+        - watch
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - resources/status
+      verbs:
+        - get
+{{- end }}

--- a/kubernetes/controller/chart/templates/rbac/resource-viewer-role.yaml
+++ b/kubernetes/controller/chart/templates/rbac/resource-viewer-role.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.rbacHelpers.enable }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/name: {{ include "ocm-k8s-toolkit.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    name: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "resource-viewer-role" "context" $) }}
+rules:
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - resources
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - delivery.ocm.software
+      resources:
+        - resources/status
+      verbs:
+        - get
+{{- end }}

--- a/kubernetes/controller/chart/test-values.yaml
+++ b/kubernetes/controller/chart/test-values.yaml
@@ -1,0 +1,18 @@
+# Test values for CI/CD and local testing
+manager:
+  replicas: 1
+  image:
+    repository: ghcr.io/open-component-model/kubernetes/controller
+    tag: latest
+  concurrency:
+    resource: 10
+  resolver:
+    workerCount: 10
+    workerQueueLength: 100
+  logging:
+    level: "debug"
+    development: true
+
+crd:
+  enable: true
+  keep: true

--- a/kubernetes/controller/chart/values.schema.json
+++ b/kubernetes/controller/chart/values.schema.json
@@ -1,0 +1,265 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "certManager": {
+            "type": "object",
+            "properties": {
+                "enable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "crd": {
+            "type": "object",
+            "properties": {
+                "enable": {
+                    "type": "boolean"
+                },
+                "keep": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "manager": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "cache": {
+                    "type": "object",
+                    "properties": {
+                        "deployerDownloadSize": {
+                            "type": "integer"
+                        },
+                        "ocmContextSize": {
+                            "type": "integer"
+                        },
+                        "ocmSessionSize": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "concurrency": {
+                    "type": "object",
+                    "properties": {
+                        "resource": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "env": {
+                    "type": "array"
+                },
+                "events": {
+                    "type": "object",
+                    "properties": {
+                        "address": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "extraArgs": {
+                    "type": "array"
+                },
+                "healthProbe": {
+                    "type": "object",
+                    "properties": {
+                        "bindAddress": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "imagePullSecrets": {
+                    "type": "array"
+                },
+                "leaderElection": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "path": {
+                            "type": "string"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "port": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "logging": {
+                    "type": "object",
+                    "properties": {
+                        "development": {
+                            "type": "boolean"
+                        },
+                        "encoder": {
+                            "type": "string"
+                        },
+                        "level": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "metricsServer": {
+                    "type": "object",
+                    "properties": {
+                        "bindAddress": {
+                            "type": "string"
+                        },
+                        "enableHttp2": {
+                            "type": "boolean"
+                        },
+                        "secure": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "podSecurityContext": {
+                    "type": "object",
+                    "properties": {
+                        "runAsNonRoot": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "path": {
+                            "type": "string"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "port": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "replicas": {
+                    "type": "integer"
+                },
+                "resolver": {
+                    "type": "object",
+                    "properties": {
+                        "workerCount": {
+                            "type": "integer"
+                        },
+                        "workerQueueLength": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "securityContext": {
+                    "type": "object",
+                    "properties": {
+                        "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                        },
+                        "capabilities": {
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "tolerations": {
+                    "type": "array"
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "enable": {
+                    "type": "boolean"
+                },
+                "port": {
+                    "type": "integer"
+                }
+            }
+        },
+        "prometheus": {
+            "type": "object",
+            "properties": {
+                "enable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "rbacHelpers": {
+            "type": "object",
+            "properties": {
+                "enable": {
+                    "type": "boolean"
+                }
+            }
+        }
+    }
+}

--- a/kubernetes/controller/chart/values.yaml
+++ b/kubernetes/controller/chart/values.yaml
@@ -1,0 +1,161 @@
+# -- String to partially override chart.fullname template (will maintain the release name)
+# nameOverride: ""
+
+# -- String to fully override chart.fullname template
+# fullnameOverride: ""
+
+## Configure the controller manager deployment
+manager:
+  # -- Number of controller manager replicas
+  replicas: 1
+  
+  image:
+    # -- Controller image repository
+    repository: ghcr.io/open-component-model/kubernetes/controller
+    # -- Controller image tag
+    tag: latest
+    # -- Image pull policy
+    pullPolicy: IfNotPresent
+
+  ## Controller concurrency settings
+  concurrency:
+    # -- Number of active resource controller workers
+    resource: 4
+
+  ## Resolver settings
+  resolver:
+    # -- Number of active resolver workers
+    workerCount: 10
+    # -- Maximum work items in queue for component version resolution
+    workerQueueLength: 100
+
+  ## Cache settings
+  cache:
+    # -- Maximum number of active OCM contexts kept alive
+    ocmContextSize: 100
+    # -- Maximum number of active OCM sessions kept alive
+    ocmSessionSize: 100
+    # -- Maximum size of the deployer download object LRU cache
+    deployerDownloadSize: 1000
+
+  ## Logging configuration (zap logger)
+  logging:
+    # -- Zap log level: 'debug', 'info', 'error', 'panic' or integer > 0
+    level: "info"
+    # -- Enable development mode (console encoder, debug level, warn stacktrace)
+    development: false
+    # -- Log encoding: 'json' or 'console'
+    encoder: "json"
+
+  ## Leader election
+  leaderElection:
+    # -- Enable leader election for controller manager
+    enabled: true
+
+  ## Health and metrics endpoints
+  healthProbe:
+    # -- Address the health probe endpoint binds to
+    bindAddress: ":8081"
+
+  ## Liveness probe configuration
+  livenessProbe:
+    # -- Path for the liveness probe
+    path: /healthz
+    # -- Port for the liveness probe
+    port: 8081
+    # -- Initial delay before starting liveness probes
+    initialDelaySeconds: 15
+    # -- Period between liveness probes
+    periodSeconds: 20
+
+  ## Readiness probe configuration
+  readinessProbe:
+    # -- Path for the readiness probe
+    path: /readyz
+    # -- Port for the readiness probe
+    port: 8081
+    # -- Initial delay before starting readiness probes
+    initialDelaySeconds: 5
+    # -- Period between readiness probes
+    periodSeconds: 10
+
+  metricsServer:
+    # -- Address the metric endpoint binds to. Set to "0" to disable
+    bindAddress: "0"
+    # -- Serve metrics endpoint securely
+    secure: false
+    # -- Enable HTTP/2 for metrics and webhook servers
+    enableHttp2: false
+
+  ## Events
+  events:
+    # -- Address of the events receiver (optional)
+    address: ""
+
+  # -- Extra arguments to pass to the controller
+  extraArgs: []
+
+  # -- Environment variables for the controller
+  env: []
+
+  # -- Image pull secrets for the controller
+  imagePullSecrets: []
+
+  # -- Pod-level security context
+  podSecurityContext:
+    runAsNonRoot: true
+
+  # -- Container-level security context
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+        drop:
+            - ALL
+
+  # -- Resource limits and requests
+  resources:
+    limits:
+        cpu: 500m
+        memory: 128Mi
+    requests:
+        cpu: 10m
+        memory: 64Mi
+
+  # -- Pod affinity rules
+  affinity: {}
+
+  # -- Node selector for pod scheduling
+  nodeSelector: {}
+
+  # -- Pod tolerations
+  tolerations: []
+
+## Helper RBAC roles for managing custom resources
+rbacHelpers:
+  # -- Install convenience admin/editor/viewer roles for CRDs
+  enable: false
+
+## Custom Resource Definitions
+crd:
+  # -- Install CRDs with the chart
+  enable: true
+  # -- Keep CRDs when uninstalling
+  keep: true
+
+## Controller metrics endpoint
+metrics:
+  # -- Enable metrics endpoint with RBAC protection
+  enable: false
+  # -- Metrics server port
+  port: 8443
+
+## Cert-manager integration
+certManager:
+  # -- Enable cert-manager for TLS certificates
+  enable: false
+
+## Prometheus ServiceMonitor
+prometheus:
+  # -- Enable Prometheus ServiceMonitor (requires prometheus-operator)
+  enable: false
+


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Adds a Helm chart for deploying the OCM Kubernetes Toolkit controller,
scaffolded using kubebuilder helm/v2-alpha plugin.

Features:
- Controller manager flags exposed as Helm values
- Prometheus ServiceMonitor support
- Auto-generated README and JSON schema
- CI workflow with E2E testing in kind


#### Which issue(s) this PR fixes

Fixes: https://github.com/open-component-model/ocm-project/issues/638