### PR TITLE
feat: version aliasing

### DIFF
--- a/bindings/go/ctf/index/v1/index.go
+++ b/bindings/go/ctf/index/v1/index.go
@@ -24,6 +24,9 @@ type Index interface {
 	// Like OCI Image Layout, multiple entries with the same digest but different tags are allowed.
 	// If a tag already exists in the same repository but points to a different digest, it is cleared ("retag" scenario).
 	// If an exact duplicate (same repository, tag, and digest) exists, the add is skipped.
+	//
+	// Note: AddArtifact performs no garbage collection. When a tag is cleared during retag, the index
+	// entry persists with an empty tag, and unreferenced blobs persist in the CTF.
 	AddArtifact(a ArtifactMetadata)
 	// GetArtifacts returns a slice of ArtifactMetadata that are stored in the index at the time of the call.
 	// It is not guaranteed to be consistent with later calls as it is a snapshot of the current state.

--- a/bindings/go/oci/ctf/store.go
+++ b/bindings/go/oci/ctf/store.go
@@ -339,7 +339,7 @@ func (s *repository) tag(ctx context.Context, desc ociImageSpecV1.Descriptor, re
 
 	slog.DebugContext(ctx, "adding artifact to index", "meta", meta)
 
-	addOrUpdateArtifactMetadataInIndex(idx, meta)
+	idx.AddArtifact(meta)
 
 	if err := s.archive.SetIndex(ctx, idx); err != nil {
 		return fmt.Errorf("unable to set index: %w", err)
@@ -380,21 +380,4 @@ func (s *repository) Tags(ctx context.Context, _ string, fn func(tags []string) 
 	// Unlock before invoking the callback to avoid potential re-entrant locking deadlocks.
 	s.mu.RUnlock()
 	return fn(tags)
-}
-
-func addOrUpdateArtifactMetadataInIndex(idx v1.Index, meta v1.ArtifactMetadata) {
-	arts := idx.GetArtifacts()
-
-	// check if the tag already exists within the repository
-	// if it does, we need to nil out the old tag if the digest differs, (thats equivalent to a retag)
-	for i, art := range arts {
-		tagAlreadyExists := art.Repository == meta.Repository && art.Tag == meta.Tag
-		digestDiffers := art.Digest != meta.Digest
-		if tagAlreadyExists && digestDiffers {
-			arts[i].Tag = ""
-			break
-		}
-	}
-
-	idx.AddArtifact(meta)
 }

--- a/bindings/go/oci/ctf/store_test.go
+++ b/bindings/go/oci/ctf/store_test.go
@@ -389,7 +389,8 @@ func TestTags(t *testing.T) {
 			return nil
 		})
 		assert.NoError(t, err)
-		assert.ElementsMatch(t, []string{"tag2"}, tags, "a retag should not return the old tag")
+		// Like OCI Image Layout, multiple tags can point to the same digest
+		assert.ElementsMatch(t, []string{"tag1", "tag2"}, tags, "multiple tags for same digest should coexist")
 	})
 }
 

