### PR TITLE
chore(ci): Fix typos in README and CI config paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
           repository: ${{ env.REPO }}
           ref: ${{ env.REF }}
           sparse-checkout: |
-            .golangci.yml
+            golangci.yml
             .env
       - name: Install Task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
@@ -208,7 +208,7 @@ jobs:
           ref: ${{ env.REF }}
           sparse-checkout: |
             ${{ matrix.module }}
-            .github/config/golangci.yml
+            golangci.yml
             .env
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
@@ -226,7 +226,7 @@ jobs:
           verify: 'false' # we verify in a separate command ONCE instead of every run on every module
           version: ${{ steps.versions.outputs.golangci_lint }}
           working-directory: ${{ github.workspace }}/${{ matrix.module }}
-          args: --timeout 10m --config=${{ github.workspace }}/.github/config/golangci.yml
+          args: --timeout 10m --config=${{ github.workspace }}/golangci.yml
 
   run_integration_tests:
     name: "Integration Tests"

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -24,7 +24,7 @@ Go bindings for the Open Component Model.
 | **plugin**                   | Plugin system for extensibility                          |
 | **transform**                | Transformation/localization of component versions        |
 | **helm**                     | Helm chart resource handling                             |
-| **input***                   | Input sources (file, directory, utf8)                    |
+| **input**                    | Input sources (file, directory, utf8)                    |
 | **generator**                | Code generation tools                                    |
 
 ## Usage


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

follow up to https://github.com/open-component-model/open-component-model/pull/1701 that was misconfiguring some things.

pull_request_target sucks...

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

makes lint run again...
