### PR TITLE
fix(renovate): update schedules and group names for GitHub Actions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -58,7 +58,7 @@
     {
       matchManagers: ['github-actions'],
       matchDepNames: ['go'],
-      groupName: 'Golang Versions',
+      groupName: 'Golang versions',
       groupSlug: 'golang-versions',
       schedule: [
         '* * * * 0' // At every minute on Sunday it is allowed to create branches

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,6 +31,9 @@
     {
       matchFileNames: ['kubernetes/controller/chart/**'],
       enabled: true,
+      schedule: [
+        '* * * * 0' // At every minute on Sunday it is allowed to create branches
+      ],
     },
     {
       matchUpdateTypes: ['minor','patch'],
@@ -55,8 +58,11 @@
     {
       matchManagers: ['github-actions'],
       matchDepNames: ['go'],
-      groupName: 'Golang versions',
-      groupSlug: 'golang-versions',
+      groupName: 'Github Actions',
+      groupSlug: 'github-actions',
+      schedule: [
+        '* * * * 0' // At every minute on Sunday it is allowed to create branches
+      ],
     },
     {
       matchManagers: [
@@ -73,7 +79,7 @@
       groupSlug: 'kubernetes-deps',
       schedule: [
         '* * * * 0' // At every minute on Sunday it is allowed to create branches
-      ]
+      ],
     },
     {
       groupName: 'Docker dependencies',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -58,8 +58,8 @@
     {
       matchManagers: ['github-actions'],
       matchDepNames: ['go'],
-      groupName: 'Github Actions',
-      groupSlug: 'github-actions',
+      groupName: 'Golang Versions',
+      groupSlug: 'golang-versions',
       schedule: [
         '* * * * 0' // At every minute on Sunday it is allowed to create branches
       ],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Adjusted the schedule for branch creation and renamed the group for GitHub Actions dependencies to improve clarity and functionality.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Testing

##### How to test the changes

<!--
Required files to test the changes:

.ocmconfig
```yaml
type: generic.config.ocm.software/v1
configurations:
  - type: credentials.config.ocm.software
    repositories:
      - repository:
          type: DockerConfig/v1
          dockerConfigFile: "~/.docker/config.json"
```

Commands that test the change:

```bash
ocm get cv xxx

ocm transfer xxx
```
-->

##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
