### PR TITLE
fix(credentialgraph): fix decade old credential resolution bug

### DIFF
--- a/bindings/go/credentials/graph_test.go
+++ b/bindings/go/credentials/graph_test.go
@@ -275,6 +275,9 @@ func GetGraph(t testing.TB, yaml string) (credentials.Resolver, error) {
 					if credentials["roleid"] != "my-role-id" {
 						return nil, fmt.Errorf("failed access")
 					}
+					if identity[runtime.IdentityAttributeHostname] != "myvault.example.com" {
+						return nil, fmt.Errorf("no secret for consumer: %v", identity)
+					}
 					return map[string]string{
 						"role_id":   "myvault.example.com-role",
 						"secret_id": "myvault.example.com-secret",
@@ -311,10 +314,12 @@ func GetGraph(t testing.TB, yaml string) (credentials.Resolver, error) {
 					switch vaultHost {
 					// this is the vault instance we are connected to, that's why we use a closure
 					case "myvault.example.com":
-						// in here, we'd have to check for the identity
 						roleid, secret := credentials["role_id"], credentials["secret_id"]
 						if roleid != "myvault.example.com-role" || secret != "myvault.example.com-secret" {
 							return nil, fmt.Errorf("failed access")
+						}
+						if identity[runtime.IdentityAttributeHostname] != "other.vault.com" {
+							return nil, fmt.Errorf("no secret for consumer: %v", identity)
 						}
 						return map[string]string{
 							"role_id":   "other.vault.com-role",
@@ -324,6 +329,9 @@ func GetGraph(t testing.TB, yaml string) (credentials.Resolver, error) {
 						roleid, secret := credentials["role_id"], credentials["secret_id"]
 						if roleid != "other.vault.com-role" || secret != "other.vault.com-secret" {
 							return nil, fmt.Errorf("failed access")
+						}
+						if identity[runtime.IdentityAttributeHostname] != "docker.io" {
+							return nil, fmt.Errorf("no secret for consumer: %v", identity)
 						}
 						return map[string]string{
 							"username": "foo",

--- a/bindings/go/credentials/graph_test.go
+++ b/bindings/go/credentials/graph_test.go
@@ -272,9 +272,6 @@ func GetGraph(t testing.TB, yaml string) (credentials.Resolver, error) {
 					},
 				},
 				CredentialFunc: func(ctx context.Context, identity runtime.Identity, credentials map[string]string) (map[string]string, error) {
-					if identity["secretId"] != "vault-access-creds" {
-						return nil, fmt.Errorf("failed access")
-					}
 					if credentials["roleid"] != "my-role-id" {
 						return nil, fmt.Errorf("failed access")
 					}
@@ -285,6 +282,22 @@ func GetGraph(t testing.TB, yaml string) (credentials.Resolver, error) {
 				},
 			}, nil
 		case runtime.NewUnversionedType("HashiCorpVault"):
+			// Extract vault host from the typed credential.
+			// During resolution this is a runtime.Identity with "hostname" field.
+			// During ingestion this is a *runtime.Raw with "serverURL" field.
+			var vaultHost string
+			if id, ok := repoType.(runtime.Identity); ok {
+				vaultHost = id[runtime.IdentityAttributeHostname]
+			} else {
+				data, _ := json.Marshal(repoType)
+				var mm map[string]any
+				_ = json.Unmarshal(data, &mm)
+				if surl, ok := mm["serverURL"].(string); ok {
+					parsedURL, _ := url.Parse(surl)
+					vaultHost = parsedURL.Hostname()
+				}
+			}
+
 			return CredentialPlugin{
 				ConsumerIdentityTypeAttributes: map[runtime.Type]map[string]func(v any) (string, string){
 					runtime.NewUnversionedType("HashiCorpVault"): {
@@ -295,8 +308,10 @@ func GetGraph(t testing.TB, yaml string) (credentials.Resolver, error) {
 					},
 				},
 				CredentialFunc: func(ctx context.Context, identity runtime.Identity, credentials map[string]string) (map[string]string, error) {
-					switch identity["hostname"] {
+					switch vaultHost {
+					// this is the vault instance we are connected to, that's why we use a closure
 					case "myvault.example.com":
+						// in here, we'd have to check for the identity
 						roleid, secret := credentials["role_id"], credentials["secret_id"]
 						if roleid != "myvault.example.com-role" || secret != "myvault.example.com-secret" {
 							return nil, fmt.Errorf("failed access")
@@ -317,7 +332,7 @@ func GetGraph(t testing.TB, yaml string) (credentials.Resolver, error) {
 					}
 
 					return map[string]string{
-						"vaultSecret": "vault-secret-for-https://" + identity["hostname"] + "/",
+						"vaultSecret": "vault-secret-for-https://" + vaultHost + "/",
 					}, nil
 				},
 			}, nil

--- a/bindings/go/credentials/resolve_direct.go
+++ b/bindings/go/credentials/resolve_direct.go
@@ -54,7 +54,7 @@ func (g *Graph) resolveFromGraph(ctx context.Context, identity runtime.Identity)
 		childMap := typedToMap(childCredentials)
 
 		// Let the plugin resolve the child's credentials.
-		credentials, err := plugin.Resolve(ctx, childID, childMap)
+		credentials, err := plugin.Resolve(ctx, identity, childMap)
 		if err != nil {
 			return nil, fmt.Errorf("no credentials for node %q resolved from plugin: %w", edgeID, err)
 		}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Instead of passing the actual to-be-resolved consumer identity to credential plugins, we passed the credential plugins identity itself.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Testing

##### How to test the changes

<!--
Required files to test the changes:

.ocmconfig
```yaml
type: generic.config.ocm.software/v1
configurations:
  - type: credentials.config.ocm.software
    repositories:
      - repository:
          type: DockerConfig/v1
          dockerConfigFile: "~/.docker/config.json"
```

Commands that test the change:

```bash
ocm get cv xxx

ocm transfer xxx
```
-->

##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
