### PR TITLE
chore: table-driven tests as follow-up to #2324

### DIFF
--- a/bindings/go/descriptor/v2/helpers_test.go
+++ b/bindings/go/descriptor/v2/helpers_test.go
@@ -9,76 +9,81 @@ import (
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
-func TestIsLocalBlob_Nil(t *testing.T) {
-	assert.False(t, descriptorv2.IsLocalBlob(nil))
-}
-
-func TestIsLocalBlob_LocalBlobStruct(t *testing.T) {
-	blob := &descriptorv2.LocalBlob{
-		Type: runtime.Type{
-			Name:    descriptorv2.LocalBlobAccessType,
-			Version: descriptorv2.LocalBlobAccessTypeVersion,
+func TestIsLocalBlob(t *testing.T) {
+	cases := []struct {
+		name  string
+		input runtime.Typed
+		want  bool
+	}{
+		{"nil", nil, false},
+		{
+			"LocalBlob struct",
+			&descriptorv2.LocalBlob{
+				Type: runtime.Type{
+					Name:    descriptorv2.LocalBlobAccessType,
+					Version: descriptorv2.LocalBlobAccessTypeVersion,
+				},
+				LocalReference: "sha256:abc123",
+				MediaType:      "application/octet-stream",
+			},
+			true,
 		},
-		LocalReference: "sha256:abc123",
-		MediaType:      "application/octet-stream",
-	}
-
-	assert.True(t, descriptorv2.IsLocalBlob(blob))
-}
-
-func TestIsLocalBlob_Raw(t *testing.T) {
-	raw := &runtime.Raw{
-		Type: runtime.Type{
-			Name:    descriptorv2.LocalBlobAccessType,
-			Version: descriptorv2.LocalBlobAccessTypeVersion,
+		{
+			"raw LocalBlob",
+			&runtime.Raw{
+				Type: runtime.Type{
+					Name:    descriptorv2.LocalBlobAccessType,
+					Version: descriptorv2.LocalBlobAccessTypeVersion,
+				},
+				Data: []byte(`{"type":"LocalBlob/v1","localReference":"sha256:abc123","mediaType":"application/octet-stream","globalAccess":{"type":"ociArtifact","imageReference":"test/image:1.0"},"referenceName":"test/repo:1.0"}`),
+			},
+			true,
 		},
-		Data: []byte(`{"type":"LocalBlob/v1","localReference":"sha256:abc123","mediaType":"application/octet-stream","globalAccess":{"type":"ociArtifact","imageReference":"test/image:1.0"},"referenceName":"test/repo:1.0"}`),
-	}
-
-	assert.True(t, descriptorv2.IsLocalBlob(raw))
-}
-
-func TestIsLocalBlob_RawOCIArtifact(t *testing.T) {
-	raw := &runtime.Raw{
-		Type: runtime.Type{
-			Name:    "ociArtifact",
-			Version: "v1",
+		{
+			"raw ociArtifact",
+			&runtime.Raw{
+				Type: runtime.Type{
+					Name:    "ociArtifact",
+					Version: "v1",
+				},
+				Data: []byte(`{"type":"ociArtifact/v1","imageReference":"ghcr.io/example/image:v1"}`),
+			},
+			false,
 		},
-		Data: []byte(`{"type":"ociArtifact/v1","imageReference":"ghcr.io/example/image:v1"}`),
-	}
-
-	assert.False(t, descriptorv2.IsLocalBlob(raw))
-}
-
-func TestIsLocalBlob_RawLegacy(t *testing.T) {
-	raw := &runtime.Raw{
-		Type: runtime.Type{
-			Name:    descriptorv2.LegacyLocalBlobAccessType,
-			Version: descriptorv2.LocalBlobAccessTypeVersion,
+		{
+			"raw legacy localBlob",
+			&runtime.Raw{
+				Type: runtime.Type{
+					Name:    descriptorv2.LegacyLocalBlobAccessType,
+					Version: descriptorv2.LocalBlobAccessTypeVersion,
+				},
+				Data: []byte(`{"type":"localBlob/v1","localReference":"sha256:abc123","mediaType":"application/octet-stream"}`),
+			},
+			true,
 		},
-		Data: []byte(`{"type":"localBlob/v1","localReference":"sha256:abc123","mediaType":"application/octet-stream"}`),
-	}
-
-	assert.True(t, descriptorv2.IsLocalBlob(raw))
-}
-
-func TestIsLocalBlob_RawUnknownType(t *testing.T) {
-	raw := &runtime.Raw{
-		Type: runtime.Type{
-			Name:    "unknownAccessType",
-			Version: "v1",
+		{
+			"raw unknown type",
+			&runtime.Raw{
+				Type: runtime.Type{
+					Name:    "unknownAccessType",
+					Version: "v1",
+				},
+				Data: []byte(`{"type":"unknownAccessType/v1","foo":"bar"}`),
+			},
+			false,
 		},
-		Data: []byte(`{"type":"unknownAccessType/v1","foo":"bar"}`),
+		{
+			"raw empty type",
+			&runtime.Raw{
+				Type: runtime.Type{},
+				Data: []byte(`{}`),
+			},
+			false,
+		},
 	}
-
-	assert.False(t, descriptorv2.IsLocalBlob(raw))
-}
-
-func TestIsLocalBlob_RawEmptyType(t *testing.T) {
-	raw := &runtime.Raw{
-		Type: runtime.Type{},
-		Data: []byte(`{}`),
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, descriptorv2.IsLocalBlob(tc.input))
+		})
 	}
-
-	assert.False(t, descriptorv2.IsLocalBlob(raw))
 }

--- a/bindings/go/descriptor/v2/scheme_test.go
+++ b/bindings/go/descriptor/v2/scheme_test.go
@@ -9,34 +9,21 @@ import (
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
-func TestScheme_ResolvesUpperCamelCase_LocalBlob(t *testing.T) {
-	obj, err := descriptorv2.Scheme.NewObject(
-		runtime.NewVersionedType(descriptorv2.LocalBlobAccessType, descriptorv2.LocalBlobAccessTypeVersion),
-	)
-	require.NoError(t, err, "Scheme must resolve UpperCamelCase type LocalBlob/v1")
-	require.IsType(t, &descriptorv2.LocalBlob{}, obj, "expected *LocalBlob from Scheme")
-}
-
-func TestScheme_ResolvesLegacy_LocalBlob(t *testing.T) {
-	obj, err := descriptorv2.Scheme.NewObject(
-		runtime.NewVersionedType(descriptorv2.LegacyLocalBlobAccessType, descriptorv2.LocalBlobAccessTypeVersion),
-	)
-	require.NoError(t, err, "Scheme must resolve legacy type localBlob/v1")
-	require.IsType(t, &descriptorv2.LocalBlob{}, obj, "expected *LocalBlob from Scheme")
-}
-
-func TestScheme_ResolvesUnversioned_LocalBlob(t *testing.T) {
-	obj, err := descriptorv2.Scheme.NewObject(
-		runtime.NewUnversionedType(descriptorv2.LocalBlobAccessType),
-	)
-	require.NoError(t, err, "Scheme must resolve unversioned LocalBlob")
-	require.IsType(t, &descriptorv2.LocalBlob{}, obj, "expected *LocalBlob from Scheme")
-}
-
-func TestScheme_ResolvesUnversionedLegacy_LocalBlob(t *testing.T) {
-	obj, err := descriptorv2.Scheme.NewObject(
-		runtime.NewUnversionedType(descriptorv2.LegacyLocalBlobAccessType),
-	)
-	require.NoError(t, err, "Scheme must resolve unversioned legacy localBlob")
-	require.IsType(t, &descriptorv2.LocalBlob{}, obj, "expected *LocalBlob from Scheme")
+func TestScheme_ResolvesLocalBlob(t *testing.T) {
+	cases := []struct {
+		name string
+		typ  runtime.Type
+	}{
+		{"UpperCamelCase versioned", runtime.NewVersionedType(descriptorv2.LocalBlobAccessType, descriptorv2.LocalBlobAccessTypeVersion)},
+		{"legacy versioned", runtime.NewVersionedType(descriptorv2.LegacyLocalBlobAccessType, descriptorv2.LocalBlobAccessTypeVersion)},
+		{"unversioned", runtime.NewUnversionedType(descriptorv2.LocalBlobAccessType)},
+		{"unversioned legacy", runtime.NewUnversionedType(descriptorv2.LegacyLocalBlobAccessType)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj, err := descriptorv2.Scheme.NewObject(tc.typ)
+			require.NoError(t, err)
+			require.IsType(t, &descriptorv2.LocalBlob{}, obj)
+		})
+	}
 }


### PR DESCRIPTION
#### What this PR does / why we need it

Follow-up to #2324: converts tests to table-driven style.

#### Which issue(s) this PR fixes

Follow-up #2324

#### Testing

##### How to test the changes

```bash
task test
```

##### Verification

- [x] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [x] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [x] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`