### PR TITLE
fix: non versioned types are deprecated

### DIFF
--- a/bindings/go/descriptor/v2/scheme.go
+++ b/bindings/go/descriptor/v2/scheme.go
@@ -13,7 +13,7 @@ func init() {
 func MustAddToScheme(scheme *runtime.Scheme) {
 	obj := &LocalBlob{}
 	scheme.MustRegisterWithAlias(obj,
-		runtime.NewUnversionedType(LocalBlobAccessType),
 		runtime.NewVersionedType(LocalBlobAccessType, LocalBlobAccessTypeVersion),
+		runtime.NewUnversionedType(LocalBlobAccessType),
 	)
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
scheme should default to versioned local blob type name

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
