### PR TITLE
fix: use unused values from the helm values section

### DIFF
--- a/kubernetes/controller/chart/README.md
+++ b/kubernetes/controller/chart/README.md
@@ -97,8 +97,6 @@ Kubernetes: `>=1.26.0-0`
 | manager.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resource limits and requests |
 | manager.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | Container-level security context |
 | manager.tolerations | list | `[]` | Pod tolerations |
-| metrics.enable | bool | `false` | Enable metrics endpoint with RBAC protection |
-| metrics.port | int | `8443` | Metrics server port |
 | prometheus.enable | bool | `false` | Enable Prometheus ServiceMonitor (requires prometheus-operator) |
 | rbacHelpers.enable | bool | `false` | Install convenience admin/editor/viewer roles for CRDs |
 | webhook.certSecret | string | `""` | Secret name for webhook TLS certificates (when not using cert-manager, create this secret manually) |

--- a/kubernetes/controller/chart/templates/crd/components.delivery.ocm.software.yaml
+++ b/kubernetes/controller/chart/templates/crd/components.delivery.ocm.software.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.1
+    {{- if .Values.crd.keep }}
+    helm.sh/resource-policy: keep
+    {{- end }}
     {{- if and .Values.webhook.enable .Values.certManager.enable }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "serving-cert" "context" $) }}
     {{- end }}

--- a/kubernetes/controller/chart/templates/crd/deployers.delivery.ocm.software.yaml
+++ b/kubernetes/controller/chart/templates/crd/deployers.delivery.ocm.software.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.1
+    {{- if .Values.crd.keep }}
+    helm.sh/resource-policy: keep
+    {{- end }}
     {{- if and .Values.webhook.enable .Values.certManager.enable }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "serving-cert" "context" $) }}
     {{- end }}

--- a/kubernetes/controller/chart/templates/crd/repositories.delivery.ocm.software.yaml
+++ b/kubernetes/controller/chart/templates/crd/repositories.delivery.ocm.software.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.1
+    {{- if .Values.crd.keep }}
+    helm.sh/resource-policy: keep
+    {{- end }}
     {{- if and .Values.webhook.enable .Values.certManager.enable }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "serving-cert" "context" $) }}
     {{- end }}

--- a/kubernetes/controller/chart/templates/crd/resources.delivery.ocm.software.yaml
+++ b/kubernetes/controller/chart/templates/crd/resources.delivery.ocm.software.yaml
@@ -4,6 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.20.1
+    {{- if .Values.crd.keep }}
+    helm.sh/resource-policy: keep
+    {{- end }}
     {{- if and .Values.webhook.enable .Values.certManager.enable }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "serving-cert" "context" $) }}
     {{- end }}

--- a/kubernetes/controller/chart/templates/manager/manager.yaml
+++ b/kubernetes/controller/chart/templates/manager/manager.yaml
@@ -10,7 +10,7 @@ metadata:
     name: {{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "controller-manager" "context" $) }}
     namespace: {{ .Release.Namespace }}
 spec:
-    replicas: 1
+    replicas: {{ .Values.manager.replicas }}
     selector:
         matchLabels:
             app.kubernetes.io/name: {{ include "ocm-k8s-toolkit.name" . }}
@@ -33,6 +33,9 @@ spec:
             {{- end }}
             {{- with .Values.manager.nodeSelector }}
             nodeSelector: {{ toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.manager.imagePullSecrets }}
+            imagePullSecrets: {{ toYaml . | nindent 16 }}
             {{- end }}
             containers:
                 - args:
@@ -99,6 +102,9 @@ spec:
                     - /manager
                   image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
                   imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
+                  {{- with .Values.manager.env }}
+                  env: {{ toYaml . | nindent 20 }}
+                  {{- end }}
                   livenessProbe:
                     httpGet:
                         path: {{ .Values.manager.livenessProbe.path }}

--- a/kubernetes/controller/chart/templates/manager/manager.yaml
+++ b/kubernetes/controller/chart/templates/manager/manager.yaml
@@ -1,3 +1,6 @@
+{{- if and (gt (int .Values.manager.replicas) 1) (not .Values.manager.leaderElection.enabled) }}
+{{- fail "manager.replicas > 1 requires manager.leaderElection.enabled=true to prevent concurrent reconcilers from racing on the same resources" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/kubernetes/controller/chart/values.schema.json
+++ b/kubernetes/controller/chart/values.schema.json
@@ -226,17 +226,6 @@
                 }
             }
         },
-        "metrics": {
-            "type": "object",
-            "properties": {
-                "enable": {
-                    "type": "boolean"
-                },
-                "port": {
-                    "type": "integer"
-                }
-            }
-        },
         "prometheus": {
             "type": "object",
             "properties": {

--- a/kubernetes/controller/chart/values.yaml
+++ b/kubernetes/controller/chart/values.yaml
@@ -115,12 +115,6 @@ crd:
   enable: true
   # -- Keep CRDs when uninstalling
   keep: true
-## Controller metrics endpoint
-metrics:
-  # -- Enable metrics endpoint with RBAC protection
-  enable: false
-  # -- Metrics server port
-  port: 8443
 ## Webhook configuration
 webhook:
   # -- Enable conversion webhook for CRD version conversion

--- a/kubernetes/controller/hack/helm.generate.sh
+++ b/kubernetes/controller/hack/helm.generate.sh
@@ -46,6 +46,9 @@ for src in "${SRC_DIR}"/*.yaml; do
         echo "{{- if .Values.crd.enable }}"
         sed -e '1{/^---$/d;}' \
             -e '/^    controller-gen\.kubebuilder\.io\/version:/a\
+    {{- if .Values.crd.keep }}\
+    helm.sh/resource-policy: keep\
+    {{- end }}\
     {{- if and .Values.webhook.enable .Values.certManager.enable }}\
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "ocm-k8s-toolkit.resourceName" (dict "suffix" "serving-cert" "context" $) }}\
     {{- end }}' \


### PR DESCRIPTION
#### What this PR does / why we need it

Notices during an investigation on the attached issue that we have a couple of values in values.yaml that aren't using in the deployment template.

#### Which issue(s) this PR fixes

Part of https://github.com/open-component-model/service-provider-ocm/issues/95.

#### Testing

##### How to test the changes

<!--
Required files to test the changes:

.ocmconfig
```yaml
type: generic.config.ocm.software/v1
configurations:
  - type: credentials.config.ocm.software
    repositories:
      - repository:
          type: DockerConfig/v1
          dockerConfigFile: "~/.docker/config.json"
```

Commands that test the change:

```bash
ocm get cv xxx

ocm transfer xxx
```
-->

##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