--- a/bindings/go/oci/go.mod
+++ b/bindings/go/oci/go.mod
@@ -13,7 +13,7 @@ require (
 	ocm.software/open-component-model/bindings/go/blob v0.0.11
 	ocm.software/open-component-model/bindings/go/configuration v0.0.12
 	ocm.software/open-component-model/bindings/go/credentials v0.0.9
-	ocm.software/open-component-model/bindings/go/ctf v0.3.0
+	ocm.software/open-component-model/bindings/go/ctf v0.4.0
 	ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20260409111948-a6aca34e77a9
 	ocm.software/open-component-model/bindings/go/descriptor/v2 v2.0.1-alpha9
 	ocm.software/open-component-model/bindings/go/repository v0.0.8

--- a/bindings/go/oci/go.sum
+++ b/bindings/go/oci/go.sum
@@ -53,8 +53,8 @@ ocm.software/open-component-model/bindings/go/configuration v0.0.12 h1:SXrHUR70g
 ocm.software/open-component-model/bindings/go/configuration v0.0.12/go.mod h1:0sMurs1+cI/ohkuNSipDPPRb5ycSSTHDZoFG92aDtlE=
 ocm.software/open-component-model/bindings/go/credentials v0.0.9 h1:sYKfVKs+CrVL2EuKYNevCjXq1cdF0DsLnWyEjamjDdY=
 ocm.software/open-component-model/bindings/go/credentials v0.0.9/go.mod h1:JFQDqqZv17uJLQSZOKa9siuLTK4zMA3Bzk4amU9ZALU=
-ocm.software/open-component-model/bindings/go/ctf v0.3.0 h1:u1B26OgUvR+gzTwY0hTVdZgFIXv5uwdI8reEvCcjNV4=
-ocm.software/open-component-model/bindings/go/ctf v0.3.0/go.mod h1:skMxA1l7rZFhKsjn8CysSVG31zjmV95WaFqMVKRjHug=
+ocm.software/open-component-model/bindings/go/ctf v0.4.0 h1:E2kDGJk/ZR2wMK6fk3yFr2Uv6AhfLdMmvdvQ7Y64/2s=
+ocm.software/open-component-model/bindings/go/ctf v0.4.0/go.mod h1:XaVTQK/STJ64pq8vClsT+onD0kEs7P+Wzsq1k2tp9h4=
 ocm.software/open-component-model/bindings/go/dag v0.0.6 h1:To76QJAmFD88C101oB/HgYvtomp8mm0270ewDLcVncw=
 ocm.software/open-component-model/bindings/go/dag v0.0.6/go.mod h1:mQbO95zYvX59VXNJGer4+wGsKY0BVI4FKwlR5BlPugM=
 ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20260409111948-a6aca34e77a9 h1:bOUxo061N0LXeXNYcqtzOrCL0KnZpkBTU2MIB+YcaDg=

--- a/bindings/go/oci/integration/go.mod
+++ b/bindings/go/oci/integration/go.mod
@@ -13,7 +13,7 @@ require (
 	ocm.software/open-component-model/bindings/go/blob v0.0.11
 	ocm.software/open-component-model/bindings/go/configuration v0.0.12
 	ocm.software/open-component-model/bindings/go/credentials v0.0.9
-	ocm.software/open-component-model/bindings/go/ctf v0.3.0
+	ocm.software/open-component-model/bindings/go/ctf v0.4.0
 	ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20260409111948-a6aca34e77a9
 	ocm.software/open-component-model/bindings/go/descriptor/v2 v2.0.1-alpha9
 	ocm.software/open-component-model/bindings/go/oci v0.0.38

--- a/bindings/go/oci/integration/go.sum
+++ b/bindings/go/oci/integration/go.sum
@@ -185,8 +185,8 @@ ocm.software/open-component-model/bindings/go/configuration v0.0.12 h1:SXrHUR70g
 ocm.software/open-component-model/bindings/go/configuration v0.0.12/go.mod h1:0sMurs1+cI/ohkuNSipDPPRb5ycSSTHDZoFG92aDtlE=
 ocm.software/open-component-model/bindings/go/credentials v0.0.9 h1:sYKfVKs+CrVL2EuKYNevCjXq1cdF0DsLnWyEjamjDdY=
 ocm.software/open-component-model/bindings/go/credentials v0.0.9/go.mod h1:JFQDqqZv17uJLQSZOKa9siuLTK4zMA3Bzk4amU9ZALU=
-ocm.software/open-component-model/bindings/go/ctf v0.3.0 h1:u1B26OgUvR+gzTwY0hTVdZgFIXv5uwdI8reEvCcjNV4=
-ocm.software/open-component-model/bindings/go/ctf v0.3.0/go.mod h1:skMxA1l7rZFhKsjn8CysSVG31zjmV95WaFqMVKRjHug=
+ocm.software/open-component-model/bindings/go/ctf v0.4.0 h1:E2kDGJk/ZR2wMK6fk3yFr2Uv6AhfLdMmvdvQ7Y64/2s=
+ocm.software/open-component-model/bindings/go/ctf v0.4.0/go.mod h1:XaVTQK/STJ64pq8vClsT+onD0kEs7P+Wzsq1k2tp9h4=
 ocm.software/open-component-model/bindings/go/dag v0.0.6 h1:To76QJAmFD88C101oB/HgYvtomp8mm0270ewDLcVncw=
 ocm.software/open-component-model/bindings/go/dag v0.0.6/go.mod h1:mQbO95zYvX59VXNJGer4+wGsKY0BVI4FKwlR5BlPugM=
 ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20260409111948-a6aca34e77a9 h1:bOUxo061N0LXeXNYcqtzOrCL0KnZpkBTU2MIB+YcaDg=

--- a/bindings/go/oci/interface.go
+++ b/bindings/go/oci/interface.go
@@ -18,6 +18,7 @@ type LocalBlob fetch.LocalBlob
 // and their associated resources in a Store.
 type ComponentVersionRepository interface {
 	repository.ComponentVersionRepository
+	AliasComponentVersionRepository
 	repository.HealthCheckable
 	ResourceDigestProcessor
 }
@@ -62,4 +63,17 @@ type Resolver interface {
 	// Ping does a healthcheck for the underlying Store. The implementation varies based on the implementing
 	// technology.
 	Ping(ctx context.Context) error
+}
+
+// AliasComponentVersionRepository defines the interface for adding aliases to existing component versions.
+type AliasComponentVersionRepository interface {
+	// AddComponentVersionAlias adds an alias to an existing component version.
+	// The alias can be used as an alternative reference to access the same component version.
+	// The versionOrAlias parameter can be either a component version or an existing alias,
+	// enabling scenarios like pointing 'edge' to whatever 'latest' currently references.
+	// The alias parameter must NOT be a semantic version in "loose" format (e.g., "1.0.0", "v2.3.4") to prevent
+	// conflicts with actual component versions. Besides this, aliases must follow OCI tag syntax constraints.
+	// Like OCI tags, aliases are mutable - reusing the same alias for a different component version will move it.
+	// The target must be a valid OCM component version - aliasing arbitrary OCI artifacts will fail.
+	AddComponentVersionAlias(ctx context.Context, component, versionOrAlias, alias string) error
 }

--- a/bindings/go/oci/internal/lister/component/component_versions.go
+++ b/bindings/go/oci/internal/lister/component/component_versions.go
@@ -2,18 +2,16 @@ package component
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 
 	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/content"
 
 	"ocm.software/open-component-model/bindings/go/oci/internal/lister"
+	"ocm.software/open-component-model/bindings/go/oci/internal/validate"
 	"ocm.software/open-component-model/bindings/go/oci/spec/annotations"
-	componentConfig "ocm.software/open-component-model/bindings/go/oci/spec/config/component"
 	"ocm.software/open-component-model/bindings/go/oci/spec/repository/path"
 )
 
@@ -75,66 +73,13 @@ func ReferenceTagVersionResolver(component string, store interface {
 			return "", fmt.Errorf("failed to resolve tag %q: %w", tag, err)
 		}
 
-		var (
-			manifestAnnotations    map[string]string
-			data                   io.ReadCloser
-			oldOCMComponentVersion bool
-		)
-		switch desc.MediaType {
-		case ociImageSpecV1.MediaTypeImageManifest:
-			data, err = store.Fetch(ctx, desc)
-			if err != nil {
-				return "", fmt.Errorf("failed to fetch descriptor for tag %q: %w", tag, err)
-			}
-			var manifest ociImageSpecV1.Manifest
-			if err := json.NewDecoder(data).Decode(&manifest); err != nil {
-				return "", errors.Join(fmt.Errorf("failed to decode manifest for tag %q: %w", tag, err), data.Close())
-			}
-			manifestAnnotations = manifest.Annotations
-			// Checks for old component versions pre-2024 which didn't have an annotation.
-			// In that case, we check if the manifest has a config of type ocm config and if yes, we can just return
-			// the tag as valid. We only do this for manifest layers and not index layers because pre-2024 component versions
-			// didn't have indexes.
-			oldOCMComponentVersion = manifest.Config.MediaType == componentConfig.MediaType
-		case ociImageSpecV1.MediaTypeImageIndex:
-			data, err = store.Fetch(ctx, desc)
-			if err != nil {
-				return "", fmt.Errorf("failed to fetch descriptor for tag %q: %w", tag, err)
-			}
-			var index ociImageSpecV1.Index
-			if err := json.NewDecoder(data).Decode(&index); err != nil {
-				return "", errors.Join(fmt.Errorf("failed to decode index for tag %q: %w", tag, err), data.Close())
-			}
-			manifestAnnotations = index.Annotations
-
-		default:
-			return "", fmt.Errorf("unsupported media type %q for tag %q: %w", desc.MediaType, tag, lister.ErrSkip)
-		}
-		if err = data.Close(); err != nil {
-			return "", fmt.Errorf("failed to close descriptor reader for tag %q: %w", tag, err)
-		}
-		annotation, ok := manifestAnnotations[annotations.OCMComponentVersion]
-		if !ok {
-			if oldOCMComponentVersion {
-				return tag, nil
-			}
-
-			return "", fmt.Errorf("failed to find %q annotation for tag %q: %w", annotations.OCMComponentVersion, tag, lister.ErrSkip)
-		}
-
-		candidate, version, err := annotations.ParseComponentVersionAnnotation(annotation)
+		version, err := validate.ComponentVersionDescriptor(ctx, store, desc, component, tag)
 		if err != nil {
-			return "", fmt.Errorf("failed to parse component version annotation: %w", err)
+			if errors.Is(err, validate.ErrInvalidComponentVersion) {
+				return "", errors.Join(err, lister.ErrSkip)
+			}
+			return "", err
 		}
-
-		if strings.HasPrefix(component, path.DefaultComponentDescriptorPath+"/") {
-			component = strings.TrimPrefix(component, path.DefaultComponentDescriptorPath+"/")
-		}
-
-		if candidate != component {
-			return "", fmt.Errorf("component %q from annotation does not match %q: %w", candidate, component, lister.ErrSkip)
-		}
-
 		return version, nil
 	}
 	return tagResolver

--- a/bindings/go/oci/internal/validate/validate.go
+++ b/bindings/go/oci/internal/validate/validate.go
@@ -1,0 +1,104 @@
+package validate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content"
+
+	"ocm.software/open-component-model/bindings/go/oci/spec/annotations"
+	componentConfig "ocm.software/open-component-model/bindings/go/oci/spec/config/component"
+	"ocm.software/open-component-model/bindings/go/oci/spec/repository/path"
+)
+
+// ErrInvalidComponentVersion indicates that an OCI descriptor does not represent
+// a valid OCM component version (wrong media type, missing annotation, or
+// component name mismatch).
+var ErrInvalidComponentVersion = errors.New("not an OCM component version")
+
+// ComponentVersionDescriptor validates whether a pre-resolved OCI descriptor
+// references a valid OCM component version for the given component. It fetches the
+// manifest or index content and checks for the OCM component version annotation.
+//
+// This function supports both legacy (pre-2024) and current OCM manifest formats.
+// For legacy manifests without annotations, it falls back to checking the config media type.
+//
+// The ref parameter is used for error messages and should identify the descriptor being validated.
+//
+// Returns the validated version string, or an error wrapping [ErrInvalidComponentVersion]
+// if the descriptor does not represent a valid OCM component version.
+func ComponentVersionDescriptor(
+	ctx context.Context,
+	fetcher content.Fetcher,
+	desc ociImageSpecV1.Descriptor,
+	component,
+	ref string,
+) (string, error) {
+	var (
+		manifestAnnotations    map[string]string
+		data                   io.ReadCloser
+		oldOCMComponentVersion bool
+		err                    error
+	)
+	switch desc.MediaType {
+	case ociImageSpecV1.MediaTypeImageManifest:
+		data, err = fetcher.Fetch(ctx, desc)
+		if err != nil {
+			return "", fmt.Errorf("failed to fetch descriptor for reference %q: %w", ref, err)
+		}
+		var manifest ociImageSpecV1.Manifest
+		if err := json.NewDecoder(data).Decode(&manifest); err != nil {
+			return "", errors.Join(fmt.Errorf("failed to decode manifest for reference %q: %w", ref, err), data.Close())
+		}
+		manifestAnnotations = manifest.Annotations
+		// Checks for old component versions pre-2024 which didn't have an annotation.
+		// In that case, we check if the manifest has a config of type ocm config and if yes, we can just return
+		// the tag as valid. We only do this for manifest layers and not index layers because pre-2024 component versions
+		// didn't have indexes.
+		oldOCMComponentVersion = manifest.Config.MediaType == componentConfig.MediaType
+	case ociImageSpecV1.MediaTypeImageIndex:
+		data, err = fetcher.Fetch(ctx, desc)
+		if err != nil {
+			return "", fmt.Errorf("failed to fetch descriptor for reference %q: %w", ref, err)
+		}
+		var index ociImageSpecV1.Index
+		if err := json.NewDecoder(data).Decode(&index); err != nil {
+			return "", errors.Join(fmt.Errorf("failed to decode index for reference %q: %w", ref, err), data.Close())
+		}
+		manifestAnnotations = index.Annotations
+
+	default:
+		return "", fmt.Errorf("unsupported media type %q for reference %q: %w", desc.MediaType, ref, ErrInvalidComponentVersion)
+	}
+	if err = data.Close(); err != nil {
+		return "", fmt.Errorf("failed to close descriptor reader for reference %q: %w", ref, err)
+	}
+	annotation, ok := manifestAnnotations[annotations.OCMComponentVersion]
+	if !ok {
+		if oldOCMComponentVersion {
+			return ref, nil
+		}
+
+		return "", fmt.Errorf("failed to find %q annotation for tag %q: %w", annotations.OCMComponentVersion, ref, ErrInvalidComponentVersion)
+	}
+
+	candidate, version, err := annotations.ParseComponentVersionAnnotation(annotation)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse component version annotation: %w", err)
+	}
+
+	if strings.HasPrefix(component, path.DefaultComponentDescriptorPath+"/") {
+		component = strings.TrimPrefix(component, path.DefaultComponentDescriptorPath+"/")
+	}
+
+	if candidate != component {
+		return "", fmt.Errorf("component %q from annotation does not match %q: %w", candidate, component, ErrInvalidComponentVersion)
+	}
+
+	return version, nil
+}

