### PR TITLE
feat!: remove snake_case docker consts

### DIFF
--- a/bindings/go/oci/credentials/docker_config.go
+++ b/bindings/go/oci/credentials/docker_config.go
@@ -27,21 +27,9 @@ const (
 	CredentialKeyAccessToken = credentialsv1.CredentialKeyAccessToken
 	// CredentialKeyRefreshToken is the key for OAuth2 refresh tokens.
 	CredentialKeyRefreshToken = credentialsv1.CredentialKeyRefreshToken
-	// LegacyCredentialKeyAccessToken is the legacy snake_case key for access tokens.
-	//
-	// Deprecated: Use CredentialKeyAccessToken instead.
-	//nolint:staticcheck // will be removed in the future
-	LegacyCredentialKeyAccessToken = credentialsv1.LegacyCredentialKeyAccessToken
-	// LegacyCredentialKeyRefreshToken is the legacy snake_case key for refresh tokens.
-	//
-	// Deprecated: Use CredentialKeyRefreshToken instead.
-	//nolint:staticcheck // will be removed in the future
-	LegacyCredentialKeyRefreshToken = credentialsv1.LegacyCredentialKeyRefreshToken
 )
 
 // CredentialFromMap converts a credential map to an auth.Credential.
-// It supports both canonical camelCase keys and legacy snake_case keys for token fields,
-// with camelCase taking precedence.
 func CredentialFromMap(credentials map[string]string) auth.Credential {
 	cred := auth.Credential{}
 	if v, ok := credentials[CredentialKeyUsername]; ok {
@@ -52,12 +40,8 @@ func CredentialFromMap(credentials map[string]string) auth.Credential {
 	}
 	if v, ok := credentials[CredentialKeyAccessToken]; ok {
 		cred.AccessToken = v
-	} else if v, ok := credentials[LegacyCredentialKeyAccessToken]; ok {
-		cred.AccessToken = v
 	}
 	if v, ok := credentials[CredentialKeyRefreshToken]; ok {
-		cred.RefreshToken = v
-	} else if v, ok := credentials[LegacyCredentialKeyRefreshToken]; ok {
 		cred.RefreshToken = v
 	}
 	return cred

--- a/bindings/go/oci/credentials/docker_config_test.go
+++ b/bindings/go/oci/credentials/docker_config_test.go
@@ -90,38 +90,6 @@ func TestCredentialFunc(t *testing.T) {
 			wantErr:   false,
 			wantEmpty: false,
 		},
-		{
-			name: "legacy snake_case token keys",
-			identity: runtime.Identity{
-				runtime.IdentityAttributeHostname: "example.com",
-			},
-			credentials: map[string]string{
-				"access_token":  "snake-access",
-				"refresh_token": "snake-refresh",
-			},
-			hostport: "example.com",
-			wantCred: &auth.Credential{
-				AccessToken:  "snake-access",
-				RefreshToken: "snake-refresh",
-			},
-		},
-		{
-			name: "camelCase takes precedence over snake_case",
-			identity: runtime.Identity{
-				runtime.IdentityAttributeHostname: "example.com",
-			},
-			credentials: map[string]string{
-				"accessToken":   "camel-access",
-				"access_token":  "snake-access",
-				"refreshToken":  "camel-refresh",
-				"refresh_token": "snake-refresh",
-			},
-			hostport: "example.com",
-			wantCred: &auth.Credential{
-				AccessToken:  "camel-access",
-				RefreshToken: "camel-refresh",
-			},
-		},
 	}
 
 	for _, tt := range tests {
@@ -185,34 +153,6 @@ func TestCredentialFromMap(t *testing.T) {
 				Password:     "pass",
 				AccessToken:  "atoken",
 				RefreshToken: "rtoken",
-			},
-		},
-		{
-			name: "legacy snake_case keys",
-			credentials: map[string]string{
-				"username":      "user",
-				"password":      "pass",
-				"access_token":  "atoken",
-				"refresh_token": "rtoken",
-			},
-			expected: auth.Credential{
-				Username:     "user",
-				Password:     "pass",
-				AccessToken:  "atoken",
-				RefreshToken: "rtoken",
-			},
-		},
-		{
-			name: "camelCase takes precedence over snake_case",
-			credentials: map[string]string{
-				"accessToken":   "camel",
-				"access_token":  "snake",
-				"refreshToken":  "camel-refresh",
-				"refresh_token": "snake-refresh",
-			},
-			expected: auth.Credential{
-				AccessToken:  "camel",
-				RefreshToken: "camel-refresh",
 			},
 		},
 	}

