### PR TITLE
chore: pin git-cliff version to v2.12.0

### DIFF
--- a/.github/workflows/release-candidate-version.yml
+++ b/.github/workflows/release-candidate-version.yml
@@ -55,13 +55,12 @@ jobs:
       highest_previous_release_version: ${{ steps.latest.outputs.highest_previous_release_version }}
     steps:
       # Checkout the repository and target branch
-      # Full checkout (no sparse-checkout): actions/checkout auto-applies
-      # --filter=blob:none whenever sparse-checkout is set, and git-cliff (libgit2)
-      # cannot lazy-fetch blobs from a partial clone, erroring with "object not found"
-      # during rename detection on history walks.
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          sparse-checkout: |
+            ${{ inputs.component_path }}
+            .github/scripts
           fetch-depth: 0
           ref: ${{ inputs.branch }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -87,6 +86,8 @@ jobs:
           # Empty when this is the first release (no previous tag exists).
           CHANGELOG_RANGE: ${{ steps.compute.outputs.changelog_range }}
         with:
+          # pinning because our release broke with v2.13.0
+          version: 'v2.12.0'
           github_token: ${{ secrets.GITHUB_TOKEN }}
           config: ${{ inputs.component_path }}/cliff.toml
           args: |


### PR DESCRIPTION
On-behalf-of: Gergely Brautigam <gergely.brautigam@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Testing

##### How to test the changes

<!--
Required files to test the changes:

.ocmconfig
```yaml
type: generic.config.ocm.software/v1
configurations:
  - type: credentials.config.ocm.software
    repositories:
      - repository:
          type: DockerConfig/v1
          dockerConfigFile: "~/.docker/config.json"
```

Commands that test the change:

```bash
ocm get cv xxx

ocm transfer xxx
```
-->

##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
