### PR TITLE
fix: add legacy snake_case credential key constants with fallback

### DIFF
--- a/bindings/go/oci/credentials/docker_config.go
+++ b/bindings/go/oci/credentials/docker_config.go
@@ -28,6 +28,13 @@ const (
 	CredentialKeyAccessToken = "accessToken"
 	// CredentialKeyRefreshToken is the key for storing refresh token credentials
 	CredentialKeyRefreshToken = "refreshToken"
+
+	// LegacyCredentialKeyAccessToken is the legacy snake_case key for access tokens.
+	// Deprecated: Use CredentialKeyAccessToken instead.
+	LegacyCredentialKeyAccessToken = "access_token"
+	// LegacyCredentialKeyRefreshToken is the legacy snake_case key for refresh tokens.
+	// Deprecated: Use CredentialKeyRefreshToken instead.
+	LegacyCredentialKeyRefreshToken = "refresh_token"
 )
 
 // CredentialFunc creates a function that returns credentials based on host and port matching.
@@ -62,10 +69,15 @@ func CredentialFunc(identity runtime.Identity, credentials map[string]string) au
 	if v, ok := credentials[CredentialKeyPassword]; ok {
 		credential.Password = v
 	}
+	// Support the canonical camelCase key first, fall back to legacy snake_case for backward compatibility.
 	if v, ok := credentials[CredentialKeyAccessToken]; ok {
+		credential.AccessToken = v
+	} else if v, ok := credentials[LegacyCredentialKeyAccessToken]; ok {
 		credential.AccessToken = v
 	}
 	if v, ok := credentials[CredentialKeyRefreshToken]; ok {
+		credential.RefreshToken = v
+	} else if v, ok := credentials[LegacyCredentialKeyRefreshToken]; ok {
 		credential.RefreshToken = v
 	}
 	registeredHostname, hostInIdentity := identity[runtime.IdentityAttributeHostname]

--- a/bindings/go/oci/credentials/docker_config_test.go
+++ b/bindings/go/oci/credentials/docker_config_test.go
@@ -19,6 +19,7 @@ func TestCredentialFunc(t *testing.T) {
 		hostport    string
 		wantErr     bool
 		wantEmpty   bool
+		wantCred    *auth.Credential // if set, assert exact credential match
 	}{
 		{
 			name: "matching host and port",
@@ -89,6 +90,38 @@ func TestCredentialFunc(t *testing.T) {
 			wantErr:   false,
 			wantEmpty: false,
 		},
+		{
+			name: "legacy snake_case token keys",
+			identity: runtime.Identity{
+				runtime.IdentityAttributeHostname: "example.com",
+			},
+			credentials: map[string]string{
+				LegacyCredentialKeyAccessToken:  "snake-access",
+				LegacyCredentialKeyRefreshToken: "snake-refresh",
+			},
+			hostport: "example.com",
+			wantCred: &auth.Credential{
+				AccessToken:  "snake-access",
+				RefreshToken: "snake-refresh",
+			},
+		},
+		{
+			name: "camelCase takes precedence over snake_case",
+			identity: runtime.Identity{
+				runtime.IdentityAttributeHostname: "example.com",
+			},
+			credentials: map[string]string{
+				CredentialKeyAccessToken:  "camel-access",
+				LegacyCredentialKeyAccessToken:           "snake-access",
+				CredentialKeyRefreshToken: "camel-refresh",
+				LegacyCredentialKeyRefreshToken:          "snake-refresh",
+			},
+			hostport: "example.com",
+			wantCred: &auth.Credential{
+				AccessToken:  "camel-access",
+				RefreshToken: "camel-refresh",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -104,6 +137,11 @@ func TestCredentialFunc(t *testing.T) {
 			require.NoError(t, err)
 			if tt.wantEmpty {
 				assert.Equal(t, auth.EmptyCredential, cred)
+				return
+			}
+
+			if tt.wantCred != nil {
+				assert.Equal(t, *tt.wantCred, cred)
 				return
 			}
 


### PR DESCRIPTION
#### What this PR does / why we need it

Adds `LegacyCredentialKeyAccessToken` (`access_token`) and `LegacyCredentialKeyRefreshToken` (`refresh_token`) as deprecated constants in the credentials package, and updates `CredentialFunc()` to accept both camelCase (canonical) and snake_case (legacy) token keys.

This is the credential binding portion of the fix for the `accessToken`/`access_token` key mismatch. The resource repository binding changes depend on these constants and are in #2383.

#### Which issue(s) this PR fixes

Part of open-component-model/ocm-project#985
Dependency of #2383

#### Testing

##### How to test the changes

Run credential binding tests:
```bash
go test ./bindings/go/oci/credentials/...
```

##### Verification

- [x] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [x] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [x] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`