### PR TITLE
chore: descriptor - rename in tests: localBlob type to LocalBlob UpperCamelCase [1/4]

### DIFF
--- a/bindings/go/descriptor/v2/helpers_test.go
+++ b/bindings/go/descriptor/v2/helpers_test.go
@@ -9,76 +9,81 @@ import (
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
-func TestIsLocalBlob_Nil(t *testing.T) {
-	assert.False(t, descriptorv2.IsLocalBlob(nil))
-}
-
-func TestIsLocalBlob_LocalBlobStruct(t *testing.T) {
-	blob := &descriptorv2.LocalBlob{
-		Type: runtime.Type{
-			Name:    descriptorv2.LocalBlobAccessType,
-			Version: descriptorv2.LocalBlobAccessTypeVersion,
+func TestIsLocalBlob(t *testing.T) {
+	cases := []struct {
+		name  string
+		input runtime.Typed
+		want  bool
+	}{
+		{"nil", nil, false},
+		{
+			"LocalBlob struct",
+			&descriptorv2.LocalBlob{
+				Type: runtime.Type{
+					Name:    descriptorv2.LocalBlobAccessType,
+					Version: descriptorv2.LocalBlobAccessTypeVersion,
+				},
+				LocalReference: "sha256:abc123",
+				MediaType:      "application/octet-stream",
+			},
+			true,
 		},
-		LocalReference: "sha256:abc123",
-		MediaType:      "application/octet-stream",
-	}
-
-	assert.True(t, descriptorv2.IsLocalBlob(blob))
-}
-
-func TestIsLocalBlob_Raw(t *testing.T) {
-	raw := &runtime.Raw{
-		Type: runtime.Type{
-			Name:    descriptorv2.LocalBlobAccessType,
-			Version: descriptorv2.LocalBlobAccessTypeVersion,
+		{
+			"raw LocalBlob",
+			&runtime.Raw{
+				Type: runtime.Type{
+					Name:    descriptorv2.LocalBlobAccessType,
+					Version: descriptorv2.LocalBlobAccessTypeVersion,
+				},
+				Data: []byte(`{"type":"LocalBlob/v1","localReference":"sha256:abc123","mediaType":"application/octet-stream","globalAccess":{"type":"ociArtifact","imageReference":"test/image:1.0"},"referenceName":"test/repo:1.0"}`),
+			},
+			true,
 		},
-		Data: []byte(`{"type":"LocalBlob/v1","localReference":"sha256:abc123","mediaType":"application/octet-stream","globalAccess":{"type":"ociArtifact","imageReference":"test/image:1.0"},"referenceName":"test/repo:1.0"}`),
-	}
-
-	assert.True(t, descriptorv2.IsLocalBlob(raw))
-}
-
-func TestIsLocalBlob_RawOCIArtifact(t *testing.T) {
-	raw := &runtime.Raw{
-		Type: runtime.Type{
-			Name:    "ociArtifact",
-			Version: "v1",
+		{
+			"raw ociArtifact",
+			&runtime.Raw{
+				Type: runtime.Type{
+					Name:    "ociArtifact",
+					Version: "v1",
+				},
+				Data: []byte(`{"type":"ociArtifact/v1","imageReference":"ghcr.io/example/image:v1"}`),
+			},
+			false,
 		},
-		Data: []byte(`{"type":"ociArtifact/v1","imageReference":"ghcr.io/example/image:v1"}`),
-	}
-
-	assert.False(t, descriptorv2.IsLocalBlob(raw))
-}
-
-func TestIsLocalBlob_RawLegacy(t *testing.T) {
-	raw := &runtime.Raw{
-		Type: runtime.Type{
-			Name:    descriptorv2.LegacyLocalBlobAccessType,
-			Version: descriptorv2.LocalBlobAccessTypeVersion,
+		{
+			"raw legacy localBlob",
+			&runtime.Raw{
+				Type: runtime.Type{
+					Name:    descriptorv2.LegacyLocalBlobAccessType,
+					Version: descriptorv2.LocalBlobAccessTypeVersion,
+				},
+				Data: []byte(`{"type":"localBlob/v1","localReference":"sha256:abc123","mediaType":"application/octet-stream"}`),
+			},
+			true,
 		},
-		Data: []byte(`{"type":"localBlob/v1","localReference":"sha256:abc123","mediaType":"application/octet-stream"}`),
-	}
-
-	assert.True(t, descriptorv2.IsLocalBlob(raw))
-}
-
-func TestIsLocalBlob_RawUnknownType(t *testing.T) {
-	raw := &runtime.Raw{
-		Type: runtime.Type{
-			Name:    "unknownAccessType",
-			Version: "v1",
+		{
+			"raw unknown type",
+			&runtime.Raw{
+				Type: runtime.Type{
+					Name:    "unknownAccessType",
+					Version: "v1",
+				},
+				Data: []byte(`{"type":"unknownAccessType/v1","foo":"bar"}`),
+			},
+			false,
 		},
-		Data: []byte(`{"type":"unknownAccessType/v1","foo":"bar"}`),
+		{
+			"raw empty type",
+			&runtime.Raw{
+				Type: runtime.Type{},
+				Data: []byte(`{}`),
+			},
+			false,
+		},
 	}
-
-	assert.False(t, descriptorv2.IsLocalBlob(raw))
-}
-
-func TestIsLocalBlob_RawEmptyType(t *testing.T) {
-	raw := &runtime.Raw{
-		Type: runtime.Type{},
-		Data: []byte(`{}`),
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, descriptorv2.IsLocalBlob(tc.input))
+		})
 	}
-
-	assert.False(t, descriptorv2.IsLocalBlob(raw))
 }

--- a/bindings/go/descriptor/v2/local_access_test.go
+++ b/bindings/go/descriptor/v2/local_access_test.go
@@ -118,8 +118,41 @@ func TestLocalBlob_UnmarshalJSON_Minimal(t *testing.T) {
 	assert.Empty(t, blob.ReferenceName)
 }
 
+func TestLocalBlob_UnmarshalJSON_UnversionedUpperCamelCase(t *testing.T) {
+	jsonData := `{
+		"type": "LocalBlob",
+		"localReference": "sha256:abc123",
+		"mediaType": "application/octet-stream"
+	}`
+
+	var blob descriptorv2.LocalBlob
+	err := json.Unmarshal([]byte(jsonData), &blob)
+
+	require.NoError(t, err)
+	assert.Equal(t, descriptorv2.LocalBlobAccessType, blob.Type.Name)
+	assert.Empty(t, blob.Type.Version)
+	assert.Equal(t, "sha256:abc123", blob.LocalReference)
+	assert.Equal(t, "application/octet-stream", blob.MediaType)
+}
+
+func TestLocalBlob_UnmarshalJSON_UnversionedLegacy(t *testing.T) {
+	jsonData := `{
+		"type": "localBlob",
+		"localReference": "sha256:abc123",
+		"mediaType": "application/octet-stream"
+	}`
+
+	var blob descriptorv2.LocalBlob
+	err := json.Unmarshal([]byte(jsonData), &blob)
+
+	require.NoError(t, err)
+	assert.Equal(t, descriptorv2.LegacyLocalBlobAccessType, blob.Type.Name)
+	assert.Empty(t, blob.Type.Version)
+	assert.Equal(t, "sha256:abc123", blob.LocalReference)
+	assert.Equal(t, "application/octet-stream", blob.MediaType)
+}
+
 func TestLocalBlob_Constants(t *testing.T) {
-	// Test access type constants
 	assert.Equal(t, "LocalBlob", descriptorv2.LocalBlobAccessType)
 	assert.Equal(t, "localBlob", descriptorv2.LegacyLocalBlobAccessType)
 	assert.Equal(t, "v1", descriptorv2.LocalBlobAccessTypeVersion)

--- a/bindings/go/descriptor/v2/scheme_test.go
+++ b/bindings/go/descriptor/v2/scheme_test.go
@@ -9,34 +9,22 @@ import (
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
-func TestScheme_ResolvesUpperCamelCase_LocalBlob(t *testing.T) {
-	obj, err := descriptorv2.Scheme.NewObject(
-		runtime.NewVersionedType(descriptorv2.LocalBlobAccessType, descriptorv2.LocalBlobAccessTypeVersion),
-	)
-	require.NoError(t, err, "Scheme must resolve UpperCamelCase type LocalBlob/v1")
-	require.IsType(t, &descriptorv2.LocalBlob{}, obj, "expected *LocalBlob from Scheme")
-}
+func TestScheme_ResolvesAllLocalBlobAliases(t *testing.T) {
+	tests := []struct {
+		name string
+		typ  runtime.Type
+	}{
+		{"versioned", runtime.NewVersionedType(descriptorv2.LocalBlobAccessType, descriptorv2.LocalBlobAccessTypeVersion)},
+		{"unversioned", runtime.NewUnversionedType(descriptorv2.LocalBlobAccessType)},
+		{"legacy versioned", runtime.NewVersionedType(descriptorv2.LegacyLocalBlobAccessType, descriptorv2.LocalBlobAccessTypeVersion)},
+		{"legacy unversioned", runtime.NewUnversionedType(descriptorv2.LegacyLocalBlobAccessType)},
+	}
 
-func TestScheme_ResolvesLegacy_LocalBlob(t *testing.T) {
-	obj, err := descriptorv2.Scheme.NewObject(
-		runtime.NewVersionedType(descriptorv2.LegacyLocalBlobAccessType, descriptorv2.LocalBlobAccessTypeVersion),
-	)
-	require.NoError(t, err, "Scheme must resolve legacy type localBlob/v1")
-	require.IsType(t, &descriptorv2.LocalBlob{}, obj, "expected *LocalBlob from Scheme")
-}
-
-func TestScheme_ResolvesUnversioned_LocalBlob(t *testing.T) {
-	obj, err := descriptorv2.Scheme.NewObject(
-		runtime.NewUnversionedType(descriptorv2.LocalBlobAccessType),
-	)
-	require.NoError(t, err, "Scheme must resolve unversioned LocalBlob")
-	require.IsType(t, &descriptorv2.LocalBlob{}, obj, "expected *LocalBlob from Scheme")
-}
-
-func TestScheme_ResolvesUnversionedLegacy_LocalBlob(t *testing.T) {
-	obj, err := descriptorv2.Scheme.NewObject(
-		runtime.NewUnversionedType(descriptorv2.LegacyLocalBlobAccessType),
-	)
-	require.NoError(t, err, "Scheme must resolve unversioned legacy localBlob")
-	require.IsType(t, &descriptorv2.LocalBlob{}, obj, "expected *LocalBlob from Scheme")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj, err := descriptorv2.Scheme.NewObject(tt.typ)
+			require.NoError(t, err)
+			require.IsType(t, &descriptorv2.LocalBlob{}, obj)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Test-only cleanup for the `localBlob` → `LocalBlob` UpperCamelCase rename. The production code, generated schemas, and original test changes from the initial scope already landed in `main` via rebase.

Absorbs #2388 (table-driven `IsLocalBlob` refactor) into this PR.

## Changes

**`descriptor/v2/local_access_test.go`**
- Add `TestLocalBlob_UnmarshalJSON_UnversionedUpperCamelCase` — covers unversioned `"LocalBlob"` type string
- Add `TestLocalBlob_UnmarshalJSON_UnversionedLegacy` — covers unversioned `"localBlob"` type string
- Remove stale comment in `TestLocalBlob_Constants`

**`descriptor/v2/scheme_test.go`**
- Consolidate 4 separate `TestScheme_Resolves*_LocalBlob` functions into one table-driven `TestScheme_ResolvesAllLocalBlobAliases`

**`descriptor/v2/helpers_test.go`** *(from #2388)*
- Consolidate 7 separate `TestIsLocalBlob_*` functions into one table-driven `TestIsLocalBlob`

## Context

This is part 1 of the `localBlob` rename series (ocm-project/ocm-project#962). Follow-up PRs:
- #2324 — constructor YAML fixtures (merged)
- #2325 — CLI string assertions
- #2326 — controller JSON type strings + CEL test (merged)

Closes #2388.