### PR TITLE
chore(releases-07): gh auth in tag creation (#2567)

### DIFF
--- a/.github/scripts/create-tag.js
+++ b/.github/scripts/create-tag.js
@@ -58,11 +58,20 @@ export function createAndPushTag({ tag, commit, message, execGit = defaultExecGi
 /**
  * Default git executor using child_process.execFileSync.
  *
+ * Authenticates via GITHUB_TOKEN when present. This is required because the
+ * checkout action sets persist-credentials: false (enforced by zizmor), so git
+ * has no stored credentials for push. The token must be passed to the script
+ * via the workflow step's env block.
+ *
  * @param {string[]} args - Git arguments.
  * @returns {string} Trimmed stdout.
  */
 function defaultExecGit(args) {
-  return execFileSync("git", args, { encoding: "utf-8", stdio: "pipe" }).trim();
+  const token = process.env.GITHUB_TOKEN;
+  const authArgs = token
+    ? ["-c", `http.extraHeader=Authorization: basic ${Buffer.from(`x-access-token:${token}`).toString("base64")}`]
+    : [];
+  return execFileSync("git", [...authArgs, ...args], { encoding: "utf-8", stdio: "pipe" }).trim();
 }
 
 // --------------------------

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -92,6 +92,9 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           TAG: ${{ needs.prepare.outputs.new_tag }}
+          # create-tag.js uses GITHUB_TOKEN to authenticate git push because
+          # the checkout above sets persist-credentials: false (zizmor requirement).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           script: |
             const script = await import('${{ github.workspace }}/.github/scripts/create-tag.js');
@@ -280,6 +283,9 @@ jobs:
         env:
           RC_TAG: ${{ needs.prepare.outputs.new_tag }}
           NEW_RELEASE_TAG: ${{ needs.prepare.outputs.promotion_tag }}
+          # create-tag.js uses GITHUB_TOKEN to authenticate git push because
+          # the checkout above sets persist-credentials: false (zizmor requirement).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           script: |
             const script = await import('${{ github.workspace }}/.github/scripts/create-tag.js');

--- a/.github/workflows/controller-release.yml
+++ b/.github/workflows/controller-release.yml
@@ -88,6 +88,9 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           TAG: ${{ needs.prepare.outputs.new_tag }}
+          # create-tag.js uses GITHUB_TOKEN to authenticate git push because
+          # the checkout above sets persist-credentials: false (zizmor requirement).
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
         with:
           github-token: ${{ steps.get_token.outputs.token }}
           script: |
@@ -274,6 +277,9 @@ jobs:
         env:
           RC_TAG: ${{ needs.prepare.outputs.new_tag }}
           NEW_RELEASE_TAG: ${{ needs.prepare.outputs.promotion_tag }}
+          # create-tag.js uses GITHUB_TOKEN to authenticate git push because
+          # the checkout above sets persist-credentials: false (zizmor requirement).
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
         with:
           github-token: ${{ steps.get_token.outputs.token }}
           script: |


### PR DESCRIPTION
On-behalf-of: SAP <matthias.bruns@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

create-tag.js doesnt have enough permissions after the added `persist-credentials: false` everywhere.


https://github.com/open-component-model/open-component-model/actions/runs/26087971515/job/76708718696#logs

https://github.com/open-component-model/open-component-model/actions/runs/26087971515/job/76708718696

This PR adds the injection of the `GITHUB_TOKEN` into the script. It was tested locally.

#### Testing

```node
#!/usr/bin/env node
// @ts-check
// Local smoke-test: verifies that the GITHUB_TOKEN auth header used by
// create-tag.js can authenticate git over HTTPS. Safe — only runs ls-remote.
//
// Usage:
//   GITHUB_TOKEN=ghp_... node .github/scripts/test-git-auth.js
//   node .github/scripts/test-git-auth.js ghp_...

import { execFileSync } from "child_process";

const token = process.argv[2] ?? process.env.GITHUB_TOKEN;

if (!token) {
  console.error("Usage: GITHUB_TOKEN=<token> node test-git-auth.js");
  console.error("   or: node test-git-auth.js <token>");
  process.exit(1);
}

const encoded = Buffer.from(`x-access-token:${token}`).toString("base64");
const authHeader = `Authorization: basic ${encoded}`;

console.log("Token prefix:", token.substring(0, 8) + "...");
console.log("Header:      ", authHeader.substring(0, 36) + "...");
console.log("");

try {
  const result = execFileSync(
    "git",
    ["-c", `http.extraHeader=${authHeader}`, "ls-remote", "origin", "HEAD"],
    { encoding: "utf-8", stdio: "pipe" },
  ).trim();
  console.log("✅ Auth OK — origin HEAD:", result);
} catch (err) {
  console.error("❌ Auth failed:", err.stderr ?? err.message);
  process.exit(1);
}

```

```text
$ node .github/scripts/test-git-auth.js
Token prefix: ghp_M0rl...
Header:       Authorization: basic XXXXX

✅ Auth OK — origin HEAD: 03c8a87e709f6bf90da0e180ed40eeec7e4dcdfa       HEAD
```

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Testing

##### How to test the changes

<!--
Required files to test the changes:

.ocmconfig
```yaml
type: generic.config.ocm.software/v1
configurations:
  - type: credentials.config.ocm.software
    repositories:
      - repository:
          type: DockerConfig/v1
          dockerConfigFile: "~/.docker/config.json"
```

Commands that test the change:

```bash
ocm get cv xxx

ocm transfer xxx
```
-->

##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
