### PR TITLE
fix: use the right k8sClient in the repository suite

### DIFF
--- a/kubernetes/controller/internal/controller/repository/suite_test.go
+++ b/kubernetes/controller/internal/controller/repository/suite_test.go
@@ -161,7 +161,7 @@ var _ = BeforeSuite(func() {
 	// Register reconcilers
 	Expect((&Reconciler{
 		BaseReconciler: &ocm.BaseReconciler{
-			Client:        k8sClient,
+			Client:        k8sManager.GetClient(),
 			Scheme:        testEnv.Scheme,
 			EventRecorder: recorder,
 		},


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Looks like the repository suite was using the wrong client. This _might_ not be the entire fix, but certainly is the odd one out.

Fixes https://github.com/open-component-model/open-component-model/actions/runs/22130037921/job/63968085140.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
