### PR TITLE
chore(ci): move CodeQL from pr/main into scheduled scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,31 +362,44 @@ jobs:
           MODULE: ${{ matrix.module }}
         run: task "${MODULE}:test"
 
+  check-go-changes:
+    name: "Check Go Changes"
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      pull-requests: read
+    outputs:
+      go_changed: ${{ steps.filter.outputs.go }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: .github
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
+        id: filter
+        with:
+          filters: |
+            go:
+              - '**/*.go'
+              - '**/go.mod'
+              - '**/go.sum'
+
   analyze-go:
-    name: "Analyze Go Modules"
-    needs: discover_modules
+    name: "Analyze Go"
+    needs: check-go-changes
+    if: ${{ needs.check-go-changes.outputs.go_changed == 'true' || github.event_name == 'push' }}
     # CodeQL bundles (codeql-action, codeql-cli-binaries) ship linux64 only - no ARM64 binary.
     runs-on: ubuntu-latest
-    timeout-minutes: 360
+    timeout-minutes: 120
     permissions:
       actions: read
       # Automatically downgraded to read-only for pull requests from forks
       # https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/#setting-permissions-in-the-workflow
       # but are kept for runs on main or on pull requests on branches in the repo (renovate).
       security-events: write
-    if: ${{ fromJSON(needs.discover_modules.outputs.modules_json)[0] != null }} # skip if no modules are found
-    strategy:
-      fail-fast: false
-      matrix:
-        project: ${{ fromJSON(needs.discover_modules.outputs.modules_json) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          # we have a self reference here because CodeQL does introspection on the step
-          sparse-checkout: |
-            .github/workflows/ci.yml
-            ${{ matrix.project }}
           persist-credentials: false
       - name: Initialize CodeQL
         uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
@@ -395,7 +408,6 @@ jobs:
           queries: security-extended
       - name: Autobuild
         uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
-
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
         with:
@@ -441,6 +453,7 @@ jobs:
     needs:
       - discover_modules
       - generate
+      - check-go-changes
       - analyze-go
       - run_unit_tests
       - run_integration_tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,7 @@ jobs:
               - '**/*.go'
               - '**/go.mod'
               - '**/go.sum'
+              - '.github/workflows/ci.yml'
 
   analyze-go:
     name: "Analyze Go"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,58 +362,6 @@ jobs:
           MODULE: ${{ matrix.module }}
         run: task "${MODULE}:test"
 
-  check-go-changes:
-    name: "Check Go Changes"
-    runs-on: ubuntu-24.04-arm
-    permissions:
-      pull-requests: read
-    outputs:
-      go_changed: ${{ steps.filter.outputs.go }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          sparse-checkout: .github
-          persist-credentials: false
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
-        id: filter
-        with:
-          filters: |
-            go:
-              - '**/*.go'
-              - '**/go.mod'
-              - '**/go.sum'
-              - '.github/workflows/ci.yml'
-
-  analyze-go:
-    name: "Analyze Go"
-    needs: check-go-changes
-    if: ${{ needs.check-go-changes.outputs.go_changed == 'true' || github.event_name == 'push' }}
-    # CodeQL bundles (codeql-action, codeql-cli-binaries) ship linux64 only - no ARM64 binary.
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    permissions:
-      actions: read
-      # Automatically downgraded to read-only for pull requests from forks
-      # https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/#setting-permissions-in-the-workflow
-      # but are kept for runs on main or on pull requests on branches in the repo (renovate).
-      security-events: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
-        with:
-          languages: go
-          queries: security-extended
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
-        with:
-          category: "/language:go"
-
   generate:
     runs-on: ubuntu-24.04-arm
     name: "Code Generation"
@@ -454,8 +402,6 @@ jobs:
     needs:
       - discover_modules
       - generate
-      - check-go-changes
-      - analyze-go
       - run_unit_tests
       - run_integration_tests
       - golangci_lint

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,20 +1,20 @@
+# CodeQL SAST Analysis
+#
+# Runs on a daily schedule and manual dispatch instead of per-PR/push.
+# This is sufficient because:
+# 1. golangci-lint (with gosec) already runs per-PR and catches pattern-based
+#    security issues with fast feedback on ARM runners.
+# 2. CodeQL's deeper data-flow/taint analysis is expensive (x86-only, ~20min+)
+#    and rarely surfaces issues that golangci-lint misses in day-to-day changes.
+# 3. Running daily on the default branch ensures new findings surface within 24h
+#    of merge — acceptable latency for the deeper analysis tier.
+# 4. workflow_dispatch allows on-demand runs for security-sensitive changes.
 name: "CodeQL"
 
 on:
-  pull_request:
-    paths:
-      - '**/*.go'
-      - '**/go.mod'
-      - '**/go.sum'
-      - '.github/workflows/codeql.yml'
-  push:
-    branches:
-      - main
-    paths:
-      - '**/*.go'
-      - '**/go.mod'
-      - '**/go.sum'
-      - '.github/workflows/codeql.yml'
+  schedule:
+    - cron: '27 3 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -27,9 +27,6 @@ jobs:
     timeout-minutes: 120
     permissions:
       actions: read
-      # Automatically downgraded to read-only for pull requests from forks
-      # https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/#setting-permissions-in-the-workflow
-      # but are kept for runs on main or on pull requests on branches in the repo (renovate).
       security-events: write
     steps:
       - name: Checkout repository

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: "CodeQL"
+
+on:
+  pull_request:
+    paths:
+      - '**/*.go'
+      - '**/go.mod'
+      - '**/go.sum'
+      - '.github/workflows/codeql.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '**/*.go'
+      - '**/go.mod'
+      - '**/go.sum'
+      - '.github/workflows/codeql.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze-go:
+    name: "Analyze Go"
+    # CodeQL bundles (codeql-action, codeql-cli-binaries) ship linux64 only - no ARM64 binary.
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      actions: read
+      # Automatically downgraded to read-only for pull requests from forks
+      # https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/#setting-permissions-in-the-workflow
+      # but are kept for runs on main or on pull requests on branches in the repo (renovate).
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
+        with:
+          languages: go
+          queries: security-extended
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
+        with:
+          category: "/language:go"


### PR DESCRIPTION
## Summary

- Replace per-module CodeQL matrix (34 parallel x86 runners) with single full-repo scan on schedule

## Expected savings

~90% reduction in CodeQL CI minutes (34 runners → 1, only run on schedule so cardinality is reduced)

## Test plan
- [ ] Verify CodeQL runs successfully on this PR (single scan, full repo)
- [ ] Verify `check-go-changes` correctly detects Go file changes
- [ ] Confirm SARIF upload to code scanning dashboard works without per-module category
- [ ] Test with a docs-only commit to verify CodeQL is skipped