### PR TITLE
chore: add status description to deployer

### DIFF
--- a/kubernetes/controller/api/v1alpha1/deployer_types.go
+++ b/kubernetes/controller/api/v1alpha1/deployer_types.go
@@ -106,6 +106,8 @@ func (in *Deployer) GetEffectiveOCMConfig() []OCMConfiguration {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].message`,description="Indicates if the Deployer is Ready",priority=1
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Displays the Age of the Deployer"
 
 // Deployer is the Schema for the deployers API.
 type Deployer struct {

--- a/kubernetes/controller/chart/templates/crd/deployers.delivery.ocm.software.yaml
+++ b/kubernetes/controller/chart/templates/crd/deployers.delivery.ocm.software.yaml
@@ -14,7 +14,17 @@ spec:
         singular: deployer
     scope: Cluster
     versions:
-        - name: v1alpha1
+        - additionalPrinterColumns:
+            - description: Indicates if the Deployer is Ready
+              jsonPath: .status.conditions[?(@.type=="Ready")].message
+              name: Ready
+              priority: 1
+              type: string
+            - description: Displays the Age of the Deployer
+              jsonPath: .metadata.creationTimestamp
+              name: Age
+              type: date
+          name: v1alpha1
           schema:
             openAPIV3Schema:
                 description: Deployer is the Schema for the deployers API.

--- a/kubernetes/controller/config/crd/bases/delivery.ocm.software_deployers.yaml
+++ b/kubernetes/controller/config/crd/bases/delivery.ocm.software_deployers.yaml
@@ -14,7 +14,17 @@ spec:
     singular: deployer
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Indicates if the Deployer is Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Ready
+      priority: 1
+      type: string
+    - description: Displays the Age of the Deployer
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Deployer is the Schema for the deployers API.

--- a/kubernetes/controller/internal/controller/deployer/deployer_controller.go
+++ b/kubernetes/controller/internal/controller/deployer/deployer_controller.go
@@ -380,9 +380,8 @@ func (r *Reconciler) reconcileDeployment(ctx context.Context, deployer *delivery
 
 	updateDeployedObjectStatusReferences(objs, deployer)
 
-	// TODO: Status propagation of RGD status to deployer
-	//       (see https://github.com/open-component-model/ocm-k8s-toolkit/issues/192)
-	status.MarkReady(r.EventRecorder, deployer, "Applied version %s", resource.Status.Resource.Version)
+	status.MarkReady(r.EventRecorder, deployer, "Applied %s:%s, resource %s",
+		componentDescriptor.Component.Name, componentDescriptor.Component.Version, matchedResource.Name)
 
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

- Add printcolumn annotations (Ready, Age) to the Deployer CRD, consistent with the other CRDs (Resource, Component, Repository)
- Enrich the Ready condition message to include the component name and OCM resource name (e.g., Applied
  ocm.software/mycomponent:0.1.0, resource deploy-manifests) instead of just the version