--- a/bindings/go/oci/spec/credentials/v1/oci_credentials.go
+++ b/bindings/go/oci/spec/credentials/v1/oci_credentials.go
@@ -16,15 +16,6 @@ const (
 	CredentialKeyAccessToken = "accessToken"
 	// CredentialKeyRefreshToken is the key for OAuth2 refresh tokens.
 	CredentialKeyRefreshToken = "refreshToken"
-
-	// LegacyCredentialKeyAccessToken is the legacy snake_case key for access tokens.
-	//
-	// Deprecated: Use CredentialKeyAccessToken instead. The removal of this key is tracked here: https://github.com/open-component-model/ocm-project/issues/1037
-	LegacyCredentialKeyAccessToken = "access_token"
-	// LegacyCredentialKeyRefreshToken is the legacy snake_case key for refresh tokens.
-	//
-	// Deprecated: Use CredentialKeyRefreshToken instead. The removal of this key is tracked here: https://github.com/open-component-model/ocm-project/issues/1037
-	LegacyCredentialKeyRefreshToken = "refresh_token"
 )
 
 // OCICredentials represents typed credentials for OCI registry authentication.
@@ -55,21 +46,12 @@ func MustRegisterCredentialType(scheme *runtime.Scheme) {
 
 // FromDirectCredentials converts a DirectCredentials properties map into typed OCICredentials.
 // This supports old .ocmconfig files that use Credentials/v1 with OCI registry properties.
-// It handles both canonical camelCase keys and legacy snake_case keys, with camelCase
-// taking precedence.
 func FromDirectCredentials(properties map[string]string) *OCICredentials {
 	return &OCICredentials{
 		Type:         runtime.NewVersionedType(OCICredentialsType, Version),
 		Username:     properties[CredentialKeyUsername],
 		Password:     properties[CredentialKeyPassword],
-		AccessToken:  stringWithFallback(properties, CredentialKeyAccessToken, LegacyCredentialKeyAccessToken),
-		RefreshToken: stringWithFallback(properties, CredentialKeyRefreshToken, LegacyCredentialKeyRefreshToken),
+		AccessToken:  properties[CredentialKeyAccessToken],
+		RefreshToken: properties[CredentialKeyRefreshToken],
 	}
-}
-
-func stringWithFallback(m map[string]string, key, fallback string) string {
-	if v, ok := m[key]; ok {
-		return v
-	}
-	return m[fallback]
 }

--- a/bindings/go/oci/spec/credentials/v1/oci_credentials_test.go
+++ b/bindings/go/oci/spec/credentials/v1/oci_credentials_test.go
@@ -44,36 +44,6 @@ func TestFromDirectCredentials(t *testing.T) {
 			},
 		},
 		{
-			name: "legacy snake_case keys",
-			properties: map[string]string{
-				"username":      "myuser",
-				"password":      "mypass",
-				"access_token":  "legacy_token",
-				"refresh_token": "legacy_refresh",
-			},
-			expected: &OCICredentials{
-				Type:         runtime.NewVersionedType(OCICredentialsType, Version),
-				Username:     "myuser",
-				Password:     "mypass",
-				AccessToken:  "legacy_token",
-				RefreshToken: "legacy_refresh",
-			},
-		},
-		{
-			name: "camelCase takes precedence over snake_case",
-			properties: map[string]string{
-				"accessToken":   "camel",
-				"access_token":  "snake",
-				"refreshToken":  "camel_refresh",
-				"refresh_token": "snake_refresh",
-			},
-			expected: &OCICredentials{
-				Type:         runtime.NewVersionedType(OCICredentialsType, Version),
-				AccessToken:  "camel",
-				RefreshToken: "camel_refresh",
-			},
-		},
-		{
 			name:       "empty properties",
 			properties: map[string]string{},
 			expected: &OCICredentials{


### PR DESCRIPTION
#### What this PR does / why we need it
Removed the legacy `snake_case` support for docker credential fields.

#### Which issue(s) this PR fixes
Fixes: https://github.com/open-component-model/ocm-project/issues/1037
