### PR TITLE
fix: check for latest go version in generator workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,8 +366,7 @@ jobs:
       - name: Setup Go (required by some generators)
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version: '1.25.x'
-          check-latest: true
+          go-version: '1.25.7'
           cache-dependency-path: |
             ${{ github.workspace }}/bindings/go/generator/go.sum
       - name: Run Code Generation


### PR DESCRIPTION
Currently, our workflows are failing with the following message:

```log
task: [bindings/go/generator:ocmtypegen/install] go install /home/runner/work/open-component-model/open-component-model/bindings/go/generator/ocmtypegen/...
[bindings/go/generator:ocmtypegen/install] go: go.mod requires go >= 1.25.7 (running go 1.25.6; GOTOOLCHAIN=local)
task: Failed to run task "generate": task: Failed to run task "bindings/go/generator:ocmtypegen/generate": task: Failed to run task "bindings/go/generator:ocmtypegen/install": exit status 1
Error: task: Failed to run task "bindings/go/generator:ocmtypegen/generate": task: Failed to run task "bindings/go/generator:ocmtypegen/install": exit status 1

Error: Process completed with exit code 201.
```

The reason for the error lies in the step before:

```log
Setup go version spec 1.25.x
Found in cache @ /opt/hostedtoolcache/go/1.25.6/x64
Added go to the path
Successfully set up Go version 1.25.x
/opt/hostedtoolcache/go/1.25.6/x64/bin/go env GOMODCACHE
/opt/hostedtoolcache/go/1.25.6/x64/bin/go env GOCACHE
/home/runner/go/pkg/mod
/home/runner/.cache/go-build
Cache is not found
go version go1.25.6 linux/amd64
```

Apparently, because go version `1.25.6` is found in the cache, the step does not download the latest available version.

There are several possibilities to fix this. Instead for using [`check-latest: true`](https://github.com/actions/setup-go?tab=readme-ov-file#check-latest-version)(`# Always check for the latest patch release`), as proposed in this PR, we could also point to the [`go.mod`](https://github.com/open-component-model/open-component-model/blob/927a68157ff8ddd89a83ca8f2f25f0d39443c6a7/bindings/go/generator/go.mod#L3) of that module (which in this case would point to `1.25.7`).

The workflow in this PR is failing because its still based on `upstream/main` and not my fork-branch. We might bypass the branch-protection to merge this in.