### PR TITLE
chore: add filepath patterns to gitguardian config

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,11 +1,31 @@
+version: 2
+
 secret:
   ignored_matches:
-  - match: 4132766f296d24c64452646571d72a1f88e66b72f27838c6749b071b0468939d
-    name: kubernetes/controller/examples public keys
-  - match: c41c71837a9ffbb3eb165eb1fb62ebed35c129c9597ee17460a831a66a372422
-    name: cli/cmd/cmd_test.go
-  - match: 57d4c1be78223b477215a9133e64eed43804b319138ad69e0d4f4d5b0ada836b
-    name: kubernetes/controller/test/e2e/testdata/docker-config-json/.docker-config-json
-  - match: 79b637493a4c76f72d00e49a2b21ed8df753a17214279912d3d51d1aa40899f2
-    name: kubernetes/controller/test/e2e/testdata/docker-config-json/bootstrap.yaml
-version: 2
+    - match: 4132766f296d24c64452646571d72a1f88e66b72f27838c6749b071b0468939d
+      name: kubernetes/controller/examples public keys
+    - match: c41c71837a9ffbb3eb165eb1fb62ebed35c129c9597ee17460a831a66a372422
+      name: cli/cmd/cmd_test.go
+    - match: 57d4c1be78223b477215a9133e64eed43804b319138ad69e0d4f4d5b0ada836b
+      name: kubernetes/controller/test/e2e/testdata/docker-config-json/.docker-config-json
+    - match: 79b637493a4c76f72d00e49a2b21ed8df753a17214279912d3d51d1aa40899f2
+      name: kubernetes/controller/test/e2e/testdata/docker-config-json/bootstrap.yaml
+  
+  ignored_paths:
+    # based on: https://docs.gitguardian.com/secrets-detection/customize-detection/exclusion-rules#filepath-suggestions
+    # --- Documentation and static content ---
+    - "**/docs/**"
+    - "**/README*"
+    - "**/*.md"
+    - "**/LICENSE*"
+    
+    # --- Test and mock data ---
+    - "**/test/**"
+    - "**/tests/**"
+    - "**/*test*"
+    - "**/mock/**"
+    - "**/*.test.*"
+    
+    # --- Package manager lock files ---
+    - "**/package-lock.json"
+    - "**/go.sum"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
add filepath patterns to gitguardian config
