### PR TITLE
chore(docs): add support for .dockerconfigjson format in docstring

### DIFF
--- a/kubernetes/controller/api/v1alpha1/common_types.go
+++ b/kubernetes/controller/api/v1alpha1/common_types.go
@@ -41,7 +41,7 @@ const (
 // +kubebuilder:validation:XValidation:rule="((!has(self.apiVersion) || self.apiVersion == \"\" || self.apiVersion == \"v1\") && (self.kind == \"Secret\" || self.kind == \"ConfigMap\")) || (self.apiVersion == \"delivery.ocm.software/v1alpha1\" && (self.kind == \"Repository\" || self.kind == \"Component\" || self.kind == \"Resource\" || self.kind == \"Replication\"))",message="apiVersion must be one of \"v1\" with kind \"Secret\" or \"ConfigMap\" or \"delivery.ocm.software/v1alpha1\" with the kind of an OCM kubernetes object"
 type OCMConfiguration struct {
 	// Ref reference config maps or secrets containing arbitrary
-	// ocm config data (in the ocm config file format), or other configurable
+	// ocm config data (in the ocm config file or .dockerconfigjson format), or other configurable
 	// ocm api objects (Repository, Component, Resource) to
 	// reuse their propagated configuration.
 	NamespacedObjectKindReference `json:",inline"`


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Apparently the ocm controllers not only support pull credentials in ocm config format but also in .dockerconfigjson format.
Update the docstring in the API to reflect this.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Testing

##### How to test the changes

<!--
Required files to test the changes:

.ocmconfig
```yaml
type: generic.config.ocm.software/v1
configurations:
  - type: credentials.config.ocm.software
    repositories:
      - repository:
          type: DockerConfig/v1
          dockerConfigFile: "~/.docker/config.json"
```

Commands that test the change:

```bash
ocm get cv xxx

ocm transfer xxx
```
-->

##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
