### PR TITLE
fix(GHA): use inputs.ref for publish eligibility in cli.yml

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -2,6 +2,19 @@ name: CLI Release
 
 run-name: CLI Release from ${{ github.ref_name }}${{ github.event.inputs.dry_run == 'true' && '(dry-run)' || '' }}
 
+# Dispatch model:
+# The operator MUST select a release branch (e.g. releases/v0.4) in the
+# GitHub UI "Use workflow from" dropdown. This sets github.ref_name for
+# the entire run — there is no separate branch input.
+# parseBranch() in release-versioning.js validates the format and rejects
+# anything that doesn't match releases/v0.\d+.
+#
+# Interaction with cli.yml:
+# This workflow calls cli.yml via workflow_call. In that context,
+# github.ref_name in cli.yml inherits THIS workflow's ref (the release
+# branch), NOT the ref input we pass. We pass inputs.ref = the RC tag
+# (e.g. cli/v0.4.0-rc.1) so cli.yml checks out the right code AND uses
+# it to determine publish eligibility. See cli.yml's branch-check step.
 on:
   workflow_dispatch:
     inputs:
@@ -88,7 +101,11 @@ jobs:
             core.info(`✅ Created RC tag ${tag}`);
 
   # --------------------------------------------------------
-  # 3. BUILD CLI
+  # 3. BUILD CLI: calls cli.yml via workflow_call
+  #    ref = RC tag (e.g. cli/v0.4.0-rc.1) → used for checkout and publish eligibility.
+  #    Note: github.ref_name inside cli.yml will be the release branch (inherited from
+  #    this workflow), not the ref input. cli.yml's branch-check uses inputs.ref to
+  #    resolve this. See cli.yml for details.
   # --------------------------------------------------------
   build:
     name: Build CLI for ${{ needs.prepare.outputs.new_tag }}

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,11 +1,18 @@
 name: CLI
 
 on:
-  # Trigger workflow on pushes to main or release branches, and on PRs targeting main as well as release tags.
-  # Pushes on 'releases/v**' don't automatically publish,
-  # they just run the build to validate the release branch.
-  # If we are on a PR, limit runtime and only build the cli if it has been modified.
-  # If we are on a push, build the CLI regardless of what has changed to always be up to date.
+  # This workflow serves two roles:
+  #
+  # 1. CI workflow — triggered directly by push/PR events.
+  #    Pushes to main or cli/v* tags build AND publish (OCI image + conformance).
+  #    Pushes to releases/v* branches only build+test (no publish).
+  #    PRs to main only build+test if cli/ files changed.
+  #
+  # 2. Reusable build step — called by cli-release.yml via workflow_call.
+  #    cli-release.yml passes inputs.ref = the RC tag (e.g. cli/v0.4.0-rc.1).
+  #    IMPORTANT: github.ref_name inside this workflow inherits the CALLER's ref
+  #    (the release branch, e.g. releases/v0.4), not inputs.ref. The branch-check
+  #    step uses inputs.ref when set to correctly determine publish eligibility.
   push:
     branches:
       - main
@@ -131,11 +138,18 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           subject-path: "${{ env.LOCATION }}/tmp/bin/ocm-*"
 
-      # Determine if this build is eligible for publishing.
-      # Direct triggers: publish on main push or cli/v* tag push.
-      # Release branches (releases/v*) only build+test on direct push.
-      # workflow_call from cli-release.yml: inputs.ref carries the RC tag
-      # (e.g. cli/v0.4.0-rc.1), which matches the cli/v* pattern.
+      # Determine if this build should publish (push OCI image to GHCR).
+      #
+      # Uses inputs.ref when set (workflow_call from cli-release.yml), otherwise
+      # GITHUB_REF_NAME. This distinction matters because workflow_call inherits
+      # the caller's github.ref_name (the release branch), not our inputs.ref.
+      #
+      # Publish eligibility:
+      #   push to main              → GITHUB_REF_NAME = "main"            → yes (default branch)
+      #   push tag cli/v0.4.0       → GITHUB_REF_NAME = "cli/v0.4.0"     → yes (cli/v* match)
+      #   push to releases/v0.4     → GITHUB_REF_NAME = "releases/v0.4"  → no  (build-only)
+      #   workflow_call (release)    → inputs.ref = "cli/v0.4.0-rc.1"     → yes (cli/v* match)
+      #   pull_request              → step skipped entirely               → no
       - name: Determine if this is a push-eligible branch
         if: ${{ github.event_name != 'pull_request' }}
         id: branch-check

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -131,18 +131,24 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           subject-path: "${{ env.LOCATION }}/tmp/bin/ocm-*"
 