--- a/bindings/go/oci/internal/validate/validate_test.go
+++ b/bindings/go/oci/internal/validate/validate_test.go
@@ -1,0 +1,272 @@
+package validate_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"ocm.software/open-component-model/bindings/go/oci/internal/validate"
+	"ocm.software/open-component-model/bindings/go/oci/spec/annotations"
+	componentConfig "ocm.software/open-component-model/bindings/go/oci/spec/config/component"
+)
+
+type mockFetcher struct {
+	fetchFunc func(ctx context.Context, desc ociImageSpecV1.Descriptor) (io.ReadCloser, error)
+}
+
+func (m *mockFetcher) Fetch(ctx context.Context, desc ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+	return m.fetchFunc(ctx, desc)
+}
+
+func TestComponentVersionDescriptor(t *testing.T) {
+	tests := []struct {
+		name            string
+		descriptor      ociImageSpecV1.Descriptor
+		component       string
+		tag             string
+		fetcher         *mockFetcher
+		expectedVersion string
+		expectedError   error
+	}{
+		{
+			name:      "valid manifest with annotation",
+			component: "example.com/component",
+			tag:       "v1.0.0",
+			descriptor: ociImageSpecV1.Descriptor{
+				MediaType: ociImageSpecV1.MediaTypeImageManifest,
+			},
+			fetcher: &mockFetcher{
+				fetchFunc: func(ctx context.Context, desc ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+					manifest := ociImageSpecV1.Manifest{
+						Annotations: map[string]string{
+							annotations.OCMComponentVersion: annotations.NewComponentVersionAnnotation("example.com/component", "v1.0.0"),
+						},
+					}
+					data, _ := json.Marshal(manifest)
+					return io.NopCloser(bytes.NewReader(data)), nil
+				},
+			},
+			expectedVersion: "v1.0.0",
+		},
+		{
+			name:      "valid index with annotation",
+			component: "example.com/component",
+			tag:       "v2.0.0",
+			descriptor: ociImageSpecV1.Descriptor{
+				MediaType: ociImageSpecV1.MediaTypeImageIndex,
+			},
+			fetcher: &mockFetcher{
+				fetchFunc: func(ctx context.Context, desc ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+					index := ociImageSpecV1.Index{
+						Annotations: map[string]string{
+							annotations.OCMComponentVersion: annotations.NewComponentVersionAnnotation("example.com/component", "v2.0.0"),
+						},
+					}
+					data, _ := json.Marshal(index)
+					return io.NopCloser(bytes.NewReader(data)), nil
+				},
+			},
+			expectedVersion: "v2.0.0",
+		},
+		{
+			name:      "component with descriptor path prefix",
+			component: "component-descriptors/example.com/component",
+			tag:       "v1.5.0",
+			descriptor: ociImageSpecV1.Descriptor{
+				MediaType: ociImageSpecV1.MediaTypeImageManifest,
+			},
+			fetcher: &mockFetcher{
+				fetchFunc: func(ctx context.Context, desc ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+					manifest := ociImageSpecV1.Manifest{
+						Annotations: map[string]string{
+							annotations.OCMComponentVersion: annotations.NewComponentVersionAnnotation("example.com/component", "v1.5.0"),
+						},
+					}
+					data, _ := json.Marshal(manifest)
+					return io.NopCloser(bytes.NewReader(data)), nil
+				},
+			},
+			expectedVersion: "v1.5.0",
+		},
+		{
+			name:      "legacy pre-2024 manifest without annotation",
+			component: "example.com/component",
+			tag:       "v0.9.0",
+			descriptor: ociImageSpecV1.Descriptor{
+				MediaType: ociImageSpecV1.MediaTypeImageManifest,
+			},
+			fetcher: &mockFetcher{
+				fetchFunc: func(ctx context.Context, desc ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+					manifest := ociImageSpecV1.Manifest{
+						Config: ociImageSpecV1.Descriptor{
+							MediaType: componentConfig.MediaType,
+						},
+					}
+					data, _ := json.Marshal(manifest)
+					return io.NopCloser(bytes.NewReader(data)), nil
+				},
+			},
+			expectedVersion: "v0.9.0",
+		},
+		{
+			name:      "unsupported media type",
+			component: "example.com/component",
+			tag:       "v1.0.0",
+			descriptor: ociImageSpecV1.Descriptor{
+				MediaType: "application/octet-stream",
+			},
+			expectedError: validate.ErrInvalidComponentVersion,
+		},
+		{
+			name:      "manifest missing annotation and not legacy format",
+			component: "example.com/component",
+			tag:       "v1.0.0",
+			descriptor: ociImageSpecV1.Descriptor{
+				MediaType: ociImageSpecV1.MediaTypeImageManifest,
+			},
+			fetcher: &mockFetcher{
+				fetchFunc: func(ctx context.Context, desc ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+					manifest := ociImageSpecV1.Manifest{
+						Config: ociImageSpecV1.Descriptor{
+							MediaType: "application/vnd.oci.image.config.v1+json",
+						},
+					}
+					data, _ := json.Marshal(manifest)
+					return io.NopCloser(bytes.NewReader(data)), nil
+				},
+			},
+			expectedError: validate.ErrInvalidComponentVersion,
+		},
+		{
+			name:      "index missing annotation",
+			component: "example.com/component",
+			tag:       "v1.0.0",
+			descriptor: ociImageSpecV1.Descriptor{
+				MediaType: ociImageSpecV1.MediaTypeImageIndex,
+			},
+			fetcher: &mockFetcher{
+				fetchFunc: func(ctx context.Context, desc ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+					index := ociImageSpecV1.Index{}
+					data, _ := json.Marshal(index)
+					return io.NopCloser(bytes.NewReader(data)), nil
+				},
+			},
+			expectedError: validate.ErrInvalidComponentVersion,
+		},
+		{
+			name:      "component name mismatch",
+			component: "example.com/component",
+			tag:       "v1.0.0",
+			descriptor: ociImageSpecV1.Descriptor{
+				MediaType: ociImageSpecV1.MediaTypeImageManifest,
+			},
+			fetcher: &mockFetcher{
+				fetchFunc: func(ctx context.Context, desc ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+					manifest := ociImageSpecV1.Manifest{
+						Annotations: map[string]string{
+							annotations.OCMComponentVersion: annotations.NewComponentVersionAnnotation("example.com/different", "v1.0.0"),
+						},
+					}
+					data, _ := json.Marshal(manifest)
+					return io.NopCloser(bytes.NewReader(data)), nil
+				},
+			},
+			expectedError: validate.ErrInvalidComponentVersion,
+		},
+		{
+			name:      "malformed annotation",
+			component: "example.com/component",
+			tag:       "v1.0.0",
+			descriptor: ociImageSpecV1.Descriptor{
+				MediaType: ociImageSpecV1.MediaTypeImageManifest,
+			},
+			fetcher: &mockFetcher{
+				fetchFunc: func(ctx context.Context, desc ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+					manifest := ociImageSpecV1.Manifest{
+						Annotations: map[string]string{
+							annotations.OCMComponentVersion: "malformed-no-colon",
+						},
+					}
+					data, _ := json.Marshal(manifest)
+					return io.NopCloser(bytes.NewReader(data)), nil
+				},
+			},
+			expectedError: fmt.Errorf("failed to parse component version annotation"),
+		},
+		{
+			name:      "fetch error",
+			component: "example.com/component",
+			tag:       "v1.0.0",
+			descriptor: ociImageSpecV1.Descriptor{
+				MediaType: ociImageSpecV1.MediaTypeImageManifest,
+			},
+			fetcher: &mockFetcher{
+				fetchFunc: func(ctx context.Context, desc ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+					return nil, fmt.Errorf("network error")
+				},
+			},
+			expectedError: fmt.Errorf("failed to fetch descriptor"),
+		},
+		{
+			name:      "malformed manifest JSON",
+			component: "example.com/component",
+			tag:       "v1.0.0",
+			descriptor: ociImageSpecV1.Descriptor{
+				MediaType: ociImageSpecV1.MediaTypeImageManifest,
+			},
+			fetcher: &mockFetcher{
+				fetchFunc: func(ctx context.Context, desc ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+					return io.NopCloser(bytes.NewReader([]byte("not json"))), nil
+				},
+			},
+			expectedError: fmt.Errorf("failed to decode manifest"),
+		},
+		{
+			name:      "malformed index JSON",
+			component: "example.com/component",
+			tag:       "v1.0.0",
+			descriptor: ociImageSpecV1.Descriptor{
+				MediaType: ociImageSpecV1.MediaTypeImageIndex,
+			},
+			fetcher: &mockFetcher{
+				fetchFunc: func(ctx context.Context, desc ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+					return io.NopCloser(bytes.NewReader([]byte("not json"))), nil
+				},
+			},
+			expectedError: fmt.Errorf("failed to decode index"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+
+			version, err := validate.ComponentVersionDescriptor(
+				ctx,
+				tt.fetcher,
+				tt.descriptor,
+				tt.component,
+				tt.tag,
+			)
+
+			if tt.expectedError != nil {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError.Error())
+				if errors.Is(tt.expectedError, validate.ErrInvalidComponentVersion) {
+					assert.ErrorIs(t, err, validate.ErrInvalidComponentVersion)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedVersion, version)
+			}
+		})
+	}
+}

