### PR TITLE
chore(deps): tune renovate dependency lanes

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,17 +15,17 @@
     enabled: true,
   },
   'updateNotScheduled': true, // Update branches that have already been created
-  'minimumReleaseAge': '28 days',
+  timezone: 'Europe/Berlin',
+  'minimumReleaseAge': '7 days',
   'branchPrefix': 'renovate/',
   'gitAuthor': 'ocmbot[bot] <125909804+ocmbot[bot]@users.noreply.github.com>',
   'gitIgnoredAuthors': [
     '125909804+ocmbot[bot]@users.noreply.github.com',
   ],
-  prConcurrentLimit: 0,
-  prHourlyLimit: 0,
+  prConcurrentLimit: 10,
+  prHourlyLimit: 3,
   automerge: false,
   automergeType: "pr",
-  separateMinorPatch: true,
   separateMultipleMajor: true,
   packageRules: [
     {


### PR DESCRIPTION
## Summary
- keep the existing weekend-oriented Renovate schedules and package-family groups intact
- restore finite PR limits so Renovate cannot open everything at once
- remove global separateMinorPatch so patch and minor updates can stay bundled when grouped
- lower the global minimum release age from 28 days to 7 days and set Europe/Berlin scheduling

## Validation
- npx --yes json5 .github/renovate.json5 > /tmp/renovate.json && node -e "JSON.parse(require('fs').readFileSync('/tmp/renovate.json','utf8')); console.log('json5 ok')"