### PR TITLE
fix(website): adjust ignore for netlify preview

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -3,7 +3,7 @@
   NPM_VERSION = "11.11.1"
 
 [build]
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- ."
+  ignore = "git diff --quiet origin/main HEAD -- ."
 
 [context.deploy-preview]
   command = "npm ci && npm run build -- --baseURL=$DEPLOY_PRIME_URL --buildDrafts --buildFuture"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Fix Netlify deploy previews being canceled with "no content change" on new PR branches.

The previous `ignore` command used `$CACHED_COMMIT_REF` which equals `$COMMIT_REF` when no prior build cache exists, making `git diff` compare a commit to itself — always zero diff, always skipped.

Replace with `git diff --quiet origin/main HEAD -- .` which directly compares the PR branch against main.

#### Context

Observed on #2366 — a docs-only PR modifying `website/content/` files, yet the deploy preview was canceled:
> Failed during stage 'checking build content for changes': Canceled build due to no content change

#### Which issue(s) this PR fixes

Fixes the Netlify deploy preview not building for #2366.