### PR TITLE
chore: replace Docker label checker with github-script composite action

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -153,14 +153,6 @@ jobs:
           # files_to_ignore: ''
   verify-labels:
     needs: [labeler, size-labeler, conventional-commit-labeler]
-    name: verify labels
-    # docker://agilepathway/pull-request-label-checker is an amd64-only image.
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    steps:
-      - name: PRs should have at least one qualifying label
-        uses: docker://agilepathway/pull-request-label-checker:latest@sha256:14f5f3dfda922496d07d53494e2d2b42885165f90677a1c03d600059b7706a61
-        with:
-          any_of: kind/chore,kind/bugfix,kind/feature,kind/dependency,kind/refactor
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/verify-labels.yaml
+    with:
+      any_of: kind/chore,kind/bugfix,kind/feature,kind/dependency,kind/refactor

--- a/.github/workflows/verify-labels.yaml
+++ b/.github/workflows/verify-labels.yaml
@@ -1,0 +1,39 @@
+name: Verify PR Labels
+
+on:
+  workflow_call:
+    inputs:
+      any_of:
+        description: Comma-separated list of labels, at least one must be present
+        required: true
+        type: string
+
+permissions:
+  pull-requests: read
+
+jobs:
+  verify-labels:
+    name: verify labels
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          ANY_OF: ${{ inputs.any_of }}
+        with:
+          script: |
+            const required = process.env.ANY_OF.split(',').map(l => l.trim());
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const prLabels = labels.map(l => l.name);
+            const match = required.find(r => prLabels.includes(r));
+            if (match) {
+              core.info(`Found qualifying label: ${match}`);
+            } else {
+              core.setFailed(
+                `PR needs at least one of: ${required.join(', ')}\n` +
+                `Current labels: ${prLabels.join(', ') || '(none)'}`
+              );
+            }


### PR DESCRIPTION
## Summary

- Remove `docker://agilepathway/pull-request-label-checker` (amd64-only Docker image)
- Add `.github/actions/verify-labels/` composite action using `actions/github-script`
- Same interface (`any_of` comma-separated labels) and behavior (fail if no qualifying label)
- Now runs on `ubuntu-24.04-arm` — no architecture lock-in, faster (no image pull)

## Test plan

- [ ] Open a PR without qualifying labels → job should fail with clear message listing current labels
- [ ] Open a PR with `kind/feature` label → job should pass
- [ ] Verify `verify-labels` job runs after `labeler`, `size-labeler`, `conventional-commit-labeler`