### PR TITLE
fix: link to sign and verify section in the tutorials

### DIFF
--- a/website/content/blog/ocm_v2_announcement.md
+++ b/website/content/blog/ocm_v2_announcement.md
@@ -61,7 +61,7 @@ The v2 CLI implements the full **Pack, Sign, Transport, Deploy** workflow:
 
 {{< card-grid >}}
 {{< link-card title="Pack" href="/docs/getting-started/create-component-versions/" description="Bundle software artifacts into component versions." >}}
-{{< link-card title="Sign" href="/docs/tutorials/sign-and-verify-components/" description="Establish provenance with RSA-based PKI signatures." >}}
+{{< link-card title="Sign" href="/docs/tutorials/signing/" description="Establish provenance with RSA-based PKI signatures." >}}
 {{< link-card title="Transport" href="/docs/concepts/transfer-and-transport/" description="Move components between registries or across air gaps." >}}
 {{< link-card title="Deploy" href="/docs/getting-started/deploy-helm-charts/" description="Deploy applications using OCM controllers." >}}
 {{< /card-grid >}}
@@ -274,7 +274,7 @@ Ready to try OCM v2? Pick your path:
 {{< step >}}
 **Sign and Verify**
 
-[Establish provenance with RSA signatures](/docs/tutorials/sign-and-verify-components/)
+[Establish provenance with RSA signatures](/docs/tutorials/signing/)
 {{< /step >}}
 {{< step >}}
 **Transfer across an Air Gap**


### PR DESCRIPTION
#### What this PR does / why we need it

https://ocm.software/blog/ocmv2/ link here:
```
Sign and Verify

[Establish provenance with RSA signatures](https://ocm.software/docs/tutorials/sign-and-verify-components/)
```

Is not correct.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Testing

##### How to test the changes

<!--
Required files to test the changes:

.ocmconfig
```yaml
type: generic.config.ocm.software/v1
configurations:
  - type: credentials.config.ocm.software
    repositories:
      - repository:
          type: DockerConfig/v1
          dockerConfigFile: "~/.docker/config.json"
```

Commands that test the change:

```bash
ocm get cv xxx

ocm transfer xxx
```
-->

##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
