### PR TITLE
fix(deps): Fix update module ocm.software/open-component-model/bindings/go/credentials to v0.0.10 (#2331)

### DIFF
--- a/bindings/go/constructor/construct.go
+++ b/bindings/go/constructor/construct.go
@@ -779,7 +779,7 @@ func resolveCredentials(ctx context.Context, provider credentials.Resolver, cons
 		return nil, nil
 	}
 
-	creds, err := provider.Resolve(ctx, consumerIdentity)
+	creds, err := provider.Resolve(ctx, consumerIdentity) //nolint:staticcheck // SA1019: tracked migration to ResolveTyped in ocm-project#702
 	if errors.Is(err, credentials.ErrNotFound) {
 		logger.DebugContext(ctx, "no credentials found for consumer identity, proceeding without credentials")
 		return nil, nil

--- a/bindings/go/constructor/construct_resource_test.go
+++ b/bindings/go/constructor/construct_resource_test.go
@@ -165,6 +165,18 @@ func (m *mockCredentialProvider) Resolve(ctx context.Context, identity runtime.I
 	return m.credentials[identity.GetType().String()], nil
 }
 
+func (m *mockCredentialProvider) ResolveTyped(ctx context.Context, identity runtime.Typed) (runtime.Typed, error) {
+	id, ok := identity.(runtime.Identity)
+	if !ok {
+		return nil, fmt.Errorf("unsupported identity type")
+	}
+	creds, err := m.Resolve(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return runtime.Identity(creds), nil
+}
+
 // setupTestComponent creates a basic component constructor for testing
 func setupTestComponent(t *testing.T, resourceYAML string) *constructorruntime.ComponentConstructor {
 	yamlData := fmt.Sprintf(`

--- a/bindings/go/constructor/go.mod
+++ b/bindings/go/constructor/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.20.0
 	ocm.software/open-component-model/bindings/go/blob v0.0.12
-	ocm.software/open-component-model/bindings/go/credentials v0.0.9
+	ocm.software/open-component-model/bindings/go/credentials v0.0.10
 	ocm.software/open-component-model/bindings/go/dag v0.0.6
 	ocm.software/open-component-model/bindings/go/descriptor/normalisation v0.0.0-20260429073711-304fed31a996
 	ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20260429073711-304fed31a996

--- a/bindings/go/constructor/go.sum
+++ b/bindings/go/constructor/go.sum
@@ -51,8 +51,8 @@ ocm.software/open-component-model/bindings/go/blob v0.0.12 h1:5YOFDxERzF6w+rPWYu
 ocm.software/open-component-model/bindings/go/blob v0.0.12/go.mod h1:YswKfR/kxhdHHK7bN98S2O73ZZlPLsHfHO2Bjsr6Zww=
 ocm.software/open-component-model/bindings/go/configuration v0.0.13 h1:fARaCEkyBvuZ8/3nUDMb0LZF3YuohBbJXCTkOqqUmkw=
 ocm.software/open-component-model/bindings/go/configuration v0.0.13/go.mod h1:B8rEZoPPL4bAYhsi5I4IZJ8EJSOwMupd95Lw/N0TBRA=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9 h1:sYKfVKs+CrVL2EuKYNevCjXq1cdF0DsLnWyEjamjDdY=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9/go.mod h1:JFQDqqZv17uJLQSZOKa9siuLTK4zMA3Bzk4amU9ZALU=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10 h1:yPxsz8RsXULC/xskWt7UrggaXMK59GedFtUeo6xzMG8=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10/go.mod h1:RJ/pYi7SwCjzuTDvlMksRjJgRwaUwuziIv+ApxqCv0U=
 ocm.software/open-component-model/bindings/go/ctf v0.4.0 h1:E2kDGJk/ZR2wMK6fk3yFr2Uv6AhfLdMmvdvQ7Y64/2s=
 ocm.software/open-component-model/bindings/go/ctf v0.4.0/go.mod h1:XaVTQK/STJ64pq8vClsT+onD0kEs7P+Wzsq1k2tp9h4=
 ocm.software/open-component-model/bindings/go/dag v0.0.6 h1:To76QJAmFD88C101oB/HgYvtomp8mm0270ewDLcVncw=

--- a/bindings/go/helm/go.mod
+++ b/bindings/go/helm/go.mod
@@ -10,7 +10,7 @@ require (
 	ocm.software/open-component-model/bindings/go/blob v0.0.12
 	ocm.software/open-component-model/bindings/go/configuration v0.0.13
 	ocm.software/open-component-model/bindings/go/constructor v0.0.7
-	ocm.software/open-component-model/bindings/go/credentials v0.0.9
+	ocm.software/open-component-model/bindings/go/credentials v0.0.10
 	ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20260429073711-304fed31a996
 	ocm.software/open-component-model/bindings/go/descriptor/v2 v2.0.3-alpha3
 	ocm.software/open-component-model/bindings/go/oci v0.0.40

--- a/bindings/go/helm/go.sum
+++ b/bindings/go/helm/go.sum
@@ -367,8 +367,8 @@ ocm.software/open-component-model/bindings/go/configuration v0.0.13 h1:fARaCEkyB
 ocm.software/open-component-model/bindings/go/configuration v0.0.13/go.mod h1:B8rEZoPPL4bAYhsi5I4IZJ8EJSOwMupd95Lw/N0TBRA=
 ocm.software/open-component-model/bindings/go/constructor v0.0.7 h1:w1VB//QLrbC6r+lB8FHqcu4dK43wQD0MgULTsxFc0hA=
 ocm.software/open-component-model/bindings/go/constructor v0.0.7/go.mod h1:Aont6PV4Tm4ZU6ESOZdnnhJ+YV7LBeKM98+PSaMX+wA=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9 h1:sYKfVKs+CrVL2EuKYNevCjXq1cdF0DsLnWyEjamjDdY=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9/go.mod h1:JFQDqqZv17uJLQSZOKa9siuLTK4zMA3Bzk4amU9ZALU=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10 h1:yPxsz8RsXULC/xskWt7UrggaXMK59GedFtUeo6xzMG8=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10/go.mod h1:RJ/pYi7SwCjzuTDvlMksRjJgRwaUwuziIv+ApxqCv0U=
 ocm.software/open-component-model/bindings/go/ctf v0.4.0 h1:E2kDGJk/ZR2wMK6fk3yFr2Uv6AhfLdMmvdvQ7Y64/2s=
 ocm.software/open-component-model/bindings/go/ctf v0.4.0/go.mod h1:XaVTQK/STJ64pq8vClsT+onD0kEs7P+Wzsq1k2tp9h4=
 ocm.software/open-component-model/bindings/go/dag v0.0.6 h1:To76QJAmFD88C101oB/HgYvtomp8mm0270ewDLcVncw=

--- a/bindings/go/helm/transformation/get_helm_chart.go
+++ b/bindings/go/helm/transformation/get_helm_chart.go
@@ -125,7 +125,7 @@ func (t *GetHelmChart) resolveCredentials(ctx context.Context, targetResource *d
 	if consumerId == nil {
 		return nil, nil
 	}
-	creds, err := t.CredentialProvider.Resolve(ctx, consumerId)
+	creds, err := t.CredentialProvider.Resolve(ctx, consumerId) //nolint:staticcheck // SA1019: tracked migration to ResolveTyped in ocm-project#702
 	if err != nil && !errors.Is(err, credentials.ErrNotFound) {
 		return nil, fmt.Errorf("failed resolving credentials: %w", err)
 	}

--- a/bindings/go/input/dir/go.mod
+++ b/bindings/go/input/dir/go.mod
@@ -20,7 +20,7 @@ require (
 	golang.org/x/text v0.35.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	ocm.software/open-component-model/bindings/go/configuration v0.0.13 // indirect
-	ocm.software/open-component-model/bindings/go/credentials v0.0.9 // indirect
+	ocm.software/open-component-model/bindings/go/credentials v0.0.10 // indirect
 	ocm.software/open-component-model/bindings/go/dag v0.0.6 // indirect
 	ocm.software/open-component-model/bindings/go/descriptor/normalisation v0.0.0-20260429073711-304fed31a996 // indirect
 	ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20260429073711-304fed31a996 // indirect

--- a/bindings/go/input/dir/go.sum
+++ b/bindings/go/input/dir/go.sum
@@ -53,8 +53,8 @@ ocm.software/open-component-model/bindings/go/configuration v0.0.13 h1:fARaCEkyB
 ocm.software/open-component-model/bindings/go/configuration v0.0.13/go.mod h1:B8rEZoPPL4bAYhsi5I4IZJ8EJSOwMupd95Lw/N0TBRA=
 ocm.software/open-component-model/bindings/go/constructor v0.0.7 h1:w1VB//QLrbC6r+lB8FHqcu4dK43wQD0MgULTsxFc0hA=
 ocm.software/open-component-model/bindings/go/constructor v0.0.7/go.mod h1:Aont6PV4Tm4ZU6ESOZdnnhJ+YV7LBeKM98+PSaMX+wA=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9 h1:sYKfVKs+CrVL2EuKYNevCjXq1cdF0DsLnWyEjamjDdY=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9/go.mod h1:JFQDqqZv17uJLQSZOKa9siuLTK4zMA3Bzk4amU9ZALU=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10 h1:yPxsz8RsXULC/xskWt7UrggaXMK59GedFtUeo6xzMG8=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10/go.mod h1:RJ/pYi7SwCjzuTDvlMksRjJgRwaUwuziIv+ApxqCv0U=
 ocm.software/open-component-model/bindings/go/ctf v0.3.0 h1:u1B26OgUvR+gzTwY0hTVdZgFIXv5uwdI8reEvCcjNV4=
 ocm.software/open-component-model/bindings/go/ctf v0.3.0/go.mod h1:skMxA1l7rZFhKsjn8CysSVG31zjmV95WaFqMVKRjHug=
 ocm.software/open-component-model/bindings/go/dag v0.0.6 h1:To76QJAmFD88C101oB/HgYvtomp8mm0270ewDLcVncw=

--- a/bindings/go/input/file/go.mod
+++ b/bindings/go/input/file/go.mod
@@ -21,7 +21,7 @@ require (
 	golang.org/x/text v0.35.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	ocm.software/open-component-model/bindings/go/configuration v0.0.13 // indirect
-	ocm.software/open-component-model/bindings/go/credentials v0.0.9 // indirect
+	ocm.software/open-component-model/bindings/go/credentials v0.0.10 // indirect
 	ocm.software/open-component-model/bindings/go/dag v0.0.6 // indirect
 	ocm.software/open-component-model/bindings/go/descriptor/normalisation v0.0.0-20260429073711-304fed31a996 // indirect
 	ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20260429073711-304fed31a996 // indirect

--- a/bindings/go/input/file/go.sum
+++ b/bindings/go/input/file/go.sum
@@ -55,8 +55,8 @@ ocm.software/open-component-model/bindings/go/configuration v0.0.13 h1:fARaCEkyB
 ocm.software/open-component-model/bindings/go/configuration v0.0.13/go.mod h1:B8rEZoPPL4bAYhsi5I4IZJ8EJSOwMupd95Lw/N0TBRA=
 ocm.software/open-component-model/bindings/go/constructor v0.0.7 h1:w1VB//QLrbC6r+lB8FHqcu4dK43wQD0MgULTsxFc0hA=
 ocm.software/open-component-model/bindings/go/constructor v0.0.7/go.mod h1:Aont6PV4Tm4ZU6ESOZdnnhJ+YV7LBeKM98+PSaMX+wA=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9 h1:sYKfVKs+CrVL2EuKYNevCjXq1cdF0DsLnWyEjamjDdY=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9/go.mod h1:JFQDqqZv17uJLQSZOKa9siuLTK4zMA3Bzk4amU9ZALU=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10 h1:yPxsz8RsXULC/xskWt7UrggaXMK59GedFtUeo6xzMG8=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10/go.mod h1:RJ/pYi7SwCjzuTDvlMksRjJgRwaUwuziIv+ApxqCv0U=
 ocm.software/open-component-model/bindings/go/ctf v0.3.0 h1:u1B26OgUvR+gzTwY0hTVdZgFIXv5uwdI8reEvCcjNV4=
 ocm.software/open-component-model/bindings/go/ctf v0.3.0/go.mod h1:skMxA1l7rZFhKsjn8CysSVG31zjmV95WaFqMVKRjHug=
 ocm.software/open-component-model/bindings/go/dag v0.0.6 h1:To76QJAmFD88C101oB/HgYvtomp8mm0270ewDLcVncw=

--- a/bindings/go/input/utf8/go.mod
+++ b/bindings/go/input/utf8/go.mod
@@ -21,7 +21,7 @@ require (
 	golang.org/x/text v0.35.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	ocm.software/open-component-model/bindings/go/configuration v0.0.13 // indirect
-	ocm.software/open-component-model/bindings/go/credentials v0.0.9 // indirect
+	ocm.software/open-component-model/bindings/go/credentials v0.0.10 // indirect
 	ocm.software/open-component-model/bindings/go/dag v0.0.6 // indirect
 	ocm.software/open-component-model/bindings/go/descriptor/normalisation v0.0.0-20260429073711-304fed31a996 // indirect
 	ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20260429073711-304fed31a996 // indirect

--- a/bindings/go/input/utf8/go.sum
+++ b/bindings/go/input/utf8/go.sum
@@ -51,8 +51,8 @@ ocm.software/open-component-model/bindings/go/configuration v0.0.13 h1:fARaCEkyB
 ocm.software/open-component-model/bindings/go/configuration v0.0.13/go.mod h1:B8rEZoPPL4bAYhsi5I4IZJ8EJSOwMupd95Lw/N0TBRA=
 ocm.software/open-component-model/bindings/go/constructor v0.0.7 h1:w1VB//QLrbC6r+lB8FHqcu4dK43wQD0MgULTsxFc0hA=
 ocm.software/open-component-model/bindings/go/constructor v0.0.7/go.mod h1:Aont6PV4Tm4ZU6ESOZdnnhJ+YV7LBeKM98+PSaMX+wA=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9 h1:sYKfVKs+CrVL2EuKYNevCjXq1cdF0DsLnWyEjamjDdY=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9/go.mod h1:JFQDqqZv17uJLQSZOKa9siuLTK4zMA3Bzk4amU9ZALU=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10 h1:yPxsz8RsXULC/xskWt7UrggaXMK59GedFtUeo6xzMG8=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10/go.mod h1:RJ/pYi7SwCjzuTDvlMksRjJgRwaUwuziIv+ApxqCv0U=
 ocm.software/open-component-model/bindings/go/ctf v0.3.0 h1:u1B26OgUvR+gzTwY0hTVdZgFIXv5uwdI8reEvCcjNV4=
 ocm.software/open-component-model/bindings/go/ctf v0.3.0/go.mod h1:skMxA1l7rZFhKsjn8CysSVG31zjmV95WaFqMVKRjHug=
 ocm.software/open-component-model/bindings/go/dag v0.0.6 h1:To76QJAmFD88C101oB/HgYvtomp8mm0270ewDLcVncw=

--- a/bindings/go/oci/go.mod
+++ b/bindings/go/oci/go.mod
@@ -12,7 +12,7 @@ require (
 	golang.org/x/sync v0.20.0
 	ocm.software/open-component-model/bindings/go/blob v0.0.12
 	ocm.software/open-component-model/bindings/go/configuration v0.0.13
-	ocm.software/open-component-model/bindings/go/credentials v0.0.9
+	ocm.software/open-component-model/bindings/go/credentials v0.0.10
 	ocm.software/open-component-model/bindings/go/ctf v0.4.0
 	ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20260429073711-304fed31a996
 	ocm.software/open-component-model/bindings/go/descriptor/v2 v2.0.3-alpha3

--- a/bindings/go/oci/go.sum
+++ b/bindings/go/oci/go.sum
@@ -51,8 +51,8 @@ ocm.software/open-component-model/bindings/go/blob v0.0.12 h1:5YOFDxERzF6w+rPWYu
 ocm.software/open-component-model/bindings/go/blob v0.0.12/go.mod h1:YswKfR/kxhdHHK7bN98S2O73ZZlPLsHfHO2Bjsr6Zww=
 ocm.software/open-component-model/bindings/go/configuration v0.0.13 h1:fARaCEkyBvuZ8/3nUDMb0LZF3YuohBbJXCTkOqqUmkw=
 ocm.software/open-component-model/bindings/go/configuration v0.0.13/go.mod h1:B8rEZoPPL4bAYhsi5I4IZJ8EJSOwMupd95Lw/N0TBRA=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9 h1:sYKfVKs+CrVL2EuKYNevCjXq1cdF0DsLnWyEjamjDdY=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9/go.mod h1:JFQDqqZv17uJLQSZOKa9siuLTK4zMA3Bzk4amU9ZALU=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10 h1:yPxsz8RsXULC/xskWt7UrggaXMK59GedFtUeo6xzMG8=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10/go.mod h1:RJ/pYi7SwCjzuTDvlMksRjJgRwaUwuziIv+ApxqCv0U=
 ocm.software/open-component-model/bindings/go/ctf v0.4.0 h1:E2kDGJk/ZR2wMK6fk3yFr2Uv6AhfLdMmvdvQ7Y64/2s=
 ocm.software/open-component-model/bindings/go/ctf v0.4.0/go.mod h1:XaVTQK/STJ64pq8vClsT+onD0kEs7P+Wzsq1k2tp9h4=
 ocm.software/open-component-model/bindings/go/dag v0.0.6 h1:To76QJAmFD88C101oB/HgYvtomp8mm0270ewDLcVncw=

--- a/bindings/go/oci/integration/go.mod
+++ b/bindings/go/oci/integration/go.mod
@@ -12,7 +12,7 @@ require (
 	golang.org/x/crypto v0.49.0
 	ocm.software/open-component-model/bindings/go/blob v0.0.12
 	ocm.software/open-component-model/bindings/go/configuration v0.0.13
-	ocm.software/open-component-model/bindings/go/credentials v0.0.9
+	ocm.software/open-component-model/bindings/go/credentials v0.0.10
 	ocm.software/open-component-model/bindings/go/ctf v0.4.0
 	ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20260429073711-304fed31a996
 	ocm.software/open-component-model/bindings/go/descriptor/v2 v2.0.3-alpha3

--- a/bindings/go/oci/integration/go.sum
+++ b/bindings/go/oci/integration/go.sum
@@ -183,8 +183,8 @@ ocm.software/open-component-model/bindings/go/blob v0.0.12 h1:5YOFDxERzF6w+rPWYu
 ocm.software/open-component-model/bindings/go/blob v0.0.12/go.mod h1:YswKfR/kxhdHHK7bN98S2O73ZZlPLsHfHO2Bjsr6Zww=
 ocm.software/open-component-model/bindings/go/configuration v0.0.13 h1:fARaCEkyBvuZ8/3nUDMb0LZF3YuohBbJXCTkOqqUmkw=
 ocm.software/open-component-model/bindings/go/configuration v0.0.13/go.mod h1:B8rEZoPPL4bAYhsi5I4IZJ8EJSOwMupd95Lw/N0TBRA=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9 h1:sYKfVKs+CrVL2EuKYNevCjXq1cdF0DsLnWyEjamjDdY=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9/go.mod h1:JFQDqqZv17uJLQSZOKa9siuLTK4zMA3Bzk4amU9ZALU=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10 h1:yPxsz8RsXULC/xskWt7UrggaXMK59GedFtUeo6xzMG8=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10/go.mod h1:RJ/pYi7SwCjzuTDvlMksRjJgRwaUwuziIv+ApxqCv0U=
 ocm.software/open-component-model/bindings/go/ctf v0.4.0 h1:E2kDGJk/ZR2wMK6fk3yFr2Uv6AhfLdMmvdvQ7Y64/2s=
 ocm.software/open-component-model/bindings/go/ctf v0.4.0/go.mod h1:XaVTQK/STJ64pq8vClsT+onD0kEs7P+Wzsq1k2tp9h4=
 ocm.software/open-component-model/bindings/go/dag v0.0.6 h1:To76QJAmFD88C101oB/HgYvtomp8mm0270ewDLcVncw=

--- a/bindings/go/oci/transformer/add_component_version.go
+++ b/bindings/go/oci/transformer/add_component_version.go
@@ -43,7 +43,7 @@ func (t *AddComponentVersion) Transform(ctx context.Context, step runtime.Typed)
 	var creds map[string]string
 	if t.CredentialProvider != nil {
 		if consumerId, err := t.RepoProvider.GetComponentVersionRepositoryCredentialConsumerIdentity(ctx, repoSpec); err == nil {
-			if creds, err = t.CredentialProvider.Resolve(ctx, consumerId); err != nil && !errors.Is(err, credentials.ErrNotFound) {
+			if creds, err = t.CredentialProvider.Resolve(ctx, consumerId); err != nil && !errors.Is(err, credentials.ErrNotFound) { //nolint:staticcheck // SA1019: tracked migration to ResolveTyped in ocm-project#702
 				return nil, fmt.Errorf("failed resolving credentials: %w", err)
 			}
 		}

--- a/bindings/go/oci/transformer/add_local_resource.go
+++ b/bindings/go/oci/transformer/add_local_resource.go
@@ -86,7 +86,7 @@ func (t *AddLocalResource) Transform(ctx context.Context, step runtime.Typed) (r
 	var creds map[string]string
 	if t.CredentialProvider != nil {
 		if consumerId, err := t.RepoProvider.GetComponentVersionRepositoryCredentialConsumerIdentity(ctx, repoSpec); err == nil {
-			if creds, err = t.CredentialProvider.Resolve(ctx, consumerId); err != nil && !errors.Is(err, credentials.ErrNotFound) {
+			if creds, err = t.CredentialProvider.Resolve(ctx, consumerId); err != nil && !errors.Is(err, credentials.ErrNotFound) { //nolint:staticcheck // SA1019: tracked migration to ResolveTyped in ocm-project#702
 				return nil, fmt.Errorf("failed resolving credentials: %w", err)
 			}
 		}

--- a/bindings/go/oci/transformer/add_oci_artifact.go
+++ b/bindings/go/oci/transformer/add_oci_artifact.go
@@ -48,7 +48,7 @@ func (t *AddOCIArtifact) Transform(ctx context.Context, step runtime.Typed) (run
 	var creds map[string]string
 	if t.CredentialProvider != nil {
 		if consumerId, err := t.Repository.GetResourceCredentialConsumerIdentity(ctx, targetResource); err == nil {
-			if creds, err = t.CredentialProvider.Resolve(ctx, consumerId); err != nil && !errors.Is(err, credentials.ErrNotFound) {
+			if creds, err = t.CredentialProvider.Resolve(ctx, consumerId); err != nil && !errors.Is(err, credentials.ErrNotFound) { //nolint:staticcheck // SA1019: tracked migration to ResolveTyped in ocm-project#702
 				return nil, fmt.Errorf("failed resolving credentials: %w", err)
 			}
 		}

--- a/bindings/go/oci/transformer/add_oci_artifact_test.go
+++ b/bindings/go/oci/transformer/add_oci_artifact_test.go
@@ -69,6 +69,10 @@ func (m *mockCredentialResolver) Resolve(ctx context.Context, id runtime.Identit
 	return map[string]string{"username": "test-user"}, nil
 }
 
+func (m *mockCredentialResolver) ResolveTyped(_ context.Context, _ runtime.Typed) (runtime.Typed, error) {
+	return runtime.Identity{"username": "test-user"}, nil
+}
+
 func TestAddOCIArtifact_Transform(t *testing.T) {
 	ctx := context.Background()
 

--- a/bindings/go/oci/transformer/get_component_version.go
+++ b/bindings/go/oci/transformer/get_component_version.go
@@ -42,7 +42,7 @@ func (t *GetComponentVersion) Transform(ctx context.Context, step runtime.Typed)
 	var creds map[string]string
 	if t.CredentialProvider != nil {
 		if consumerId, err := t.RepoProvider.GetComponentVersionRepositoryCredentialConsumerIdentity(ctx, repoSpec); err == nil {
-			if creds, err = t.CredentialProvider.Resolve(ctx, consumerId); err != nil && !errors.Is(err, credentials.ErrNotFound) {
+			if creds, err = t.CredentialProvider.Resolve(ctx, consumerId); err != nil && !errors.Is(err, credentials.ErrNotFound) { //nolint:staticcheck // SA1019: tracked migration to ResolveTyped in ocm-project#702
 				return nil, fmt.Errorf("failed resolving credentials: %w", err)
 			}
 		}

--- a/bindings/go/oci/transformer/get_local_resource.go
+++ b/bindings/go/oci/transformer/get_local_resource.go
@@ -76,7 +76,7 @@ func (t *GetLocalResource) Transform(ctx context.Context, step runtime.Typed) (r
 	var creds map[string]string
 	if t.CredentialProvider != nil {
 		if consumerId, err := t.RepoProvider.GetComponentVersionRepositoryCredentialConsumerIdentity(ctx, repoSpec); err == nil {
-			if creds, err = t.CredentialProvider.Resolve(ctx, consumerId); err != nil && !errors.Is(err, credentials.ErrNotFound) {
+			if creds, err = t.CredentialProvider.Resolve(ctx, consumerId); err != nil && !errors.Is(err, credentials.ErrNotFound) { //nolint:staticcheck // SA1019: tracked migration to ResolveTyped in ocm-project#702
 				return nil, fmt.Errorf("failed resolving credentials: %w", err)
 			}
 		}

--- a/bindings/go/oci/transformer/get_oci_artifact.go
+++ b/bindings/go/oci/transformer/get_oci_artifact.go
@@ -51,7 +51,7 @@ func (t *GetOCIArtifact) Transform(ctx context.Context, step runtime.Typed) (run
 	var creds map[string]string
 	if t.CredentialProvider != nil {
 		if consumerId, err := t.Repository.GetResourceCredentialConsumerIdentity(ctx, targetResource); err == nil {
-			if creds, err = t.CredentialProvider.Resolve(ctx, consumerId); err != nil && !errors.Is(err, credentials.ErrNotFound) {
+			if creds, err = t.CredentialProvider.Resolve(ctx, consumerId); err != nil && !errors.Is(err, credentials.ErrNotFound) { //nolint:staticcheck // SA1019: tracked migration to ResolveTyped in ocm-project#702
 				return nil, fmt.Errorf("failed resolving credentials: %w", err)
 			}
 		}

--- a/bindings/go/plugin/go.mod
+++ b/bindings/go/plugin/go.mod
@@ -10,7 +10,7 @@ require (
 	ocm.software/open-component-model/bindings/go/blob v0.0.12
 	ocm.software/open-component-model/bindings/go/configuration v0.0.13
 	ocm.software/open-component-model/bindings/go/constructor v0.0.7
-	ocm.software/open-component-model/bindings/go/credentials v0.0.9
+	ocm.software/open-component-model/bindings/go/credentials v0.0.10
 	ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20260429073711-304fed31a996
 	ocm.software/open-component-model/bindings/go/descriptor/v2 v2.0.3-alpha3
 	ocm.software/open-component-model/bindings/go/repository v0.0.8

--- a/bindings/go/plugin/go.sum
+++ b/bindings/go/plugin/go.sum
@@ -63,8 +63,8 @@ ocm.software/open-component-model/bindings/go/configuration v0.0.13 h1:fARaCEkyB
 ocm.software/open-component-model/bindings/go/configuration v0.0.13/go.mod h1:B8rEZoPPL4bAYhsi5I4IZJ8EJSOwMupd95Lw/N0TBRA=
 ocm.software/open-component-model/bindings/go/constructor v0.0.7 h1:w1VB//QLrbC6r+lB8FHqcu4dK43wQD0MgULTsxFc0hA=
 ocm.software/open-component-model/bindings/go/constructor v0.0.7/go.mod h1:Aont6PV4Tm4ZU6ESOZdnnhJ+YV7LBeKM98+PSaMX+wA=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9 h1:sYKfVKs+CrVL2EuKYNevCjXq1cdF0DsLnWyEjamjDdY=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9/go.mod h1:JFQDqqZv17uJLQSZOKa9siuLTK4zMA3Bzk4amU9ZALU=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10 h1:yPxsz8RsXULC/xskWt7UrggaXMK59GedFtUeo6xzMG8=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10/go.mod h1:RJ/pYi7SwCjzuTDvlMksRjJgRwaUwuziIv+ApxqCv0U=
 ocm.software/open-component-model/bindings/go/ctf v0.3.0 h1:u1B26OgUvR+gzTwY0hTVdZgFIXv5uwdI8reEvCcjNV4=
 ocm.software/open-component-model/bindings/go/ctf v0.3.0/go.mod h1:skMxA1l7rZFhKsjn8CysSVG31zjmV95WaFqMVKRjHug=
 ocm.software/open-component-model/bindings/go/dag v0.0.6 h1:To76QJAmFD88C101oB/HgYvtomp8mm0270ewDLcVncw=

--- a/bindings/go/repository/component/fallback/v1/repository.go
+++ b/bindings/go/repository/component/fallback/v1/repository.go
@@ -347,7 +347,7 @@ func (f *FallbackRepository) getRepositoryForSpecification(ctx context.Context, 
 	consumerIdentity, err := f.repositoryProvider.GetComponentVersionRepositoryCredentialConsumerIdentity(ctx, specification)
 	if err == nil {
 		if f.credentialsResolver != nil {
-			if c, err := f.credentialsResolver.Resolve(ctx, consumerIdentity); err != nil {
+			if c, err := f.credentialsResolver.Resolve(ctx, consumerIdentity); err != nil { //nolint:staticcheck // SA1019: tracked migration to ResolveTyped in ocm-project#702
 				// does not know the credentials package - so we need to check manually
 				if errors.Is(err, credentials.ErrNotFound) {
 					slog.DebugContext(ctx, fmt.Sprintf("resolving credentials for repository %q failed: %s", specification, err.Error()))

--- a/bindings/go/repository/component/resolvers/pathmatcher.go
+++ b/bindings/go/repository/component/resolvers/pathmatcher.go
@@ -55,7 +55,7 @@ func (p *pathMatcherResolver) getRepository(ctx context.Context, specification r
 	consumerIdentity, err := p.repoProvider.GetComponentVersionRepositoryCredentialConsumerIdentity(ctx, specification)
 	if err == nil {
 		if p.graph != nil {
-			if credMap, err = p.graph.Resolve(ctx, consumerIdentity); err != nil {
+			if credMap, err = p.graph.Resolve(ctx, consumerIdentity); err != nil { //nolint:staticcheck // SA1019: tracked migration to ResolveTyped in ocm-project#702
 				if errors.Is(err, credentials.ErrNotFound) {
 					slog.DebugContext(ctx, fmt.Sprintf("resolving credentials for repository %q failed: %s", specification, err.Error()))
 				} else {

--- a/bindings/go/repository/go.mod
+++ b/bindings/go/repository/go.mod
@@ -11,7 +11,7 @@ require (
 	golang.org/x/sync v0.20.0
 	ocm.software/open-component-model/bindings/go/blob v0.0.12
 	ocm.software/open-component-model/bindings/go/configuration v0.0.13
-	ocm.software/open-component-model/bindings/go/credentials v0.0.9
+	ocm.software/open-component-model/bindings/go/credentials v0.0.10
 	ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20260429073711-304fed31a996
 	ocm.software/open-component-model/bindings/go/runtime v0.0.8
 )

--- a/bindings/go/repository/go.sum
+++ b/bindings/go/repository/go.sum
@@ -47,8 +47,8 @@ ocm.software/open-component-model/bindings/go/blob v0.0.12 h1:5YOFDxERzF6w+rPWYu
 ocm.software/open-component-model/bindings/go/blob v0.0.12/go.mod h1:YswKfR/kxhdHHK7bN98S2O73ZZlPLsHfHO2Bjsr6Zww=
 ocm.software/open-component-model/bindings/go/configuration v0.0.13 h1:fARaCEkyBvuZ8/3nUDMb0LZF3YuohBbJXCTkOqqUmkw=
 ocm.software/open-component-model/bindings/go/configuration v0.0.13/go.mod h1:B8rEZoPPL4bAYhsi5I4IZJ8EJSOwMupd95Lw/N0TBRA=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9 h1:sYKfVKs+CrVL2EuKYNevCjXq1cdF0DsLnWyEjamjDdY=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9/go.mod h1:JFQDqqZv17uJLQSZOKa9siuLTK4zMA3Bzk4amU9ZALU=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10 h1:yPxsz8RsXULC/xskWt7UrggaXMK59GedFtUeo6xzMG8=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10/go.mod h1:RJ/pYi7SwCjzuTDvlMksRjJgRwaUwuziIv+ApxqCv0U=
 ocm.software/open-component-model/bindings/go/dag v0.0.6 h1:To76QJAmFD88C101oB/HgYvtomp8mm0270ewDLcVncw=
 ocm.software/open-component-model/bindings/go/dag v0.0.6/go.mod h1:mQbO95zYvX59VXNJGer4+wGsKY0BVI4FKwlR5BlPugM=
 ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20260429073711-304fed31a996 h1:adLNvjRjo68BhQiSzTSbSzL4cNu0x6bAf0KDDW8jvD0=

--- a/bindings/go/transfer/go.mod
+++ b/bindings/go/transfer/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/stretchr/testify v1.11.1
 	ocm.software/open-component-model/bindings/go/blob v0.0.12
-	ocm.software/open-component-model/bindings/go/credentials v0.0.9
+	ocm.software/open-component-model/bindings/go/credentials v0.0.10
 	ocm.software/open-component-model/bindings/go/dag v0.0.6
 	ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20260429073711-304fed31a996
 	ocm.software/open-component-model/bindings/go/descriptor/v2 v2.0.3-alpha3

--- a/bindings/go/transfer/go.sum
+++ b/bindings/go/transfer/go.sum
@@ -348,8 +348,8 @@ ocm.software/open-component-model/bindings/go/cel v0.0.0-20260429073711-304fed31
 ocm.software/open-component-model/bindings/go/cel v0.0.0-20260429073711-304fed31a996/go.mod h1:GHZfvK+e1mgGf3V15w3ZgTVDxuFSqxxOoSRqIMUtNSA=
 ocm.software/open-component-model/bindings/go/configuration v0.0.13 h1:fARaCEkyBvuZ8/3nUDMb0LZF3YuohBbJXCTkOqqUmkw=
 ocm.software/open-component-model/bindings/go/configuration v0.0.13/go.mod h1:B8rEZoPPL4bAYhsi5I4IZJ8EJSOwMupd95Lw/N0TBRA=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9 h1:sYKfVKs+CrVL2EuKYNevCjXq1cdF0DsLnWyEjamjDdY=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9/go.mod h1:JFQDqqZv17uJLQSZOKa9siuLTK4zMA3Bzk4amU9ZALU=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10 h1:yPxsz8RsXULC/xskWt7UrggaXMK59GedFtUeo6xzMG8=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10/go.mod h1:RJ/pYi7SwCjzuTDvlMksRjJgRwaUwuziIv+ApxqCv0U=
 ocm.software/open-component-model/bindings/go/ctf v0.4.0 h1:E2kDGJk/ZR2wMK6fk3yFr2Uv6AhfLdMmvdvQ7Y64/2s=
 ocm.software/open-component-model/bindings/go/ctf v0.4.0/go.mod h1:XaVTQK/STJ64pq8vClsT+onD0kEs7P+Wzsq1k2tp9h4=
 ocm.software/open-component-model/bindings/go/dag v0.0.6 h1:To76QJAmFD88C101oB/HgYvtomp8mm0270ewDLcVncw=

--- a/bindings/go/transfer/integration/go.mod
+++ b/bindings/go/transfer/integration/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/registry v0.41.0
 	golang.org/x/crypto v0.49.0
 	ocm.software/open-component-model/bindings/go/blob v0.0.12
-	ocm.software/open-component-model/bindings/go/credentials v0.0.9
+	ocm.software/open-component-model/bindings/go/credentials v0.0.10
 	ocm.software/open-component-model/bindings/go/ctf v0.4.0
 	ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20260429073711-304fed31a996
 	ocm.software/open-component-model/bindings/go/descriptor/v2 v2.0.3-alpha3

--- a/bindings/go/transfer/integration/go.sum
+++ b/bindings/go/transfer/integration/go.sum
@@ -422,8 +422,8 @@ ocm.software/open-component-model/bindings/go/cel v0.0.0-20260429073711-304fed31
 ocm.software/open-component-model/bindings/go/cel v0.0.0-20260429073711-304fed31a996/go.mod h1:GHZfvK+e1mgGf3V15w3ZgTVDxuFSqxxOoSRqIMUtNSA=
 ocm.software/open-component-model/bindings/go/configuration v0.0.13 h1:fARaCEkyBvuZ8/3nUDMb0LZF3YuohBbJXCTkOqqUmkw=
 ocm.software/open-component-model/bindings/go/configuration v0.0.13/go.mod h1:B8rEZoPPL4bAYhsi5I4IZJ8EJSOwMupd95Lw/N0TBRA=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9 h1:sYKfVKs+CrVL2EuKYNevCjXq1cdF0DsLnWyEjamjDdY=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9/go.mod h1:JFQDqqZv17uJLQSZOKa9siuLTK4zMA3Bzk4amU9ZALU=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10 h1:yPxsz8RsXULC/xskWt7UrggaXMK59GedFtUeo6xzMG8=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10/go.mod h1:RJ/pYi7SwCjzuTDvlMksRjJgRwaUwuziIv+ApxqCv0U=
 ocm.software/open-component-model/bindings/go/ctf v0.4.0 h1:E2kDGJk/ZR2wMK6fk3yFr2Uv6AhfLdMmvdvQ7Y64/2s=
 ocm.software/open-component-model/bindings/go/ctf v0.4.0/go.mod h1:XaVTQK/STJ64pq8vClsT+onD0kEs7P+Wzsq1k2tp9h4=
 ocm.software/open-component-model/bindings/go/dag v0.0.6 h1:To76QJAmFD88C101oB/HgYvtomp8mm0270ewDLcVncw=

--- a/bindings/go/transform/go.mod
+++ b/bindings/go/transform/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.11.1
 	ocm.software/open-component-model/bindings/go/cel v0.0.0-20260429073711-304fed31a996
-	ocm.software/open-component-model/bindings/go/credentials v0.0.9
+	ocm.software/open-component-model/bindings/go/credentials v0.0.10
 	ocm.software/open-component-model/bindings/go/dag v0.0.6
 	ocm.software/open-component-model/bindings/go/runtime v0.0.8
 	sigs.k8s.io/yaml v1.6.0

--- a/bindings/go/transform/go.sum
+++ b/bindings/go/transform/go.sum
@@ -49,8 +49,8 @@ ocm.software/open-component-model/bindings/go/cel v0.0.0-20260429073711-304fed31
 ocm.software/open-component-model/bindings/go/cel v0.0.0-20260429073711-304fed31a996/go.mod h1:GHZfvK+e1mgGf3V15w3ZgTVDxuFSqxxOoSRqIMUtNSA=
 ocm.software/open-component-model/bindings/go/configuration v0.0.13 h1:fARaCEkyBvuZ8/3nUDMb0LZF3YuohBbJXCTkOqqUmkw=
 ocm.software/open-component-model/bindings/go/configuration v0.0.13/go.mod h1:B8rEZoPPL4bAYhsi5I4IZJ8EJSOwMupd95Lw/N0TBRA=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9 h1:sYKfVKs+CrVL2EuKYNevCjXq1cdF0DsLnWyEjamjDdY=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9/go.mod h1:JFQDqqZv17uJLQSZOKa9siuLTK4zMA3Bzk4amU9ZALU=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10 h1:yPxsz8RsXULC/xskWt7UrggaXMK59GedFtUeo6xzMG8=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10/go.mod h1:RJ/pYi7SwCjzuTDvlMksRjJgRwaUwuziIv+ApxqCv0U=
 ocm.software/open-component-model/bindings/go/dag v0.0.6 h1:To76QJAmFD88C101oB/HgYvtomp8mm0270ewDLcVncw=
 ocm.software/open-component-model/bindings/go/dag v0.0.6/go.mod h1:mQbO95zYvX59VXNJGer4+wGsKY0BVI4FKwlR5BlPugM=
 ocm.software/open-component-model/bindings/go/runtime v0.0.8 h1:NIN8smq0Fs64N10UCSx7RrysIB/u8ukVF/GeT76uQRE=

--- a/cli/cmd/add/component-version/cmd.go
+++ b/cli/cmd/add/component-version/cmd.go
@@ -480,7 +480,7 @@ func (prov *constructorProvider) GetTargetRepository(ctx context.Context, _ *con
 	identity, err := prov.pluginManager.ComponentVersionRepositoryRegistry.GetComponentVersionRepositoryCredentialConsumerIdentity(ctx, prov.targetRepoSpec)
 	if err == nil {
 		if prov.graph != nil {
-			if creds, err = prov.graph.Resolve(ctx, identity); err != nil {
+			if creds, err = prov.graph.Resolve(ctx, identity); err != nil { //nolint:staticcheck // SA1019: tracked migration to ResolveTyped in ocm-project#702
 				if errors.Is(err, credentials.ErrNotFound) {
 					slog.DebugContext(ctx, fmt.Sprintf("resolving credentials for repository %q failed: %s", prov.targetRepoSpec, err.Error()))
 				} else {

--- a/cli/cmd/download/shared/common.go
+++ b/cli/cmd/download/shared/common.go
@@ -59,7 +59,7 @@ func DownloadResourceData(ctx context.Context, pluginManager *manager.PluginMana
 		}
 		var creds map[string]string
 		if credIdentity, err := plugin.GetResourceCredentialConsumerIdentity(ctx, res); err == nil {
-			if creds, err = credentialGraph.Resolve(ctx, credIdentity); err != nil && !errors.Is(err, credentials.ErrNotFound) {
+			if creds, err = credentialGraph.Resolve(ctx, credIdentity); err != nil && !errors.Is(err, credentials.ErrNotFound) { //nolint:staticcheck // SA1019: tracked migration to ResolveTyped in ocm-project#702
 				return nil, fmt.Errorf("getting credentials for resource %q failed: %w", res.Name, err)
 			}
 		}

--- a/cli/cmd/sign/component-version/cmd.go
+++ b/cli/cmd/sign/component-version/cmd.go
@@ -281,7 +281,7 @@ func SignComponentVersion(cmd *cobra.Command, args []string) error {
 	// credentials
 	credMap := map[string]string{}
 	if consumerID, err := handler.GetSigningCredentialConsumerIdentity(ctx, signatureName, *unsignedDigest, signerSpec); err == nil {
-		if creds, err := credentialGraph.Resolve(ctx, consumerID); err == nil {
+		if creds, err := credentialGraph.Resolve(ctx, consumerID); err == nil { //nolint:staticcheck // SA1019: tracked migration to ResolveTyped in ocm-project#702
 			credMap = creds
 			logger.DebugContext(ctx, "using discovered credentials", "attributes", slices.Collect(maps.Keys(credMap)))
 		} else {

--- a/cli/cmd/verify/component-version/cmd.go
+++ b/cli/cmd/verify/component-version/cmd.go
@@ -256,7 +256,7 @@ func VerifyComponentVersion(cmd *cobra.Command, args []string) error {
 
 			var creds map[string]string
 			if consumerID, err := handler.GetVerifyingCredentialConsumerIdentity(egctx, signature, verifierSpec); err == nil {
-				if creds, err = credentialGraph.Resolve(egctx, consumerID); err != nil {
+				if creds, err = credentialGraph.Resolve(egctx, consumerID); err != nil { //nolint:staticcheck // SA1019: tracked migration to ResolveTyped in ocm-project#702
 					if errors.Is(err, credentials.ErrNotFound) {
 						logger.DebugContext(egctx, "could not resolve credentials for verification", "error", err.Error())
 					} else {

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -19,7 +19,7 @@ require (
 	ocm.software/open-component-model/bindings/go/cel v0.0.0-20260429073711-304fed31a996
 	ocm.software/open-component-model/bindings/go/configuration v0.0.13
 	ocm.software/open-component-model/bindings/go/constructor v0.0.7
-	ocm.software/open-component-model/bindings/go/credentials v0.0.9
+	ocm.software/open-component-model/bindings/go/credentials v0.0.10
 	ocm.software/open-component-model/bindings/go/ctf v0.4.0
 	ocm.software/open-component-model/bindings/go/dag v0.0.6
 	ocm.software/open-component-model/bindings/go/descriptor/normalisation v0.0.0-20260429073711-304fed31a996

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -387,8 +387,8 @@ ocm.software/open-component-model/bindings/go/configuration v0.0.13 h1:fARaCEkyB
 ocm.software/open-component-model/bindings/go/configuration v0.0.13/go.mod h1:B8rEZoPPL4bAYhsi5I4IZJ8EJSOwMupd95Lw/N0TBRA=
 ocm.software/open-component-model/bindings/go/constructor v0.0.7 h1:w1VB//QLrbC6r+lB8FHqcu4dK43wQD0MgULTsxFc0hA=
 ocm.software/open-component-model/bindings/go/constructor v0.0.7/go.mod h1:Aont6PV4Tm4ZU6ESOZdnnhJ+YV7LBeKM98+PSaMX+wA=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9 h1:sYKfVKs+CrVL2EuKYNevCjXq1cdF0DsLnWyEjamjDdY=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9/go.mod h1:JFQDqqZv17uJLQSZOKa9siuLTK4zMA3Bzk4amU9ZALU=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10 h1:yPxsz8RsXULC/xskWt7UrggaXMK59GedFtUeo6xzMG8=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10/go.mod h1:RJ/pYi7SwCjzuTDvlMksRjJgRwaUwuziIv+ApxqCv0U=
 ocm.software/open-component-model/bindings/go/ctf v0.4.0 h1:E2kDGJk/ZR2wMK6fk3yFr2Uv6AhfLdMmvdvQ7Y64/2s=
 ocm.software/open-component-model/bindings/go/ctf v0.4.0/go.mod h1:XaVTQK/STJ64pq8vClsT+onD0kEs7P+Wzsq1k2tp9h4=
 ocm.software/open-component-model/bindings/go/dag v0.0.6 h1:To76QJAmFD88C101oB/HgYvtomp8mm0270ewDLcVncw=

--- a/cli/integration/go.mod
+++ b/cli/integration/go.mod
@@ -14,7 +14,7 @@ require (
 	helm.sh/helm/v4 v4.1.4
 	ocm.software/open-component-model/bindings/go/blob v0.0.12
 	ocm.software/open-component-model/bindings/go/configuration v0.0.13
-	ocm.software/open-component-model/bindings/go/credentials v0.0.9
+	ocm.software/open-component-model/bindings/go/credentials v0.0.10
 	ocm.software/open-component-model/bindings/go/ctf v0.4.0
 	ocm.software/open-component-model/bindings/go/descriptor/normalisation v0.0.0-20260429073711-304fed31a996
 	ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20260429073711-304fed31a996

--- a/cli/integration/go.sum
+++ b/cli/integration/go.sum
@@ -456,8 +456,8 @@ ocm.software/open-component-model/bindings/go/configuration v0.0.13 h1:fARaCEkyB
 ocm.software/open-component-model/bindings/go/configuration v0.0.13/go.mod h1:B8rEZoPPL4bAYhsi5I4IZJ8EJSOwMupd95Lw/N0TBRA=
 ocm.software/open-component-model/bindings/go/constructor v0.0.7 h1:w1VB//QLrbC6r+lB8FHqcu4dK43wQD0MgULTsxFc0hA=
 ocm.software/open-component-model/bindings/go/constructor v0.0.7/go.mod h1:Aont6PV4Tm4ZU6ESOZdnnhJ+YV7LBeKM98+PSaMX+wA=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9 h1:sYKfVKs+CrVL2EuKYNevCjXq1cdF0DsLnWyEjamjDdY=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9/go.mod h1:JFQDqqZv17uJLQSZOKa9siuLTK4zMA3Bzk4amU9ZALU=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10 h1:yPxsz8RsXULC/xskWt7UrggaXMK59GedFtUeo6xzMG8=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10/go.mod h1:RJ/pYi7SwCjzuTDvlMksRjJgRwaUwuziIv+ApxqCv0U=
 ocm.software/open-component-model/bindings/go/ctf v0.4.0 h1:E2kDGJk/ZR2wMK6fk3yFr2Uv6AhfLdMmvdvQ7Y64/2s=
 ocm.software/open-component-model/bindings/go/ctf v0.4.0/go.mod h1:XaVTQK/STJ64pq8vClsT+onD0kEs7P+Wzsq1k2tp9h4=
 ocm.software/open-component-model/bindings/go/dag v0.0.6 h1:To76QJAmFD88C101oB/HgYvtomp8mm0270ewDLcVncw=

--- a/kubernetes/controller/go.mod
+++ b/kubernetes/controller/go.mod
@@ -31,7 +31,7 @@ require (
 	golang.org/x/time v0.15.0
 	ocm.software/open-component-model/bindings/go/blob v0.0.12
 	ocm.software/open-component-model/bindings/go/configuration v0.0.13
-	ocm.software/open-component-model/bindings/go/credentials v0.0.9
+	ocm.software/open-component-model/bindings/go/credentials v0.0.10
 	ocm.software/open-component-model/bindings/go/ctf v0.4.0
 	ocm.software/open-component-model/bindings/go/descriptor/normalisation v0.0.0-20260429073711-304fed31a996
 	ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20260429073711-304fed31a996

--- a/kubernetes/controller/go.sum
+++ b/kubernetes/controller/go.sum
@@ -413,8 +413,8 @@ ocm.software/open-component-model/bindings/go/configuration v0.0.13 h1:fARaCEkyB
 ocm.software/open-component-model/bindings/go/configuration v0.0.13/go.mod h1:B8rEZoPPL4bAYhsi5I4IZJ8EJSOwMupd95Lw/N0TBRA=
 ocm.software/open-component-model/bindings/go/constructor v0.0.7 h1:w1VB//QLrbC6r+lB8FHqcu4dK43wQD0MgULTsxFc0hA=
 ocm.software/open-component-model/bindings/go/constructor v0.0.7/go.mod h1:Aont6PV4Tm4ZU6ESOZdnnhJ+YV7LBeKM98+PSaMX+wA=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9 h1:sYKfVKs+CrVL2EuKYNevCjXq1cdF0DsLnWyEjamjDdY=
-ocm.software/open-component-model/bindings/go/credentials v0.0.9/go.mod h1:JFQDqqZv17uJLQSZOKa9siuLTK4zMA3Bzk4amU9ZALU=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10 h1:yPxsz8RsXULC/xskWt7UrggaXMK59GedFtUeo6xzMG8=
+ocm.software/open-component-model/bindings/go/credentials v0.0.10/go.mod h1:RJ/pYi7SwCjzuTDvlMksRjJgRwaUwuziIv+ApxqCv0U=
 ocm.software/open-component-model/bindings/go/ctf v0.4.0 h1:E2kDGJk/ZR2wMK6fk3yFr2Uv6AhfLdMmvdvQ7Y64/2s=
 ocm.software/open-component-model/bindings/go/ctf v0.4.0/go.mod h1:XaVTQK/STJ64pq8vClsT+onD0kEs7P+Wzsq1k2tp9h4=
 ocm.software/open-component-model/bindings/go/dag v0.0.6 h1:To76QJAmFD88C101oB/HgYvtomp8mm0270ewDLcVncw=

--- a/kubernetes/controller/internal/controller/deployer/deployer_controller.go
+++ b/kubernetes/controller/internal/controller/deployer/deployer_controller.go
@@ -732,7 +732,7 @@ func resolveResourceCredentials(
 		return nil, fmt.Errorf("failed to create credential graph: %w", err)
 	}
 
-	creds, err := credGraph.Resolve(ctx, id)
+	creds, err := credGraph.Resolve(ctx, id) //nolint:staticcheck // SA1019: tracked migration to ResolveTyped in ocm-project#702
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve credentials: %w", err)
 	}

--- a/kubernetes/controller/internal/ocm/resource.go
+++ b/kubernetes/controller/internal/ocm/resource.go
@@ -48,7 +48,7 @@ func VerifyResource(ctx context.Context, pm *manager.PluginManager, resource *de
 			return nil, fmt.Errorf("failed creating credential graph: %w", err)
 		}
 
-		creds, err = credGraph.Resolve(ctx, id)
+		creds, err = credGraph.Resolve(ctx, id) //nolint:staticcheck // SA1019: tracked migration to ResolveTyped in ocm-project#702
 		if err != nil && !errors.Is(err, credentials.ErrNotFound) {
 			return nil, fmt.Errorf("failed resolving credentials for digest processor: %w", err)
 		}

--- a/kubernetes/controller/pkg/configuration/config_test.go
+++ b/kubernetes/controller/pkg/configuration/config_test.go
@@ -104,8 +104,8 @@ func TestGetConfigFromSecret(t *testing.T) {
 				Type: ocmruntime.Type{Version: genericv1.Version, Name: genericv1.ConfigType},
 				Configurations: []*ocmruntime.Raw{
 					{
-						Type: ocmruntime.Type{Version: "", Name: credentialsv1.ConfigType},
-						Data: []byte(`{"repositories":[{"repository":{"dockerConfig":"{\"auths\": {\"my-registry.io\": {\"username\":\"user\",\"password\":\"pass\",\"email\":\"\"}}}","type":"DockerConfig/v1"}}],"type":"credentials.config.ocm.software"}`),
+						Type: ocmruntime.Type{Version: credentialsv1.Version, Name: credentialsv1.ConfigType},
+						Data: []byte(`{"repositories":[{"repository":{"dockerConfig":"{\"auths\": {\"my-registry.io\": {\"username\":\"user\",\"password\":\"pass\",\"email\":\"\"}}}","type":"DockerConfig/v1"}}],"type":"credentials.config.ocm.software/v1"}`),
 					},
 				},
 			},
@@ -154,8 +154,8 @@ func TestGetConfigFromSecret(t *testing.T) {
 				Type: ocmruntime.Type{Version: genericv1.Version, Name: genericv1.ConfigType},
 				Configurations: []*ocmruntime.Raw{
 					{
-						Type: ocmruntime.Type{Version: "", Name: credentialsv1.ConfigType},
-						Data: []byte(`{"repositories":[{"repository":{"dockerConfig":"{\"auths\":{\"registry1.io\":{\"username\": \"user1\", \"password\": \"pass1\"},\"registry2.io\":{\"username\":\"user2\",\"password\":\"pass2\"}}}","type":"DockerConfig/v1"}}],"type":"credentials.config.ocm.software"}`),
+						Type: ocmruntime.Type{Version: credentialsv1.Version, Name: credentialsv1.ConfigType},
+						Data: []byte(`{"repositories":[{"repository":{"dockerConfig":"{\"auths\":{\"registry1.io\":{\"username\": \"user1\", \"password\": \"pass1\"},\"registry2.io\":{\"username\":\"user2\",\"password\":\"pass2\"}}}","type":"DockerConfig/v1"}}],"type":"credentials.config.ocm.software/v1"}`),
 					},
 				},
 			},
@@ -176,8 +176,8 @@ func TestGetConfigFromSecret(t *testing.T) {
 				Type: ocmruntime.Type{Version: genericv1.Version, Name: genericv1.ConfigType},
 				Configurations: []*ocmruntime.Raw{
 					{
-						Type: ocmruntime.Type{Version: "", Name: credentialsv1.ConfigType},
-						Data: []byte(`{"repositories":[{"repository":{"dockerConfig":"{\"auths\":{\"my-registry.io\":{\"auth\": \"dXNlcjpwYXNz\"}}}","type":"DockerConfig/v1"}}],"type":"credentials.config.ocm.software"}`),
+						Type: ocmruntime.Type{Version: credentialsv1.Version, Name: credentialsv1.ConfigType},
+						Data: []byte(`{"repositories":[{"repository":{"dockerConfig":"{\"auths\":{\"my-registry.io\":{\"auth\": \"dXNlcjpwYXNz\"}}}","type":"DockerConfig/v1"}}],"type":"credentials.config.ocm.software/v1"}`),
 					},
 				},
 			},


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Fixes test and lint failures caused by bumping `bindings/go/credentials` from v0.0.9 to v0.0.10 (#2331).

The v0.0.10 release added `ResolveTyped` to the `credentials.Resolver` interface and changed the default config type serialization to include the version suffix (`credentials.config.ocm.software/v1`).

Changes:
- Add `ResolveTyped` to test mock implementations that directly implement `credentials.Resolver` (constructor, OCI transformer)
- Add `//nolint:staticcheck` directives to deprecated `Resolve` calls that still need `map[string]string` until the full typed credentials migration is complete
- Update Kubernetes controller test expectations to match the new versioned config type serialization

#### Which issue(s) this PR fixes

Fixes #2331

Related epic: https://github.com/open-component-model/ocm-project/issues/702

#### Testing

```bash
task test
task test/integration
```