### PR TITLE
fix(ci): Add read permissions for pull-request verification in workflow

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -154,5 +154,7 @@ jobs:
   verify-labels:
     needs: [labeler, size-labeler, conventional-commit-labeler]
     uses: ./.github/workflows/verify-labels.yaml
+    permissions:
+      pull-requests: read
     with:
       any_of: kind/chore,kind/bugfix,kind/feature,kind/dependency,kind/refactor


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

forgot to add a missing read permission on the workflow caller

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

https://github.com/open-component-model/open-component-model/actions/runs/25434503972

