### PR TITLE
fix(cli): suppress version check warning for pseudo-version builds

### DIFF
--- a/cli/cmd/setup/versioncheck.go
+++ b/cli/cmd/setup/versioncheck.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/spf13/cobra"
 
 	ocmctx "ocm.software/open-component-model/cli/internal/context"
@@ -75,6 +76,15 @@ func isVersionCheckDisabled(cmd *cobra.Command, currentVersion string) bool {
 	// Dev builds have no meaningful version to compare.
 	if currentVersion == "" || currentVersion == "n/a" {
 		slog.Debug("version check skipped: no build version set")
+		return true
+	}
+
+	// Pseudo-versions (e.g. 0.0.0-20260520062203-abc) are produced by go install from
+	// an untagged commit. They are not real releases and must not trigger a warning.
+	// RCs and alphas (e.g. 0.6.0-rc.1) are intentional pre-releases and should warn.
+	if v, err := semver.NewVersion(currentVersion); err != nil ||
+		(v.Major() == 0 && v.Minor() == 0 && v.Patch() == 0 && v.Prerelease() != "") {
+		slog.Debug("version check skipped: dev/pseudo-version build", slog.String("version", currentVersion))
 		return true
 	}
 

--- a/cli/cmd/setup/versioncheck_test.go
+++ b/cli/cmd/setup/versioncheck_test.go
@@ -1,0 +1,40 @@
+package setup
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func Test_isVersionCheckDisabled_devVersions(t *testing.T) {
+	tests := []struct {
+		version string
+		skip    bool
+	}{
+		{"", true},
+		{"n/a", true},
+		// pseudo-versions produced by go install from untagged commit
+		{"0.0.0-20260520062203-565e352c12c5", true},
+		{"v0.0.0-20260520062203-565e352c12c5", true},
+		{"0.0.0-dev", true},
+		// intentional pre-releases — must NOT skip
+		{"0.6.0-rc.1", false},
+		{"v0.6.0-rc.1", false},
+		{"0.6.0-alpha.1", false},
+		{"0.6.0-beta.2", false},
+		// stable release
+		{"0.6.0", false},
+		{"v0.6.0", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "root"}
+			cmd.SetContext(t.Context())
+			got := isVersionCheckDisabled(cmd, tt.version)
+			if got != tt.skip {
+				t.Errorf("isVersionCheckDisabled(%q) = %v, want %v", tt.version, got, tt.skip)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`go install` from an untagged commit produces a pseudo-version like `v0.0.0-20260520062203-565e352c12c5`. Because semver treats `0.0.0-<prerelease> < 0.6.0`, the version check always fired and showed a spurious "newer version available" warning for developer builds.

## Fix

In `isVersionCheckDisabled`, after rejecting `""` / `"n/a"`, parse the current version and skip when it is `0.0.0` with any prerelease segment. This covers all pseudo-versions from `go install` while leaving intentional pre-releases (e.g. `0.6.0-rc.1`, `0.6.0-alpha.1`) to warn normally — which is the desired behaviour.
