### PR TITLE
fix: spares-checkout automatically sets --filter=blob:none which does not fetch blobs for git-cliff

### DIFF
--- a/.github/workflows/release-candidate-version.yml
+++ b/.github/workflows/release-candidate-version.yml
@@ -55,17 +55,14 @@ jobs:
       highest_previous_release_version: ${{ steps.latest.outputs.highest_previous_release_version }}
     steps:
       # Checkout the repository and target branch
+      # Full checkout (no sparse-checkout): actions/checkout auto-applies
+      # --filter=blob:none whenever sparse-checkout is set, and git-cliff (libgit2)
+      # cannot lazy-fetch blobs from a partial clone, erroring with "object not found"
+      # during rename detection on history walks.
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          sparse-checkout: |
-            ${{ inputs.component_path }}
-            .github/scripts
           fetch-depth: 0
-          # v6 defaults to --filter:blob:none. Then lazy-fetch fails to get blobs
-          # from a partial clone resulting in "object not found" when walking history.
-          # We force disable that filter logic here.
-          filter: ''
           ref: ${{ inputs.branch }}
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-candidate-version.yml
+++ b/.github/workflows/release-candidate-version.yml
@@ -62,6 +62,10 @@ jobs:
             ${{ inputs.component_path }}
             .github/scripts
           fetch-depth: 0
+          # v6 defaults to --filter:blob:none. Then lazy-fetch fails to get blobs
+          # from a partial clone resulting in "object not found" when walking history.
+          # We force disable that filter logic here.
+          filter: ''
           ref: ${{ inputs.branch }}
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
On-behalf-of: Gergely Brautigam <gergely.brautigam@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Fixes https://github.com/open-component-model/open-component-model/actions/runs/25478944168
and https://github.com/open-component-model/open-component-model/actions/runs/25478961745

Force disable v6 partial blob fetching feature.

So what happens with git-cliff is that it doesn't read that, it reads the history. It walks the buckets and libgit2 isn't checking that out with lazy-fetch in case a spares-checkout is defined.

So when sparse-checkout is SET, the action automatically sets --filter=blob:none. set here: https://github.com/actions/checkout/blob/de0fac2e4500dabe0009e67214ff5f5447ce83dd/src/git-source-provider.ts#L165-L169



#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Testing

##### How to test the changes

<!--
Required files to test the changes:

.ocmconfig
```yaml
type: generic.config.ocm.software/v1
configurations:
  - type: credentials.config.ocm.software
    repositories:
      - repository:
          type: DockerConfig/v1
          dockerConfigFile: "~/.docker/config.json"
```

Commands that test the change:

```bash
ocm get cv xxx

ocm transfer xxx
```
-->

##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
