### PR TITLE
fix: use amd64 runner

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -41,7 +41,9 @@ jobs:
 
   verify-links:
     name: Verify links (repo)
-    runs-on: ubuntu-24.04-arm
+    # action-linkspector uses Puppeteer, which downloads an x86-only Chrome
+    # binary on ARM runners — run on amd64 until upstream ships ARM support.
+    runs-on: ubuntu-latest
     permissions:
       checks: write
       contents: read
@@ -60,7 +62,8 @@ jobs:
 
   verify-links-website:
     name: Verify links (website)
-    runs-on: ubuntu-24.04-arm
+    # action-linkspector uses Puppeteer (see verify-links comment above).
+    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     permissions:
       checks: write


### PR DESCRIPTION
#### What this PR does / why we need it

Switches the `verify-links` and `verify-links-website` CI jobs from `ubuntu-24.04-arm` to `ubuntu-latest` (amd64).

The `action-linkspector` action uses Puppeteer to launch Chrome for link checking. On ARM runners, Puppeteer downloads a Chrome package that contains an incompatible binary (`chrome-linux64` inside a `linux_arm` path), causing the job to fail with:

```
💥 Main error: Failed to launch the browser process:
chrome: 1: Syntax error: redirection unexpected
```

This is the same class of issue that the `spellcheck` job already works around (amd64-only Docker image).