### PR TITLE
fix(website): add docsRepo to params.toml for commit link URL

### DIFF
--- a/website/config/_default/hugo.toml
+++ b/website/config/_default/hugo.toml
@@ -15,10 +15,6 @@ defaultContentLanguage = "en"
 disableLanguages = ["de", "nl"]
 defaultContentLanguageInSubdir = false
 
-repoHost = "GitHub"
-docsRepo = "https://github.com/open-component-model/open-component-model"
-docsRepoBranch = "main"
-docsRepoSubPath = "website"
 editPage = false
 lastMod = false
 

--- a/website/config/_default/params.toml
+++ b/website/config/_default/params.toml
@@ -63,6 +63,7 @@ mainSections = ["docs", "community"]
 
   # Repository
   repoHost = "GitHub" # GitHub (default), Gitea, GitLab, Bitbucket, or BitbucketServer
+  docsRepo = "https://github.com/open-component-model/open-component-model"
 
 # Debug
 [render_hooks.image]

--- a/website/config/_default/params.toml
+++ b/website/config/_default/params.toml
@@ -64,6 +64,8 @@ mainSections = ["docs", "community"]
   # Repository
   repoHost = "GitHub" # GitHub (default), Gitea, GitLab, Bitbucket, or BitbucketServer
   docsRepo = "https://github.com/open-component-model/open-component-model"
+  docsRepoBranch = "main"
+  docsRepoSubPath = "website"
 
 # Debug
 [render_hooks.image]


### PR DESCRIPTION
## Summary
- Footer commit link resolved to `ocm.software/commit/<hash>` (404) instead of GitHub
- Root cause: `docsRepo` in hugo.toml root level is not accessible via `site.Params.doks.docsRepo` in Hugo templates
- Fix: add `docsRepo` to `[doks]` section in params.toml where Doks theme expects it

Closes open-component-model/ocm-project#1017

## Verification
Built locally — commit link now correctly resolves to:
`https://github.com/open-component-model/open-component-model/commit/<hash>`

## Test plan
- [ ] Run `npm run build` in `website/`, check `public/index.html` for full GitHub commit URL
- [ ] Deploy preview footer link goes to GitHub, not ocm.software