### PR TITLE
chore: remove unused cli arguments

### DIFF
--- a/kubernetes/controller/chart/README.md
+++ b/kubernetes/controller/chart/README.md
@@ -65,8 +65,6 @@ Kubernetes: `>=1.26.0-0`
 | manager.affinity | object | `{}` | Pod affinity rules |
 | manager.cache.deployerDownloadMaxResourceSize | string | `"2Mi"` | Maximum size of a single downloadable resource as a Kubernetes resource.Quantity (e.g. "2Mi", "512Ki"). "0" disables the limit. |
 | manager.cache.deployerDownloadSize | int | `1000` | Maximum size of the deployer download object LRU cache |
-| manager.cache.ocmContextSize | int | `100` | Maximum number of active OCM contexts kept alive |
-| manager.cache.ocmSessionSize | int | `100` | Maximum number of active OCM sessions kept alive |
 | manager.concurrency.resource | int | `4` | Number of active resource controller workers |
 | manager.env | list | `[]` | Environment variables for the controller |
 | manager.extraArgs | list | `[]` | Extra arguments to pass to the controller |

--- a/kubernetes/controller/chart/templates/manager/manager.yaml
+++ b/kubernetes/controller/chart/templates/manager/manager.yaml
@@ -65,12 +65,6 @@ spec:
                     {{- end }}
                     {{- /* Cache */}}
                     {{- with .Values.manager.cache }}
-                    {{- if .ocmContextSize }}
-                    - --ocm-context-cache-size={{ .ocmContextSize }}
-                    {{- end }}
-                    {{- if .ocmSessionSize }}
-                    - --ocm-session-cache-size={{ .ocmSessionSize }}
-                    {{- end }}
                     {{- if .deployerDownloadSize }}
                     - --deployer-download-cache-size={{ .deployerDownloadSize }}
                     {{- end }}

--- a/kubernetes/controller/chart/values.schema.json
+++ b/kubernetes/controller/chart/values.schema.json
@@ -35,12 +35,6 @@
                         },
                         "deployerDownloadSize": {
                             "type": "integer"
-                        },
-                        "ocmContextSize": {
-                            "type": "integer"
-                        },
-                        "ocmSessionSize": {
-                            "type": "integer"
                         }
                     }
                 },

--- a/kubernetes/controller/chart/values.yaml
+++ b/kubernetes/controller/chart/values.yaml
@@ -27,10 +27,6 @@ manager:
     workerQueueLength: 1000
   ## Cache settings
   cache:
-    # -- Maximum number of active OCM contexts kept alive
-    ocmContextSize: 100
-    # -- Maximum number of active OCM sessions kept alive
-    ocmSessionSize: 100
     # -- Maximum size of the deployer download object LRU cache
     deployerDownloadSize: 1000
     # -- Maximum size of a single downloadable resource as a Kubernetes resource.Quantity (e.g. "2Mi", "512Ki"). "0" disables the limit.

--- a/kubernetes/controller/cmd/main.go
+++ b/kubernetes/controller/cmd/main.go
@@ -84,8 +84,6 @@ func main() {
 		enableHTTP2               bool
 		deployerDownloadCacheSize int
 		deployerMaxResourceSize   string
-		ocmContextCacheSize       int
-		ocmSessionCacheSize       int
 		resourceConcurrency       int
 		resolverWorkerCount       int
 		resolverWorkerQueueLength int
@@ -105,10 +103,6 @@ func main() {
 		"The maximum size of the deployer download object LRU cache.")
 	flag.StringVar(&deployerMaxResourceSize, "deployer-download-max-resource-size", defaultMaxResourceSize,
 		"Maximum size of a single downloadable resource as a Kubernetes resource.Quantity (e.g. \"2Mi\", \"512Ki\"). \"0\" disables the limit.")
-	flag.IntVar(&ocmContextCacheSize, "ocm-context-cache-size", 100, //nolint:mnd // no magic number
-		"The maximum size of the OCM context cache. This is the number of active OCM contexts that can be kept alive.")
-	flag.IntVar(&ocmSessionCacheSize, "ocm-session-cache-size", 100, //nolint:mnd // no magic number
-		"The maximum size of the OCM context cache. This is the number of active OCM sessions that can be kept alive.")
 	flag.IntVar(&resourceConcurrency, "resource-controller-concurrency", 4, //nolint:mnd // no magic number
 		"The resource controller concurrency. This is the number of active resource controller workers that can be kept alive.")
 	flag.IntVar(&resolverWorkerCount, "resolver-worker-count", 10, //nolint:mnd // no magic number


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Apparently, we forgot to remove unused CLI arguments. This PR fixes this.
