### PR TITLE
fix: add failure on exisiting branch and dont swallow message.

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -61,7 +61,10 @@ jobs:
             // Check if target branch exists
             try {
               await github.rest.repos.getBranch({ owner, repo, branch: target });
-              core.info(`Branch '${target}' already exists. Skipping creation.`);
+              core.summary.addHeading('Release Branch Already Exists', 3);
+              core.summary.addRaw(`Branch \`${target}\` already exists. No branch was created.`);
+              await core.summary.write();
+              core.setFailed(`Branch '${target}' already exists. No branch was created.`);
               return;
             } catch (error) {
               if (error.status !== 404) throw error;

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -13,8 +13,6 @@ on:
 
 jobs:
   create-release-branch:
-    environment:
-      name: ocm-release
     name: Create Release Branch from ${{ github.event.inputs.source_branch }} to ${{ github.event.inputs.target_branch }}
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Let the workflow fail in case the release branhc to create already exist. Also print a Summary in that case.

  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release branch workflow to explicitly fail with a clear summary and message when the target branch already exists, replacing a previous silent skip.
  * Removed an unused environment configuration from the release branch workflow to simplify execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->