--- a/bindings/go/oci/repository.go
+++ b/bindings/go/oci/repository.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"regexp"
 
 	"github.com/opencontainers/go-digest"
 	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -23,6 +24,7 @@ import (
 	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
 	v2 "ocm.software/open-component-model/bindings/go/descriptor/v2"
 	ociblob "ocm.software/open-component-model/bindings/go/oci/blob"
+	"ocm.software/open-component-model/bindings/go/oci/compref"
 	internaldigest "ocm.software/open-component-model/bindings/go/oci/internal/digest"
 	"ocm.software/open-component-model/bindings/go/oci/internal/fetch"
 	"ocm.software/open-component-model/bindings/go/oci/internal/identity"
@@ -31,6 +33,7 @@ import (
 	complister "ocm.software/open-component-model/bindings/go/oci/internal/lister/component"
 	"ocm.software/open-component-model/bindings/go/oci/internal/log"
 	"ocm.software/open-component-model/bindings/go/oci/internal/pack"
+	"ocm.software/open-component-model/bindings/go/oci/internal/validate"
 	"ocm.software/open-component-model/bindings/go/oci/looseref"
 	"ocm.software/open-component-model/bindings/go/oci/spec"
 	accessv1 "ocm.software/open-component-model/bindings/go/oci/spec/access/v1"
@@ -42,7 +45,10 @@ import (
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
-var _ ComponentVersionRepository = (*Repository)(nil)
+var (
+	_            ComponentVersionRepository = (*Repository)(nil)
+	versionRegex                            = regexp.MustCompile(compref.VersionRegex)
+)
 
 // Repository implements the ComponentVersionRepository interface using OCI registries.
 // Each component may be stored in a separate OCI repository, but ultimately the storage is determined by the Resolver.
@@ -848,4 +854,44 @@ func findDescriptorFromReference(descriptors []ociImageSpecV1.Descriptor, refere
 		}
 	}
 	return ociImageSpecV1.Descriptor{}, fmt.Errorf("no matching descriptor found for reference %s", reference)
+}
+
+func (repo *Repository) AddComponentVersionAlias(ctx context.Context, component, versionOrAlias, alias string) (err error) {
+	ctx = slogcontext.NewCtx(ctx, repo.logger)
+	done := log.Operation(ctx, "add component version alias",
+		slog.String("component", component),
+		slog.String("versionOrAlias", versionOrAlias),
+		slog.String("alias", alias))
+	defer func() {
+		done(err)
+	}()
+
+	if versionRegex.MatchString(alias) {
+		return fmt.Errorf("alias %q uses semantic version format and cannot be used as an alias (use non-semver names like 'edge' or 'latest' instead)", alias)
+	}
+
+	reference, store, err := repo.getStore(ctx, component, versionOrAlias)
+	if err != nil {
+		return fmt.Errorf("failed to get store for component version %s/%s: %w", component, versionOrAlias, err)
+	}
+
+	base, err := store.Resolve(ctx, reference)
+	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return errors.Join(repository.ErrNotFound,
+				fmt.Errorf("component version %s/%s not found: %w", component, versionOrAlias, err))
+		}
+		return fmt.Errorf("failed to resolve component version %s/%s: %w", component, versionOrAlias, err)
+	}
+
+	if _, err := validate.ComponentVersionDescriptor(ctx, store, base, component, reference); err != nil {
+		return fmt.Errorf("reference %q does not point to a valid OCM component version: %w", reference, err)
+	}
+
+	if err := store.Tag(ctx, base, alias); err != nil {
+		return fmt.Errorf("failed to tag component version %s/%s with alias %q: %w",
+			component, versionOrAlias, alias, err)
+	}
+
+	return nil
 }

