### PR TITLE
chore: correct depency cache by adding the right go.mod

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -75,6 +75,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: conformance/scenarios/sovereign/components/notes/go.mod
+          cache-dependency-path: conformance/scenarios/sovereign/components/notes/go.sum
       - name: Install Task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
         with:


### PR DESCRIPTION
On-behalf-of: Gerald Morrison (SAP) <gerald.morrison@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Correct depency cache by adding the right go.mod
  