-      # Determine if this branch is eligible for publishing, but only if we're not on a PR.
-      # Release branches (releases/v*) only build+test; publish happens on main or release tags.
+      # Determine if this build is eligible for publishing.
+      # Direct triggers: publish on main push or cli/v* tag push.
+      # Release branches (releases/v*) only build+test on direct push.
+      # workflow_call from cli-release.yml: inputs.ref carries the RC tag
+      # (e.g. cli/v0.4.0-rc.1), which matches the cli/v* pattern.
       - name: Determine if this is a push-eligible branch
         if: ${{ github.event_name != 'pull_request' }}
         id: branch-check
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          INPUT_REF: ${{ inputs.ref }}
         with:
           script: |
+            const ref = process.env.INPUT_REF || process.env.GITHUB_REF_NAME;
             core.setOutput(
               "should_push_oci_image",
-              process.env.GITHUB_REF_NAME === context.payload.repository.default_branch ||
-              /^cli\/v\d+\.\d+(\.\d+)?(-.*)?$/.test(process.env.GITHUB_REF_NAME)
+              ref === context.payload.repository.default_branch ||
+              /^cli\/v\d+\.\d+(\.\d+)?(-.*)?$/.test(ref)
             )
 
       # Upload CLI binaries and OCI layout as build artifacts

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -142,9 +142,9 @@ Once created, only bug fixes and documentation changes are allowed.
 Release candidates are created for both components sequentially, in lock-step.
 
 1. Run workflow **[CLI Release](https://github.com/open-component-model/open-component-model/actions/workflows/cli-release.yml)** with:
+   - **"Use workflow from"** set to the release branch created in step 1 (e.g., `releases/v0.17`)
    - `dry_run = true` first to validate
    - `dry_run = false` for actual release
-   - `Branch to release from` set to the release branch created in step 1 (e.g., `releases/v0.17`)
 2. Run workflow **[Controller Release](https://github.com/open-component-model/open-component-model/actions/workflows/controller-release.yml)** with equivalent inputs.
 3. Verify both pre-releases were created successfully on the GitHub Releases page.
    - CLI assets: platform binaries (`ocm-*`) and OCI tarballs


### PR DESCRIPTION
## Summary

- **Fix publish gating in `cli.yml`**: When called via `workflow_call` from `cli-release.yml`, `GITHUB_REF_NAME` inherits the caller's ref (`releases/v0.4`) instead of the RC tag (`cli/v0.4.0-rc.1`). The `should_push_oci_image` check only matched `main` or `cli/v*`, so the Publish and Attest job was skipped for releases dispatched from release branches. Now uses `inputs.ref` when available.
- **Update `RELEASE_PROCESS.md`**: Replace stale "Branch to release from" input reference with the "Use workflow from" branch selector, matching the workflow change in #2131.

## Root Cause

After #2131 removed the explicit `branch` text input from `cli-release.yml`, the operator must select the `releases/v*` branch in the GitHub UI "Use workflow from" dropdown. This sets `GITHUB_REF_NAME = "releases/v0.4"` for the entire call chain.

`cli.yml`'s branch-check (`should_push_oci_image`) tests `GITHUB_REF_NAME` against:
1. Default branch (`main`) — no match
2. `cli/v*` tag pattern — no match

Result: Publish and Attest skipped → Conformance skipped.

The v0.3 release worked because the old workflow was dispatched from `main` (the text input carried the branch separately), so `GITHUB_REF_NAME = "main"` matched condition 1.

## Fix

Use `inputs.ref` (the RC tag, e.g. `cli/v0.4.0-rc.1`) when present, fall back to `GITHUB_REF_NAME` for direct triggers. The RC tag matches the `cli/v*` pattern, enabling publish.

| Trigger | `inputs.ref` | Effective ref | Publishes |
|---------|-------------|---------------|-----------|
| `workflow_call` from `cli-release.yml` | `cli/v0.4.0-rc.1` | `cli/v0.4.0-rc.1` | Yes |
| Push to `main` | empty | `main` | Yes |
| Push tag `cli/v0.4.0` | empty | `cli/v0.4.0` | Yes |
| Push to `releases/v0.4` | empty | `releases/v0.4` | No (build-only) |
| Pull request | n/a | step skipped | No |

## Test plan

- [ ] Verify the v0.4 release workflow can be re-run successfully from `releases/v0.4` after this change is cherry-picked
- [ ] Dry-run a CLI release from a release branch to confirm Publish and Attest job is no longer skipped