--- a/bindings/go/oci/repository_test.go
+++ b/bindings/go/oci/repository_test.go
@@ -1535,6 +1535,425 @@ func TestRepository_ProcessResourceDigest(t *testing.T) {
 	}
 }
 
+func TestRepository_AddComponentVersionAlias(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	fs, err := filesystem.NewFS(t.TempDir(), os.O_RDWR)
+	r.NoError(err)
+	store := ocictf.NewFromCTF(ctf.NewFileSystemCTF(fs))
+	repo := Repository(t, ocictf.WithCTF(store))
+
+	componentName := "ocm.software/test-component"
+
+	// Helper to create descriptor
+	makeDesc := func(version string) *descriptor.Descriptor {
+		return &descriptor.Descriptor{
+			Meta: descriptor.Meta{Version: "v2"},
+			Component: descriptor.Component{
+				Provider:      descriptor.Provider{Name: "test-provider"},
+				ComponentMeta: descriptor.ComponentMeta{ObjectMeta: descriptor.ObjectMeta{Name: componentName, Version: version}},
+			},
+		}
+	}
+
+	// Add versions 1.0.0 and 2.0.0
+	r.NoError(repo.AddComponentVersion(ctx, makeDesc("1.0.0")))
+	r.NoError(repo.AddComponentVersion(ctx, makeDesc("2.0.0")))
+
+	// Add multiple aliases to 1.0.0
+	r.NoError(repo.AddComponentVersionAlias(ctx, componentName, "1.0.0", "latest"))
+	r.NoError(repo.AddComponentVersionAlias(ctx, componentName, "1.0.0", "stable"))
+
+	// Verify aliases resolve correctly
+	for _, alias := range []string{"latest", "stable"} {
+		got, err := repo.GetComponentVersion(ctx, componentName, alias)
+		r.NoError(err)
+		r.Equal("1.0.0", got.Component.Version)
+	}
+
+	got, err := repo.GetComponentVersion(ctx, componentName, "1.0.0")
+	r.NoError(err, "original version must be retrievable after aliasing")
+	r.Equal("1.0.0", got.Component.Version)
+
+	// Move "latest" to 2.0.0
+	r.NoError(repo.AddComponentVersionAlias(ctx, componentName, "2.0.0", "latest"))
+
+	got, err = repo.GetComponentVersion(ctx, componentName, "latest")
+	r.NoError(err)
+	r.Equal("2.0.0", got.Component.Version, "latest should now point to 2.0.0")
+
+	// Both versions must still be retrievable after alias move
+	got, err = repo.GetComponentVersion(ctx, componentName, "1.0.0")
+	r.NoError(err, "1.0.0 must be retrievable after alias moved")
+	r.Equal("1.0.0", got.Component.Version)
+
+	got, err = repo.GetComponentVersion(ctx, componentName, "2.0.0")
+	r.NoError(err, "2.0.0 must be retrievable")
+	r.Equal("2.0.0", got.Component.Version)
+
+	// "stable" should still point to 1.0.0
+	got, err = repo.GetComponentVersion(ctx, componentName, "stable")
+	r.NoError(err)
+	r.Equal("1.0.0", got.Component.Version, "stable should still point to 1.0.0")
+}
+
+func TestRepository_AddComponentVersionAlias_NonExistent(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	fs, err := filesystem.NewFS(t.TempDir(), os.O_RDWR)
+	r.NoError(err)
+	store := ocictf.NewFromCTF(ctf.NewFileSystemCTF(fs))
+	repo := Repository(t, ocictf.WithCTF(store))
+
+	// Must fail for non-existent component
+	err = repo.AddComponentVersionAlias(ctx, "non-existent", "1.0.0", "latest")
+	r.Error(err)
+	r.ErrorIs(err, repository.ErrNotFound)
+}
+
+func TestRepository_AddComponentVersionAlias_ChainedAndIdempotent(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	fs, err := filesystem.NewFS(t.TempDir(), os.O_RDWR)
+	r.NoError(err)
+	store := ocictf.NewFromCTF(ctf.NewFileSystemCTF(fs))
+	repo := Repository(t, ocictf.WithCTF(store))
+
+	componentName := "ocm.software/test-component"
+	desc := &descriptor.Descriptor{
+		Meta: descriptor.Meta{Version: "v2"},
+		Component: descriptor.Component{
+			Provider:      descriptor.Provider{Name: "test-provider"},
+			ComponentMeta: descriptor.ComponentMeta{ObjectMeta: descriptor.ObjectMeta{Name: componentName, Version: "1.0.0"}},
+		},
+	}
+	r.NoError(repo.AddComponentVersion(ctx, desc))
+
+	// Chain: version -> latest -> stable -> production
+	r.NoError(repo.AddComponentVersionAlias(ctx, componentName, "1.0.0", "latest"))
+	r.NoError(repo.AddComponentVersionAlias(ctx, componentName, "latest", "stable"))
+	r.NoError(repo.AddComponentVersionAlias(ctx, componentName, "stable", "production"))
+
+	// All must resolve to 1.0.0
+	for _, ref := range []string{"1.0.0", "latest", "stable", "production"} {
+		got, err := repo.GetComponentVersion(ctx, componentName, ref)
+		r.NoError(err, "ref %s should resolve", ref)
+		r.Equal("1.0.0", got.Component.Version)
+	}
+
+	// Idempotent: adding same alias multiple times should work
+	for i := 0; i < 3; i++ {
+		r.NoError(repo.AddComponentVersionAlias(ctx, componentName, "1.0.0", "latest"))
+		got, err := repo.GetComponentVersion(ctx, componentName, "latest")
+		r.NoError(err)
+		r.Equal("1.0.0", got.Component.Version)
+	}
+
+	// version still retrievable after repeated operations
+	got, err := repo.GetComponentVersion(ctx, componentName, "1.0.0")
+	r.NoError(err)
+	r.Equal("1.0.0", got.Component.Version)
+}
+
+func TestRepository_AddComponentVersionAlias_ManyVersionsStayRetrievable(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	fs, err := filesystem.NewFS(t.TempDir(), os.O_RDWR)
+	r.NoError(err)
+	store := ocictf.NewFromCTF(ctf.NewFileSystemCTF(fs))
+	repo := Repository(t, ocictf.WithCTF(store))
+
+	componentName := "ocm.software/test-component"
+	versions := []string{"1.0.0", "1.1.0", "2.0.0", "2.1.0"}
+
+	// Add all versions
+	for _, v := range versions {
+		desc := &descriptor.Descriptor{
+			Meta: descriptor.Meta{Version: "v2"},
+			Component: descriptor.Component{
+				Provider:      descriptor.Provider{Name: "test-provider"},
+				ComponentMeta: descriptor.ComponentMeta{ObjectMeta: descriptor.ObjectMeta{Name: componentName, Version: v}},
+			},
+		}
+		r.NoError(repo.AddComponentVersion(ctx, desc))
+	}
+
+	// Move "latest" through all versions
+	for _, v := range versions {
+		r.NoError(repo.AddComponentVersionAlias(ctx, componentName, v, "latest"))
+	}
+
+	// ALL versions must still be retrievable
+	for _, v := range versions {
+		got, err := repo.GetComponentVersion(ctx, componentName, v)
+		r.NoError(err, "version %s must be retrievable after alias operations", v)
+		r.Equal(v, got.Component.Version)
+	}
+
+	// "latest" should point to last version
+	got, err := repo.GetComponentVersion(ctx, componentName, "latest")
+	r.NoError(err)
+	r.Equal("2.1.0", got.Component.Version)
+}
+
+func TestRepository_AddComponentVersionAlias_OCIImageIndex(t *testing.T) {
+	// This test exercises the OCI image index code path in AddComponentVersionAlias.
+	// When a component version has a local resource with an OCI layout media type,
+	// AddComponentVersion wraps the manifest in an OCI image index. Aliasing must
+	// work correctly through this index-based structure.
+	r := require.New(t)
+	ctx := t.Context()
+
+	fs, err := filesystem.NewFS(t.TempDir(), os.O_RDWR)
+	r.NoError(err)
+	store := ocictf.NewFromCTF(ctf.NewFileSystemCTF(fs))
+	repo := Repository(t, ocictf.WithCTF(store))
+
+	componentName := "ocm.software/test-component"
+
+	// Helper to create a component version with an OCI layout resource,
+	// which triggers OCI image index creation in AddDescriptorToStore.
+	addVersionWithOCILayoutResource := func(version string) {
+		desc := &descriptor.Descriptor{
+			Meta: descriptor.Meta{Version: "v2"},
+			Component: descriptor.Component{
+				Provider:      descriptor.Provider{Name: "test-provider"},
+				ComponentMeta: descriptor.ComponentMeta{ObjectMeta: descriptor.ObjectMeta{Name: componentName, Version: version}},
+			},
+		}
+
+		data, _ := createSingleLayerOCIImage(t, []byte("content-"+version), "image:"+version)
+
+		resource := &descriptor.Resource{
+			Relation: descriptor.LocalRelation,
+			ElementMeta: descriptor.ElementMeta{
+				ObjectMeta: descriptor.ObjectMeta{Name: "test-resource", Version: version},
+			},
+			Type: "ociImage",
+			Access: &v2.LocalBlob{
+				LocalReference: digest.FromBytes(data).String(),
+				MediaType:      layout.MediaTypeOCIImageLayoutV1 + "+tar",
+			},
+		}
+		desc.Component.Resources = append(desc.Component.Resources, *resource)
+
+		newRes, err := repo.AddLocalResource(ctx, componentName, version, resource, inmemory.New(bytes.NewReader(data)))
+		r.NoError(err)
+		desc.Component.Resources[0] = *newRes
+
+		r.NoError(repo.AddComponentVersion(ctx, desc))
+	}
+
+	addVersionWithOCILayoutResource("1.0.0")
+	addVersionWithOCILayoutResource("2.0.0")
+
+	// Alias "latest" to 1.0.0 (stored as an OCI image index)
+	r.NoError(repo.AddComponentVersionAlias(ctx, componentName, "1.0.0", "latest"))
+
+	// Verify the alias resolves to the correct component version
+	got, err := repo.GetComponentVersion(ctx, componentName, "latest")
+	r.NoError(err)
+	r.Equal("1.0.0", got.Component.Version)
+
+	// Original version must still be retrievable
+	got, err = repo.GetComponentVersion(ctx, componentName, "1.0.0")
+	r.NoError(err)
+	r.Equal("1.0.0", got.Component.Version)
+
+	// Move alias to 2.0.0
+	r.NoError(repo.AddComponentVersionAlias(ctx, componentName, "2.0.0", "latest"))
+
+	got, err = repo.GetComponentVersion(ctx, componentName, "latest")
+	r.NoError(err)
+	r.Equal("2.0.0", got.Component.Version, "latest should now point to 2.0.0")
+
+	// Both original versions must remain retrievable after alias move
+	got, err = repo.GetComponentVersion(ctx, componentName, "1.0.0")
+	r.NoError(err, "1.0.0 must be retrievable after alias moved away")
+	r.Equal("1.0.0", got.Component.Version)
+
+	got, err = repo.GetComponentVersion(ctx, componentName, "2.0.0")
+	r.NoError(err, "2.0.0 must be retrievable")
+	r.Equal("2.0.0", got.Component.Version)
+
+	// Resources must be accessible through the alias
+	b, _, err := repo.GetLocalResource(ctx, componentName, "latest", map[string]string{
+		"name":    "test-resource",
+		"version": "2.0.0",
+	})
+	r.NoError(err, "resource should be accessible through alias")
+	r.NotNil(b)
+
+	// Chain alias through index-backed versions: latest -> stable
+	r.NoError(repo.AddComponentVersionAlias(ctx, componentName, "latest", "stable"))
+	got, err = repo.GetComponentVersion(ctx, componentName, "stable")
+	r.NoError(err)
+	r.Equal("2.0.0", got.Component.Version, "stable should resolve through latest to 2.0.0")
+}
+
+func TestRepository_ListComponentVersions_WithAliases(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	fs, err := filesystem.NewFS(t.TempDir(), os.O_RDWR)
+	r.NoError(err)
+	store := ocictf.NewFromCTF(ctf.NewFileSystemCTF(fs))
+	repo := Repository(t, ocictf.WithCTF(store))
+
+	componentName := "ocm.software/test-component"
+
+	makeDesc := func(version string) *descriptor.Descriptor {
+		return &descriptor.Descriptor{
+			Meta: descriptor.Meta{Version: "v2"},
+			Component: descriptor.Component{
+				Provider:      descriptor.Provider{Name: "test-provider"},
+				ComponentMeta: descriptor.ComponentMeta{ObjectMeta: descriptor.ObjectMeta{Name: componentName, Version: version}},
+			},
+		}
+	}
+
+	// Add three versions
+	r.NoError(repo.AddComponentVersion(ctx, makeDesc("1.0.0")))
+	r.NoError(repo.AddComponentVersion(ctx, makeDesc("2.0.0")))
+	r.NoError(repo.AddComponentVersion(ctx, makeDesc("3.0.0")))
+
+	// Create multiple aliases pointing to 1.0.0
+	r.NoError(repo.AddComponentVersionAlias(ctx, componentName, "1.0.0", "latest"))
+	r.NoError(repo.AddComponentVersionAlias(ctx, componentName, "1.0.0", "stable"))
+
+	// ListComponentVersions must return exactly the 3 unique versions, no duplicates from aliases
+	versions, err := repo.ListComponentVersions(ctx, componentName)
+	r.NoError(err)
+	r.Equal([]string{"3.0.0", "2.0.0", "1.0.0"}, versions,
+		"aliases must not produce duplicate entries in version listing")
+
+	// Move "latest" to 3.0.0 — listing should still show exactly 3 unique versions
+	r.NoError(repo.AddComponentVersionAlias(ctx, componentName, "3.0.0", "latest"))
+
+	versions, err = repo.ListComponentVersions(ctx, componentName)
+	r.NoError(err)
+	r.Equal([]string{"3.0.0", "2.0.0", "1.0.0"}, versions,
+		"moving an alias must not change the set of listed versions")
+}
+
+func TestRepository_AddComponentVersionAlias_RejectsSemverAlias(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	fs, err := filesystem.NewFS(t.TempDir(), os.O_RDWR)
+	r.NoError(err)
+	store := ocictf.NewFromCTF(ctf.NewFileSystemCTF(fs))
+	repo := Repository(t, ocictf.WithCTF(store))
+
+	componentName := "ocm.software/test-component"
+
+	makeDesc := func(version string) *descriptor.Descriptor {
+		return &descriptor.Descriptor{
+			Meta: descriptor.Meta{Version: "v2"},
+			Component: descriptor.Component{
+				Provider:      descriptor.Provider{Name: "test-provider"},
+				ComponentMeta: descriptor.ComponentMeta{ObjectMeta: descriptor.ObjectMeta{Name: componentName, Version: version}},
+			},
+		}
+	}
+
+	r.NoError(repo.AddComponentVersion(ctx, makeDesc("1.0.0")))
+	r.NoError(repo.AddComponentVersion(ctx, makeDesc("2.0.0")))
+
+	// Attempting to alias 1.0.0 as "2.0.0" should fail because "2.0.0" is semver-formatted
+	err = repo.AddComponentVersionAlias(ctx, componentName, "1.0.0", "2.0.0")
+	r.Error(err)
+	r.Contains(err.Error(), "uses semantic version format")
+
+	// Verify both versions are still independently accessible
+	got, err := repo.GetComponentVersion(ctx, componentName, "1.0.0")
+	r.NoError(err)
+	r.Equal("1.0.0", got.Component.Version)
+
+	got, err = repo.GetComponentVersion(ctx, componentName, "2.0.0")
+	r.NoError(err)
+	r.Equal("2.0.0", got.Component.Version)
+
+	// Both versions should be listed
+	versions, err := repo.ListComponentVersions(ctx, componentName)
+	r.NoError(err)
+	r.ElementsMatch([]string{"1.0.0", "2.0.0"}, versions)
+}
+
+func TestRepository_AddComponentVersionAlias_GetLocalResource(t *testing.T) {
+	r := require.New(t)
+	ctx := t.Context()
+
+	fs, err := filesystem.NewFS(t.TempDir(), os.O_RDWR)
+	r.NoError(err)
+	store := ocictf.NewFromCTF(ctf.NewFileSystemCTF(fs))
+	repo := Repository(t, ocictf.WithCTF(store))
+
+	componentName := "ocm.software/test-component"
+	resourceContent := []byte("hello from the resource layer")
+	contentDigest := digest.FromBytes(resourceContent)
+
+	desc := &descriptor.Descriptor{
+		Meta: descriptor.Meta{Version: "v2"},
+		Component: descriptor.Component{
+			Provider:      descriptor.Provider{Name: "test-provider"},
+			ComponentMeta: descriptor.ComponentMeta{ObjectMeta: descriptor.ObjectMeta{Name: componentName, Version: "1.0.0"}},
+		},
+	}
+
+	resource := &descriptor.Resource{
+		Relation: descriptor.LocalRelation,
+		ElementMeta: descriptor.ElementMeta{
+			ObjectMeta: descriptor.ObjectMeta{Name: "my-resource", Version: "1.0.0"},
+		},
+		Type: "plainData",
+		Access: &v2.LocalBlob{
+			LocalReference: contentDigest.String(),
+			MediaType:      ociImageSpecV1.MediaTypeImageLayer,
+		},
+	}
+	desc.Component.Resources = append(desc.Component.Resources, *resource)
+
+	newRes, err := repo.AddLocalResource(ctx, componentName, "1.0.0", resource, inmemory.New(bytes.NewReader(resourceContent)))
+	r.NoError(err)
+	desc.Component.Resources[0] = *newRes
+
+	r.NoError(repo.AddComponentVersion(ctx, desc))
+
+	// Alias 1.0.0 as "latest"
+	r.NoError(repo.AddComponentVersionAlias(ctx, componentName, "1.0.0", "latest"))
+
+	identity := map[string]string{"name": "my-resource", "version": "1.0.0"}
+
+	// GetLocalResource through the alias must return the correct content
+	blob, _, err := repo.GetLocalResource(ctx, componentName, "latest", identity)
+	r.NoError(err, "GetLocalResource through alias must succeed")
+	r.NotNil(blob)
+
+	reader, err := blob.ReadCloser()
+	r.NoError(err)
+	defer reader.Close()
+	downloaded, err := io.ReadAll(reader)
+	r.NoError(err)
+	r.Equal(resourceContent, downloaded, "content retrieved through alias must match original")
+
+	// GetLocalResource through the original version must still work
+	blob, _, err = repo.GetLocalResource(ctx, componentName, "1.0.0", identity)
+	r.NoError(err, "GetLocalResource through original version must still succeed")
+	r.NotNil(blob)
+
+	reader2, err := blob.ReadCloser()
+	r.NoError(err)
+	defer reader2.Close()
+	downloaded2, err := io.ReadAll(reader2)
+	r.NoError(err)
+	r.Equal(resourceContent, downloaded2, "content retrieved through original version must match")
+}
+
 func TestRepositoryHealthCheck(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
###   Summary

  Adds the ability to create aliases (additional tags) for existing component versions, similar to OCI tag behavior (e.g., tagging the same image as both v1.0.0 and latest).
  
  Also see https://github.com/open-component-model/ocm-project/issues/720.

 ###  Changes

  CTF Module (bindings/go/ctf)

  - index/v1/index.go: Modified AddArtifact to allow multiple entries with the same digest but different tags (OCI Image Layout-like behavior)
  - index/v1/index_test.go: Added tests for multi-tag scenarios, cross-repository isolation, and encode/decode roundtrip persistence

  OCI Module (bindings/go/oci)

  - interface.go: New AliasComponentVersionRepository interface with AddComponentVersionAlias method
  - repository.go: Implementation of AddComponentVersionAlias that tags existing manifests/indexes with new aliases
  - repository_test.go: tests covering aliasing, tag chaining, alias movement, and version immutability
  - ctf/store.go: Removed dead code (addOrUpdateArtifactMetadataInIndex was operating on a clone)
  - ctf/store_test.go: Updated test expectations for multi-tag behavior
 

  Compatibility Considerations

  CTF Index Format

  - Old CTF read by new code: Fully compatible
  - New CTF read by old code: Read operations work correctly
  - New CTF written by old code:  Old AddArtifact would overwrite tags on the same digest (potential data loss if mixing library versions writing to the same CTF)

  Key Design Decisions

  - Aliases are stored only in CTF's artifact-index.json / OCI registry tags
  - Manifest/index blobs are never modified - AnnotationVersion always contains the semantic version from the component descriptor
  - The aliasing feature only calls store.Tag(), ensuring content-addressable integrity

  Merge Order

  1. Merge CTF first: The multi-tag support is self-contained and backwards compatible for reads. The OCI module requires this change, but CTF works independently.
  2. Merge OCI second: Depends on the new CTF behavior for the aliasing feature to work correctly.