### PR TITLE
chore: remove mandelsoft library from controllers

### DIFF
--- a/kubernetes/controller/go.mod
+++ b/kubernetes/controller/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/fluxcd/pkg/runtime v0.94.0
 	github.com/go-logr/logr v1.4.3
 	github.com/google/cel-go v0.26.1
-	github.com/mandelsoft/goutils v0.0.0-20251225170327-b32fc0dd2706
 	github.com/onsi/ginkgo/v2 v2.27.3
 	github.com/onsi/gomega v1.39.0
 	github.com/prometheus/client_golang v1.23.2
@@ -150,8 +149,5 @@ require (
 
 // TODO: remove once structured merge diff v6 support lands in k8s upstream
 replace k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20251125145642-4e65d59e963e
-
-// TODO: remove once mandelsoft utils no longer has an unreleased version of vfs as dep
-replace github.com/mandelsoft/vfs => github.com/mandelsoft/vfs v0.4.4
 
 replace github.com/ThalesIgnite/crypto11 => github.com/ThalesGroup/crypto11 v1.6.0

--- a/kubernetes/controller/go.sum
+++ b/kubernetes/controller/go.sum
@@ -140,8 +140,6 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mailru/easyjson v0.9.1 h1:LbtsOm5WAswyWbvTEOqhypdPeZzHavpZx96/n553mR8=
 github.com/mailru/easyjson v0.9.1/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
-github.com/mandelsoft/goutils v0.0.0-20251225170327-b32fc0dd2706 h1:DvZS608llVbZQYGlwtdlQ42g4BtPAmDjePXPHAneqSg=
-github.com/mandelsoft/goutils v0.0.0-20251225170327-b32fc0dd2706/go.mod h1:fTCyGFCMm+ugUn1FqcHeWelCjoSYtkJaqnJvSmgkx1M=
 github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=
 github.com/maruel/natural v1.1.1/go.mod h1:v+Rfd79xlw1AgVBjbO0BEQmptqb5HvL/k9GRHB7ZKEg=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=

--- a/kubernetes/controller/internal/ocm/ocm.go
+++ b/kubernetes/controller/internal/ocm/ocm.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/mandelsoft/goutils/matcher"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -77,7 +76,7 @@ func GetEffectiveConfig(ctx context.Context, client ctrl.Client, obj v1alpha1.Co
 	return refs, nil
 }
 
-func RegexpFilter(regex string) (matcher.Matcher[string], error) {
+func RegexpFilter(regex string) (func(string) bool, error) {
 	if regex == "" {
 		return func(_ string) bool {
 			return true
@@ -93,14 +92,14 @@ func RegexpFilter(regex string) (matcher.Matcher[string], error) {
 	}, nil
 }
 
-func GetLatestValidVersion(ctx context.Context, versions []string, semvers string, filter ...matcher.Matcher[string]) (*semver.Version, error) {
+func GetLatestValidVersion(ctx context.Context, versions []string, semvers string, filter ...func(string) bool) (*semver.Version, error) {
 	logger := log.FromContext(ctx)
 	constraint, err := semver.NewConstraint(semvers)
 	if err != nil {
 		return nil, err
 	}
 
-	var f matcher.Matcher[string]
+	var f func(string) bool
 	filtered := versions
 	if len(filter) > 0 {
 		f = filter[0]


### PR DESCRIPTION
#### What this PR does / why we need it

Removes the `github.com/mandelsoft/goutils` dependency from the controller module. The only usage was the `matcher.Matcher[string]` type alias, which is replaced with a plain `func(string) bool` function signature. This also removes the associated `replace` directive for `github.com/mandelsoft/vfs`.

This reduces the dependency footprint of the controller and eliminates the need to track unreleased transitive dependencies.

#### Which issue(s) this PR fixes

N/A — Dependency cleanup.