### PR TITLE
fix(docs): bump go version for website hacks

### DIFF
--- a/website/hack/generate-cli-docs/go.mod
+++ b/website/hack/generate-cli-docs/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-component-model/ocm-website/hack/generate-cli-docs
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/spf13/cobra v1.10.2


### PR DESCRIPTION
New ocm version requires go `1.26.2`