### PR TITLE
chore(controller): move Helm chart to dedicated OCI path and disable Renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,6 +29,11 @@
   separateMultipleMajor: true,
   packageRules: [
     {
+      // TODO: Revert when the release process is in place
+      matchFileNames: ['kubernetes/controller/chart/**'],
+      enabled: false,
+    },
+    {
       matchUpdateTypes: ['minor','patch'],
       automerge: true,
     },

--- a/.github/workflows/kubernetes-controller.yml
+++ b/.github/workflows/kubernetes-controller.yml
@@ -157,7 +157,7 @@ jobs:
         working-directory: kubernetes/controller
         run: |
           task helm/package VERSION=${{ steps.version.outputs.version }} APP_VERSION=${{ steps.version.outputs.version }}
-          helm push dist/ocm-k8s-toolkit-*.tgz oci://ghcr.io/open-component-model/charts
+          helm push dist/ocm-k8s-toolkit-*.tgz oci://ghcr.io/open-component-model/kubernetes/controller/chart
       - name: Cleanup unused cache
         shell: bash
         run: |


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Moves the Kubernetes controller Helm chart from `ghcr.io/open-component-model/charts` to `ghcr.io/open-component-model/kubernetes/controller/chart` and disables Renovate dependency updates for the chart directory.