### PR TITLE
docs(website): tighten Sigstore how-to tabs and link to new tutorial

### DIFF
--- a/website/content/docs/concepts/signing-and-verification-concept.md
+++ b/website/content/docs/concepts/signing-and-verification-concept.md
@@ -288,9 +288,12 @@ without needing any out-of-band information.
 
 This matters directly for OCM's sovereign-delivery and air-gapped scenarios. The component version is the unit of transport,
 and OCM carries the proof of authorship along with it: the signed descriptor and the bundle embedded inside it travel as one.
+
 The only piece a verifier needs in addition is a local trusted-root file — the public keys of the Fulcio CA and the Rekor
 instance the component was signed against, whether that is public-good Sigstore or an enterprise stack — distributed into the
-disconnected environment once, out of band. With those pieces in place, `ocm verify cv` runs entirely offline: no callback to
+disconnected environment once, out of band.
+
+With those pieces in place, `ocm verify cv` runs entirely offline: no callback to
 any Sigstore service, no TUF refresh, no network egress whatsoever. This is what makes Sigstore viable in regulated and
 sovereign-cloud deployments where egress to public or on-premise infrastructure is not permitted at verification time.
 

--- a/website/content/docs/concepts/signing-and-verification-concept.md
+++ b/website/content/docs/concepts/signing-and-verification-concept.md
@@ -269,16 +269,30 @@ When using PEM encoding for signing, the credential referenced by `public_key_pe
 
 ### Sigstore (Keyless)
 
-Sigstore replaces the long-lived key pair at the heart of RSA signing with a short-lived certificate bound to your OIDC identity. The signer logs in to an identity provider; Sigstore issues a certificate valid for ~10 minutes; the signature is recorded in a public transparency log. Verifiers don't pin a public key — they declare which identity they trust.
+Sigstore replaces the long-lived key pair at the heart of RSA signing with a short-lived certificate bound to your OIDC identity.
+The signer logs in to an identity provider; Sigstore issues a certificate valid for ~10 minutes; the signature is recorded in a public transparency log.
+Verifiers don't pin a public key — they declare which identity they trust.
 
-The Sigstore stack is four cooperating pieces. For the public-good happy path (`sigstore.dev`) you don't deploy any of them; for an enterprise stack a platform team has already deployed them and you point your config at their endpoints.
+The Sigstore stack is four cooperating pieces. For the public-good happy path (`sigstore.dev`) you don't deploy any of them;
+for an enterprise stack a platform team has already deployed them and you point your config at their endpoints.
 
 - **OIDC IdP** — the identity provider you log in to (Google, GitHub, Microsoft, or your corporate IdP). The token it issues proves *who* is signing.
 - **Fulcio** — a short-lived certificate authority. It accepts your OIDC token and issues a certificate (valid for ~10 minutes) that binds the token's identity claims to a fresh signing key.
 - **Rekor** — an append-only public transparency log. Every signature is recorded so anyone can audit when, and by whom, it was made.
 - **TUF** — the mechanism clients use to discover the current trusted roots for Fulcio and Rekor. The verifier uses it to know which CA and which log to trust.
 
-The signature payload stored in the component descriptor is a Sigstore bundle: the signature bytes, the Fulcio certificate, and the Rekor inclusion proof, all in one self-contained blob.
+The signature payload stored in the component descriptor is a Sigstore bundle: the signature bytes, the Fulcio certificate,
+and the Rekor inclusion proof, all in one self-contained blob. This self-containment is a key design principle of Sigstore:
+the signature value includes everything a verifier needs to validate the signature and establish trust in the signer's identity,
+without needing any out-of-band information.
+
+This matters directly for OCM's sovereign-delivery and air-gapped scenarios. The component version is the unit of transport,
+and OCM carries the proof of authorship along with it: the signed descriptor and the bundle embedded inside it travel as one.
+The only piece a verifier needs in addition is a local trusted-root file — the public keys of the Fulcio CA and the Rekor
+instance the component was signed against, whether that is public-good Sigstore or an enterprise stack — distributed into the
+disconnected environment once, out of band. With those pieces in place, `ocm verify cv` runs entirely offline: no callback to
+any Sigstore service, no TUF refresh, no network egress whatsoever. This is what makes Sigstore viable in regulated and
+sovereign-cloud deployments where egress to public or on-premise infrastructure is not permitted at verification time.
 
 ```yaml
 signature:

--- a/website/content/docs/concepts/signing-and-verification-concept.md
+++ b/website/content/docs/concepts/signing-and-verification-concept.md
@@ -188,27 +188,25 @@ A component version can have **multiple signatures** from different parties, ena
 
 ## Supported Signing Algorithms
 
-OCM currently only supports RSA-based signing algorithms:
+OCM supports two algorithm families: long-lived RSA key pairs and keyless signing via [Sigstore](https://www.sigstore.dev/).
 
-| Algorithm | Type | Characteristics |
-| --------- | ---- | --------------- |
-| RSASSA-PSS (default) | Asymmetric | Probabilistic, stronger security guarantees, recommended for new implementations |
-| RSA-PKCS#1 v1.5 | Asymmetric | Deterministic, widely supported, compatible with legacy systems |
+| Algorithm | Type | Trust Model | Characteristics |
+| --------- | ---- | ----------- | --------------- |
+| RSASSA-PSS (default) | Asymmetric (RSA) | Public key or certificate chain | Probabilistic, stronger security guarantees, recommended for new RSA-based implementations |
+| RSA-PKCS#1 v1.5 | Asymmetric (RSA) | Public key or certificate chain | Deterministic, widely supported, compatible with legacy systems |
+| Sigstore (keyless, early access) | Asymmetric (ECDSA, ephemeral) | OIDC identity | Short-lived certificate from Fulcio bound to your OIDC identity, transparency-log entry in Rekor; no long-lived keys to manage |
 
 To override the default signing algorithm or encoding policy, see the `--signer-spec` flag in the [CLI reference]({{< relref "/docs/reference/ocm-cli/ocm_sign_component-version.md" >}}).
 The signer spec file configures only the algorithm and encoding policy — credentials are always resolved separately via the [`.ocmconfig`]({{< relref "configure-multiple-credentials.md" >}}) file.
 
-For key management, OCM uses PEM-encoded key files configured in the `.ocmconfig`:
+For RSA-based signing, OCM uses PEM-encoded key files configured in the `.ocmconfig`:
 
 - **Private keys**: Used by producers to sign component versions
 - **Public keys**: Distributed to consumers for verification
 
 See [How-to: Generate Signing Keys]({{< relref "generate-signing-keys.md" >}}) for creating RSA key pairs.
 
-{{< callout context="tip" title="Upcoming Sigstore Support" icon="outline/bulb" >}}
-We are planning to add support for [Sigstore](https://www.sigstore.dev/) and Cosign as an additional signing mechanism.
-This will enable keyless signing workflows and improved supply chain security. Stay tuned for updates.
-{{< /callout >}}
+Sigstore-based signing has no long-lived keys: a fresh signing key is generated per signature and certified by Fulcio against your OIDC identity. See [Sigstore (Keyless)](#sigstore-keyless) below.
 
 ### Signature Encoding Policies
 
@@ -269,9 +267,38 @@ A common source of confusion: "PEM" in `signatureEncodingPolicy` refers to the *
 When using PEM encoding for signing, the credential referenced by `public_key_pem` / `public_key_pem_file` must contain **X.509 certificates** (not bare public keys), because the certificate chain is embedded into the signature for self-contained verification.
 {{< /callout >}}
 
+### Sigstore (Keyless)
+
+Sigstore replaces the long-lived key pair at the heart of RSA signing with a short-lived certificate bound to your OIDC identity. The signer logs in to an identity provider; Sigstore issues a certificate valid for ~10 minutes; the signature is recorded in a public transparency log. Verifiers don't pin a public key — they declare which identity they trust.
+
+The Sigstore stack is four cooperating pieces. For the public-good happy path (`sigstore.dev`) you don't deploy any of them; for an enterprise stack a platform team has already deployed them and you point your config at their endpoints.
+
+- **OIDC IdP** — the identity provider you log in to (Google, GitHub, Microsoft, or your corporate IdP). The token it issues proves *who* is signing.
+- **Fulcio** — a short-lived certificate authority. It accepts your OIDC token and issues a certificate (valid for ~10 minutes) that binds the token's identity claims to a fresh signing key.
+- **Rekor** — an append-only public transparency log. Every signature is recorded so anyone can audit when, and by whom, it was made.
+- **TUF** — the mechanism clients use to discover the current trusted roots for Fulcio and Rekor. The verifier uses it to know which CA and which log to trust.
+
+The signature payload stored in the component descriptor is a Sigstore bundle: the signature bytes, the Fulcio certificate, and the Rekor inclusion proof, all in one self-contained blob.
+
+```yaml
+signature:
+  algorithm: sigstore
+  mediaType: application/vnd.dev.sigstore.bundle.v0.3+json
+  issuer: https://github.com/login/oauth
+  value: <base64-encoded Sigstore bundle>
+```
+
+Because the certificate is in the bundle and the trust roots come from TUF (or an enterprise trusted-root file), no encoding-policy choice is involved — Sigstore is its own algorithm with its own bundle format.
+
+For how this changes what verifiers pin, see [Identity-Based Trust](#identity-based-trust-sigstore) below.
+
+{{< callout context="note" title="Sigstore signing is in early access" icon="outline/info-circle" >}}
+Sigstore (keyless) signing is currently being rolled out and we are awaiting feedback. The interface may evolve based on that feedback.
+{{< /callout >}}
+
 ## Trust Models
 
-The encoding policy you choose determines how verifiers establish trust in a signature.
+The algorithm and encoding policy you choose determine how verifiers establish trust in a signature. OCM supports three trust models.
 
 ### Key Pinning (Plain Encoding)
 
@@ -291,15 +318,26 @@ The signer embeds the certificate chain (leaf + any intermediates) directly in t
 - Supports organizational delegation: the root CA can issue intermediate CAs for different teams
 - The root CA is never embedded in the signature; OCM rejects self-signed certificates found in the embedded chain
 
+### Identity-Based Trust (Sigstore)
+
+The signer authenticates to an OIDC identity provider; Fulcio binds that identity to a short-lived certificate; Rekor records the signature in a public transparency log. The verifier doesn't pin a key or a CA — it declares **which OIDC identity** it trusts.
+
+- No long-lived keys to manage, distribute, or rotate
+- Trust anchor is the signer's identity (e.g. `jane.doe@example.com` via `https://github.com/login/oauth`), not a public key
+- Public-good Sigstore (`sigstore.dev`) is shared infrastructure; an enterprise stack runs Fulcio/Rekor/TUF inside the organization
+- Audit trail is automatic and public (or organization-internal for enterprise stacks)
+
 ### When to Use Each
 
-| Criterion | Plain (Key Pinning) | PEM (Certificate Chain) |
-| --------- | ------------------- | ----------------------- |
-| PKI infrastructure available | No | Yes |
-| Number of signers | Few | Many or changing |
-| Key rotation complexity | High (update all verifiers) | Low (root CA stays stable) |
-| Signature is self-contained | No (public key needed separately) | Yes |
-| Recommended for | Simple setups, personal projects | Enterprise environments |
+| Criterion | Plain (Key Pinning) | PEM (Certificate Chain) | Sigstore (Identity) |
+| --------- | ------------------- | ----------------------- | ------------------- |
+| Long-lived keys to manage | Yes | Yes (issued by your CA) | No |
+| PKI infrastructure available | No | Yes | N/A (Fulcio replaces it) |
+| Number of signers | Few | Many or changing | Anyone with an OIDC identity |
+| Key rotation complexity | High (update all verifiers) | Low (root CA stays stable) | None (certs are short-lived) |
+| Signature is self-contained | No (public key needed separately) | Yes | Yes (bundle includes cert + log proof) |
+| Audit trail | Build your own | Build your own | Built-in (Rekor) |
+| Recommended for | Simple setups, personal projects | Enterprise environments with existing PKI | Teams that want to skip key management entirely |
 
 For hands-on steps, see [Tutorial: Plain Signatures]({{< relref "docs/tutorials/signing/plain.md" >}}) and [Tutorial: Certificate Chains (PEM)]({{< relref "docs/tutorials/signing/pem.md" >}}).
 

--- a/website/content/docs/how-to/Sign and Verify/_index.md
+++ b/website/content/docs/how-to/Sign and Verify/_index.md
@@ -9,11 +9,11 @@ sidebar:
 
 Protect the integrity and authenticity of your component versions through cryptographic signing and verification.
 
-These guides walk you through the complete signing workflow — from generating keys to verifying signatures in production.
+These guides walk you through the complete signing workflow — covering both keyed (RSA) and keyless (Sigstore) algorithms, from generating keys or trusting identities to verifying signatures in production.
 
 ## Guides in This Section
 
 - **Generate Signing Keys** — Create RSA key pairs for signing and verification
 - **Configure Signing Credentials** — Set up OCM to use your keys
-- **Sign Component Versions** — Attach cryptographic signatures to component versions
-- **Verify Component Versions** — Validate signatures to ensure authenticity and integrity
+- **Sign Component Versions** — Attach cryptographic signatures to component versions, using either RSA or Sigstore (keyless)
+- **Verify Component Versions** — Validate signatures to ensure authenticity and integrity, for either RSA or Sigstore (keyless)

--- a/website/content/docs/how-to/Sign and Verify/sign-component-version.md
+++ b/website/content/docs/how-to/Sign and Verify/sign-component-version.md
@@ -172,12 +172,13 @@ If you've done classical key-based signing, here's what changes:
 
 | Aspect | RSA | Sigstore |
 | --- | --- | --- |
-| Before you sign | Generate key pair, configure `.ocmconfig` with file paths | Nothing — just log in when prompted |
-| What proves authorship | Possession of the private key | Your OIDC login (e.g. corporate email) |
+| Before you start | Generate key pair, configure `.ocmconfig` with file paths | Nothing — just log in when prompted |
+| What proves trust | Possession of the private key | Your OIDC login (e.g. corporate email) |
 | What the verifier needs | Your public key, distributed somehow | Your expected identity (email + provider) |
-| Audit trail | None unless you build one | Public, automatic |
 
-**Mental model:** your identity is the key. When you sign, you log in with your OIDC provider (Google, GitHub, Microsoft, …). Sigstore issues a short-lived certificate that binds the signature to that identity. The verifier doesn't need a public key from you — they just check that the identity in the certificate is one they trust.
+Sigstore also gives you a public, automatic audit trail (Rekor transparency log); RSA gives you none unless you build one.
+
+For the conceptual picture (how Fulcio, Rekor, and OIDC fit together), see [Identity-Based Trust (Sigstore)]({{< relref "docs/concepts/signing-and-verification-concept.md#identity-based-trust-sigstore" >}}).
 
 <!-- markdownlint-disable-next-line MD024 -->
 ## You'll end up with
@@ -191,10 +192,13 @@ If you've done classical key-based signing, here's what changes:
 
 - [OCM CLI installed]({{< relref "ocm-cli-installation.md" >}})
 - A browser on the same machine (signing opens a browser window to log you in)
+- An OIDC identity with a provider supported by your Sigstore stack — on public Sigstore that's Google, GitHub, or Microsoft
+- Network access to `*.sigstore.dev` (in particular `fulcio.sigstore.dev`, `oauth2.sigstore.dev`, `rekor.sigstore.dev`, `tuf-repo-cdn.sigstore.dev`) — corporate networks often block these
+- If `cosign` isn't on your PATH or its version is too low, OCM downloads and caches it under `~/.cache/ocm/cosign/...` automatically; subsequent runs skip the download
 - A component version in a CTF archive or OCI registry (we'll use `github.com/acme.org/helloworld:1.0.0` from the [getting started guide]({{< relref "create-component-version.md" >}}); any component you can write to works)
 
 {{< callout context="note" >}}
-Want the full picture of what's happening behind the scenes (Fulcio certificates, Rekor transparency log, OIDC token flow)? A dedicated Sigstore tutorial is in the works. For now, [ADR 0017: Sigstore Integration](https://github.com/open-component-model/open-component-model/blob/main/docs/adr/0017_sigstore_integration.md) covers the design.
+For the end-to-end walkthrough including how Fulcio certificates, Rekor transparency log, and the OIDC token flow fit together, see [Tutorial: Sigstore (Keyless)]({{< relref "docs/tutorials/signing/sigstore.md" >}}). Design background lives in [ADR 0017: Sigstore Integration](https://github.com/open-component-model/open-component-model/blob/main/docs/adr/0017_sigstore_integration.md).
 {{< /callout >}}
 
 <!-- markdownlint-disable-next-line MD024 -->
@@ -289,10 +293,6 @@ signature:
 time=2026-05-19T17:43:28.524+02:00 level=INFO msg="signed successfully" name=default digest=91dd197868907487e62872695db1fa7b397fde300bcbae23e24abc188fb147ad hashAlgorithm=SHA-256 normalisationAlgorithm=jsonNormalisation/v4alpha1
 ```
 {{< /details >}}
-
-{{< callout context="tip" >}}
-If the `cosign` binary is not on your PATH or its version to low, OCM will download and cache the binary into `~/.cache/ocm/cosign/...`. Subsequent runs skip the download.
-{{< /callout >}}
 
 {{< /step >}}
 

--- a/website/content/docs/how-to/Sign and Verify/verify-component-version.md
+++ b/website/content/docs/how-to/Sign and Verify/verify-component-version.md
@@ -140,13 +140,13 @@ Verify a [Sigstore](https://www.sigstore.dev/) keyless signature. There's no pub
 
 If you've done classical key-based verification, here's what changes:
 
-| Aspect               | RSA                                                    | Sigstore                                                        |
-|----------------------|--------------------------------------------------------|-----------------------------------------------------------------|
-| Before you verify    | Obtain the signer's public key, configure `.ocmconfig` | Nothing — declare expected identity in a verifier spec file     |
-| What proves trust    | Signature decrypts with the public key you have        | Signature ties back to an OIDC identity you've decided to trust |
-| Key rotation problem | You re-distribute the new public key                   | Doesn't apply — there's no long-lived key                       |
+| Aspect                  | RSA                                                    | Sigstore                                                        |
+| ----------------------- | ------------------------------------------------------ | --------------------------------------------------------------- |
+| Before you start        | Obtain the signer's public key, configure `.ocmconfig` | Nothing — declare expected identity in a verifier spec file     |
+| What proves trust       | Signature decrypts with the public key you have        | Signature ties back to an OIDC identity you've decided to trust |
+| What the verifier needs | The signer's public key (rotated and re-distributed)   | The expected OIDC identity and issuer — no long-lived key       |
 
-**Mental model:** instead of asking "does this signature match the public key I was handed?" you ask "was this signed by `jane.doe@example.com` logging in via GitHub?" The verifier only needs to know **who** to trust.
+For the conceptual picture (how Fulcio, Rekor, and OIDC fit together), see [Identity-Based Trust (Sigstore)]({{< relref "docs/concepts/signing-and-verification-concept.md#identity-based-trust-sigstore" >}}).
 
 <!-- markdownlint-disable-next-line MD024 -->
 ## You'll end up with
@@ -163,7 +163,7 @@ If you've done classical key-based verification, here's what changes:
 - The expected signer identity (their OIDC email and which provider they logged in with)
 
 {{< callout context="note" >}}
-Want the full picture of how Sigstore verification works behind the scenes (Fulcio certificate validation, Rekor inclusion proofs, TUF trust roots)? A dedicated Sigstore tutorial is in the works. For now, [ADR 0017: Sigstore Integration](https://github.com/open-component-model/open-component-model/blob/main/docs/adr/0017_sigstore_integration.md) covers the design.
+For the end-to-end walkthrough including Fulcio certificate validation, Rekor inclusion proofs, and TUF trust roots, see [Tutorial: Sigstore (Keyless)]({{< relref "docs/tutorials/signing/sigstore.md" >}}). Design background lives in [ADR 0017: Sigstore Integration](https://github.com/open-component-model/open-component-model/blob/main/docs/adr/0017_sigstore_integration.md).
 {{< /callout >}}
 
 <!-- markdownlint-disable-next-line MD024 -->
@@ -252,33 +252,22 @@ time=2026-05-19T18:49:13.856+02:00 level=INFO msg="SIGNATURE VERIFICATION SUCCES
 
 ### Verify a specific signature
 
-If the component carries multiple signatures (e.g. an RSA signature and a Sigstore signature), select one with `--signature`:
+If the component carries multiple signatures (e.g. an RSA signature and a Sigstore signature), select one by **name** with `--signature`. The name is whatever was set at sign time — `default` if no `--signature` flag was passed:
 
 ```bash
 ocm verify cv \
   --verifier-spec ./sigstore-verify.yaml \
-  --signature sigstore \
+  --signature default \
   ghcr.io/<your namespace>//github.com/acme.org/helloworld:1.0.0
 ```
 
 {{< callout context="note" >}}
-The verifier spec's `type` field decides **which** verifier handles the signature. The `--signature` flag picks **which** signature on the component to verify.
+The verifier spec's `type` field decides **which algorithm/handler** verifies the signature. The `--signature` flag picks **which named signature** on the component to verify (matched by name, not by algorithm).
 {{< /callout >}}
 
 {{< /step >}}
 
 {{< /steps >}}
-
-## Inspect the recorded identity (optional)
-
-If verification fails because of an identity mismatch, you can read the identity directly from the signature to see what to put in your spec:
-
-```bash
-ocm get cv /tmp/helloworld/transport-archive//github.com/acme.org/helloworld:1.0.0 -o yaml \
-  | yq '.[0].signatures[] | select(.signature.algorithm == "sigstore")'
-```
-
-Look for the signer email and the OIDC issuer URL. Those are exactly what `certificateIdentity` and `certificateOIDCIssuer` are matched against.
 
 <!-- markdownlint-disable-next-line MD024 -->
 ## Troubleshooting
@@ -301,7 +290,7 @@ Error: SIGNATURE VERIFICATION FAILED: cosign verify-blob failed: exit status 1
 stderr: Error: failed to verify certificate identity: no matching CertificateIdentity found, last error: expected issuer value "https://accounts.google.com", got "https://github.com/login/oauth"
 ```
 
-**Fix:** Inspect the signature (see above) to read the actual identity, and update `certificateIdentity` / `certificateOIDCIssuer` to match. Watch for trailing slashes and capitalization.
+**Fix:** Update `certificateIdentity` / `certificateOIDCIssuer` in your verifier spec to match the identity actually recorded in the signature. Watch for trailing slashes and capitalization. To read the actual identity stored in the signature, see [Tutorial: Sigstore (Keyless) — Inspect the signature]({{< relref "docs/tutorials/signing/sigstore.md" >}}).
 
 ### Symptom: "keyless verification requires both an issuer constraint ... and an identity constraint"
 

--- a/website/content/docs/tutorials/signing/_index.md
+++ b/website/content/docs/tutorials/signing/_index.md
@@ -5,3 +5,13 @@ icon: "✍️"
 weight: 55
 toc: false
 ---
+
+OCM supports three signing approaches. Pick the tutorial that matches the trust model you want to use.
+
+| Tutorial | Algorithm | Trust anchor | When to choose it |
+| --- | --- | --- | --- |
+| [Plain Signatures]({{< relref "plain.md" >}}) | RSA key pair | Public key the verifier holds | Small teams, self-signed workflows, no PKI |
+| [Certificate Chains (PEM)]({{< relref "pem.md" >}}) | RSA + X.509 chain | Root CA the verifier holds | Existing PKI, organizational delegation, key rotation without verifier reconfiguration |
+| [Sigstore (Keyless)]({{< relref "sigstore.md" >}}) | Sigstore (ECDSA, ephemeral) | OIDC identity the verifier trusts | Skip key management entirely; built-in audit trail via the Rekor transparency log |
+
+For the conceptual background and a side-by-side comparison of the three trust models, see [Concept: Signing and Verification — Trust Models]({{< relref "docs/concepts/signing-and-verification-concept.md#trust-models" >}}).

--- a/website/content/docs/tutorials/signing/pem.md
+++ b/website/content/docs/tutorials/signing/pem.md
@@ -575,4 +575,5 @@ Use `--force` to overwrite or choose a different name with `--signature`.
 ## Related Documentation
 
 - [Plain Signatures]({{< relref "docs/tutorials/signing/plain.md" >}}) -- Basic key-pair signing without certificate chains
+- [Sigstore (Keyless)]({{< relref "docs/tutorials/signing/sigstore.md" >}}) -- Identity-based signing — no keys to manage
 - [Configure Credentials for Signing]({{< relref "configure-signing-credentials.md" >}}) -- Full credential configuration reference

--- a/website/content/docs/tutorials/signing/plain.md
+++ b/website/content/docs/tutorials/signing/plain.md
@@ -84,8 +84,7 @@ components:
 EOF
 
 # Create component version in a CTF archive located at ./transport-archive
-ocm add cv 
-
+ocm add cv
 ```
 
 You should see that the component version was created successfully.

--- a/website/content/docs/tutorials/signing/plain.md
+++ b/website/content/docs/tutorials/signing/plain.md
@@ -318,3 +318,5 @@ rm -rf /tmp/ocm-signing-tutorial
 ## Related Documentation
 
 - [Concept: Signing and Verification]({{< relref "docs/concepts/signing-and-verification-concept.md" >}}) - Understand the theory behind OCM signing
+- [Tutorial: Certificate Chains (PEM)]({{< relref "docs/tutorials/signing/pem.md" >}}) - Same RSA key pair, but with an X.509 chain instead of a bare public key
+- [Tutorial: Sigstore (Keyless)]({{< relref "docs/tutorials/signing/sigstore.md" >}}) - Identity-based signing — no keys to manage

--- a/website/content/docs/tutorials/signing/sigstore.md
+++ b/website/content/docs/tutorials/signing/sigstore.md
@@ -1,0 +1,324 @@
+---
+title: "Sigstore (Keyless)"
+description: "Sign and verify a component version with your OIDC identity — no key pair to generate, no public key to distribute."
+icon: "🪪"
+weight: 30
+toc: true
+hasMermaid: true
+---
+
+In this tutorial you'll sign a component version with [Sigstore](https://www.sigstore.dev/) and verify it again — without generating a key pair. Your OIDC identity (Google, GitHub, or Microsoft) is what proves authorship, and a verifier only needs to know which identity to trust.
+
+For the conceptual background — what Fulcio, Rekor, and TUF each do, and how identity-based trust differs from key pinning — see [Concept: Sigstore (Keyless)]({{< relref "docs/concepts/signing-and-verification-concept.md#sigstore-keyless" >}}) and [Concept: Identity-Based Trust]({{< relref "docs/concepts/signing-and-verification-concept.md#identity-based-trust-sigstore" >}}).
+
+## What You'll Learn
+
+- Configure OCM to use your OIDC identity as a signing credential
+- Sign a component version with `ocm sign cv` against public Sigstore
+- Read the recorded identity out of a Sigstore signature
+- Verify the signature by declaring whose identity you trust
+
+**Estimated time:** ~10 minutes
+
+## How It Works
+
+```mermaid
+flowchart LR
+    subgraph sign ["Sign (You)"]
+        direction TB
+        A[Component Version] --> B[Browser-based OIDC login]
+        B --> C[Fulcio issues short-lived cert]
+        C --> D[Sign + record in Rekor]
+        D --> E[Signed Component Version]
+    end
+
+    E --> T["Share Component"]
+
+    T --> verify
+
+    subgraph verify ["Verify (Consumer)"]
+        direction TB
+        F[Signed Component Version] --> G[Check identity in cert]
+        G --> H{Matches expected<br/>identity?}
+        H -->|Yes| VALID["✓ Trusted"]
+        H -->|No| INVALID["✗ Rejected"]
+    end
+
+    style VALID fill:#dcfce7,color:#166534
+    style INVALID fill:#fee2e2,color:#991b1b
+```
+
+The producer logs in via OIDC; Fulcio binds that login to a short-lived signing certificate; the signature and certificate are recorded in the Rekor transparency log and embedded in the component descriptor. The consumer doesn't need a public key — they declare which OIDC identity they trust, and OCM checks that the signature was made by that identity.
+
+## Prerequisites
+
+- [OCM CLI installed]({{< relref "docs/getting-started/ocm-cli-installation.md" >}})
+- A web browser on the same machine — signing opens a browser window for OIDC login
+- An account at one of {Google, GitHub, Microsoft} — public Sigstore federates with these
+- Network access to `*.sigstore.dev` — corporate firewalls sometimes block these
+- A component version to sign (we'll create one if you don't have one)
+
+{{< callout context="note" title="Cosign is fetched automatically" icon="outline/info-circle" >}}
+The OCM CLI invokes the `cosign` binary under the hood. If it's not on your PATH (or the version is too old), OCM downloads and caches it under `~/.cache/ocm/cosign/...` on first use. Subsequent runs skip the download.
+{{< /callout >}}
+
+## Scenario
+
+- **Component:** `github.com/acme.org/helloworld:1.0.0` in a local CTF archive
+- **Working directory:** `/tmp/ocm-sigstore-tutorial`
+- **Signer identity:** your OIDC login at Google, GitHub, or Microsoft
+
+## Steps
+
+{{< steps >}}
+
+{{< step >}}
+
+### Create a sample component (if needed)
+
+If you already have a component version in a CTF archive, e.g. by following our [Create a Component Version]({{< relref "create-component-version.md" >}}) guide, skip to the next step.
+
+Otherwise create a small helloworld component:
+
+```bash
+mkdir -p /tmp/ocm-sigstore-tutorial && cd /tmp/ocm-sigstore-tutorial
+
+cat > component-constructor.yaml << 'EOF'
+components:
+- name: github.com/acme.org/helloworld
+  version: 1.0.0
+  provider:
+    name: acme.org
+EOF
+
+ocm add cv
+```
+
+<details>
+<summary>Expected output</summary>
+
+```text
+ COMPONENT                      │ VERSION │ PROVIDER
+────────────────────────────────┼─────────┼──────────
+ github.com/acme.org/helloworld │ 1.0.0   │ acme.org
+```
+
+</details>
+
+This creates a `transport-archive` directory containing your component version.
+
+{{< /step >}}
+
+{{< step >}}
+
+### Configure the signing credential
+
+Sigstore's signer credential is your OIDC identity, not a private key on disk. Tell OCM to obtain it interactively at sign time by adding a consumer entry to `.ocmconfig`:
+
+```bash
+cat > .ocmconfig << 'EOF'
+type: generic.config.ocm.software/v1
+configurations:
+- type: credentials.config.ocm.software
+  consumers:
+  - identity:
+      type: SigstoreSigner/v1alpha1
+      signature: default
+    credentials:
+    - type: OIDCIdentityTokenProvider/v1alpha1
+EOF
+```
+
+Two things are happening here:
+
+- **`identity.type: SigstoreSigner/v1alpha1`** — when `ocm sign` looks up a credential, this is the consumer identity it asks for. The `signature: default` field matches the default signature name; if you sign with `--signature prod`, you'd add a second entry with `signature: prod`.
+- **`credentials.type: OIDCIdentityTokenProvider/v1alpha1`** — instructs OCM to run the interactive OIDC flow (open a browser, exchange the code for a token) instead of reading a static token from the config. This is the only credential type that triggers the browser flow.
+
+No `algorithm` field is needed in the consumer identity — Sigstore is the only signing algorithm that uses this consumer type, so the lookup is unambiguous.
+
+{{< /step >}}
+
+{{< step >}}
+
+### Create the signer spec
+
+The signer spec selects which signing handler runs. Create `sigstore-sign.yaml`:
+
+```bash
+cat > sigstore-sign.yaml << 'EOF'
+type: SigstoreSigningConfiguration/v1alpha1
+EOF
+```
+
+That's the full signer spec for public Sigstore. With no other fields, the handler uses the public-good Fulcio (`fulcio.sigstore.dev`) and Rekor (`rekor.sigstore.dev`) endpoints, with trust roots discovered automatically via TUF.
+
+{{< callout context="note" title="Spec and credential work as a pair" icon="outline/info-circle" >}}
+The signer spec picks **how** to sign (which handler, which endpoints). The `.ocmconfig` consumer identity provides the credential **the handler asks for** (the OIDC token, in this case). Both must be present for signing to succeed — the spec on its own has no token, the credential on its own has no handler. Linking them is the consumer-identity `type` and `signature` fields.
+{{< /callout >}}
+
+{{< /step >}}
+
+{{< step >}}
+
+### Sign the component version
+
+Run the sign command with both files:
+
+```bash
+ocm sign cv \
+  --config ./.ocmconfig \
+  --signer-spec ./sigstore-sign.yaml \
+  ./transport-archive//github.com/acme.org/helloworld:1.0.0
+```
+
+A browser window opens against the public Sigstore login page (Dex). Pick your identity provider (Google, GitHub, or Microsoft), authenticate, and you'll see an OCM "Signing identity verified!" page. Return to the terminal — signing continues automatically.
+
+What just happened, in three sentences: OCM exchanged your OIDC token at Fulcio for a short-lived signing certificate (~10 minutes validity) bound to your email address. It hashed the component descriptor, signed the hash with the ephemeral key, and recorded the entry in the Rekor transparency log. The signature, the Fulcio certificate, and the Rekor inclusion proof are bundled into the component descriptor's `signatures` field as one self-contained blob.
+
+<details>
+<summary>Expected output</summary>
+
+```text
+digest:
+  hashAlgorithm: SHA-256
+  normalisationAlgorithm: jsonNormalisation/v4alpha1
+  value: 4e376182b3d535143e8e009b1e467df3a5b0c1f912c71ae432200654c355606f
+name: default
+signature:
+  algorithm: sigstore
+  issuer: https://accounts.google.com
+  mediaType: application/vnd.dev.sigstore.bundle.v0.3+json
+  value: eyJtZWRpYVR5cGUiOiJhcHBsaWNhdGlvbi92bmQuZGV2LnNpZ3N0b3JlLmJ1bmRsZS52MC4z...
+
+time=2026-05-20T15:32:55.725+02:00 level=INFO msg="signed successfully" name=default digest=4e376182b3d535143e8e009b1e467df3a5b0c1f912c71ae432200654c355606f hashAlgorithm=SHA-256 normalisationAlgorithm=jsonNormalisation/v4alpha1
+```
+
+</details>
+
+{{< /step >}}
+
+{{< step >}}
+
+### Inspect the signature
+
+Before verifying, take a look at what was actually written to the component descriptor. This is where Sigstore's identity-based trust becomes concrete:
+
+```bash
+ocm get cv ./transport-archive//github.com/acme.org/helloworld:1.0.0 -o yaml \
+  | yq '.[0].component.signatures[] | select(.signature.algorithm == "sigstore")'
+```
+
+You should see your signature with the recorded identity:
+
+```yaml
+name: default
+digest:
+  hashAlgorithm: SHA-256
+  normalisationAlgorithm: jsonNormalisation/v4alpha1
+  value: 4e376182b3d535143e8e009b1e467df3a5b0c1f912c71ae432200654c355606f
+signature:
+  algorithm: sigstore
+  issuer: https://accounts.google.com
+  mediaType: application/vnd.dev.sigstore.bundle.v0.3+json
+  value: <base64-encoded Sigstore bundle>
+```
+
+Note the `issuer` field: that's the OIDC provider you logged in with, copied into the component descriptor at sign time. Combined with the email embedded in the bundle's Fulcio certificate, it's everything a verifier needs to decide whether to trust the signature.
+
+The `value` field is the full Sigstore bundle — base64-encoded JSON containing the signature bytes, the Fulcio certificate (with your email as the certificate's Subject Alternative Name), and the Rekor inclusion proof. All three travel with the component descriptor; nothing needs to be fetched at verify time.
+
+{{< /step >}}
+
+{{< step >}}
+
+### Configure the verifier identity
+
+Verification is "do I trust *this identity*?" — not "do I have *this public key*?" Tell OCM which identity you trust by writing a verifier spec.
+
+Two values matter, both required:
+
+- **`certificateIdentity`** — the email or workload identity of whoever signed (e.g. your own email, copied from the previous step's output)
+- **`certificateOIDCIssuer`** — *which* OIDC provider they logged in with (different providers can have the same email)
+
+Create `sigstore-verify.yaml`:
+
+```bash
+cat > sigstore-verify.yaml << 'EOF'
+type: SigstoreVerificationConfiguration/v1alpha1
+certificateOIDCIssuer: https://accounts.google.com
+certificateIdentity: jane.doe@example.com
+EOF
+```
+
+Replace `certificateIdentity` with the email you logged in with, and adjust `certificateOIDCIssuer` to match your provider:
+
+| Signer logged in via | `certificateOIDCIssuer` value |
+| --- | --- |
+| Google | `https://accounts.google.com` |
+| GitHub | `https://github.com/login/oauth` |
+| Microsoft | `https://login.microsoftonline.com` |
+
+{{< callout context="caution" title="The issuer is the upstream IdP, not Sigstore Dex" icon="outline/alert-triangle" >}}
+Public Sigstore uses Dex (`oauth2.sigstore.dev`) as a federation gateway, but the issuer recorded in your signing certificate is the **upstream identity provider** — the one in the table above. Don't put `oauth2.sigstore.dev` here.
+{{< /callout >}}
+
+{{< /step >}}
+
+{{< step >}}
+
+### Verify the signature
+
+Run verify with the verifier spec:
+
+```bash
+ocm verify cv \
+  --verifier-spec ./sigstore-verify.yaml \
+  ./transport-archive//github.com/acme.org/helloworld:1.0.0
+```
+
+<details>
+<summary>Expected output</summary>
+
+```text
+time=2026-05-20T15:35:18.412+02:00 level=INFO msg="verifying signature" name=default
+time=2026-05-20T15:35:18.951+02:00 level=INFO msg="signature verification completed" name=default duration=539.512209ms
+time=2026-05-20T15:35:18.951+02:00 level=INFO msg="SIGNATURE VERIFICATION SUCCESSFUL"
+```
+
+</details>
+
+> ✅ **Success!** ✅
+> The component version is verified as authentic and signed by the identity you trusted.
+
+What just ran: OCM extracted the Sigstore bundle from the descriptor, validated the Fulcio certificate against TUF-discovered trust roots, checked the Rekor inclusion proof, and finally compared the certificate's identity against your verifier spec. None of those steps required a public key from the signer — the certificate-bound identity is the trust anchor.
+
+{{< /step >}}
+
+{{< /steps >}}
+
+## What You've Learned
+
+- ✅ Configured OCM to use your OIDC identity as a signing credential, with no key pair to manage
+- ✅ Signed a component version using a short-lived Fulcio certificate
+- ✅ Read the recorded identity out of a Sigstore signature
+- ✅ Verified the signature by declaring which identity you trust
+- ✅ Saw how spec files and `.ocmconfig` consumer identities link via `signature` name
+
+## Where to next
+
+- **Running an enterprise Sigstore stack?** [How-to: Sign Component Versions]({{< relref "sign-component-version.md" >}}) covers the `signingConfig` field and the `trusted_root_json` credential for private deployments.
+- **Curious about the theory?** [Concept: Signing and Verification]({{< relref "docs/concepts/signing-and-verification-concept.md" >}}) explains identity-based trust, how it differs from RSA key pinning, and why Sigstore works in air-gapped scenarios.
+- **Other algorithms?** [Tutorial: Plain Signatures]({{< relref "docs/tutorials/signing/plain.md" >}}) (RSA key pair) and [Tutorial: Certificate Chains (PEM)]({{< relref "docs/tutorials/signing/pem.md" >}}) (PKI-based).
+
+## Cleanup
+
+```bash
+rm -rf /tmp/ocm-sigstore-tutorial
+```
+
+## Related Documentation
+
+- [Concept: Signing and Verification]({{< relref "docs/concepts/signing-and-verification-concept.md" >}}) — Identity-based trust and the Sigstore stack
+- [How-to: Sign Component Versions]({{< relref "sign-component-version.md" >}}) — Task-oriented sign reference (RSA and Sigstore)
+- [How-to: Verify Component Versions]({{< relref "verify-component-version.md" >}}) — Task-oriented verify reference
+- [ADR 0017: Sigstore Integration](https://github.com/open-component-model/open-component-model/blob/main/docs/adr/0017_sigstore_integration.md) — Sigstore design and OIDC flow details

--- a/website/package.json
+++ b/website/package.json
@@ -16,7 +16,7 @@
     "dev": "HUGO_PARAMS_COMMITFULL=$(git log -1 --format=%H -- .) HUGO_PARAMS_COMMITSHORT=$(git log -1 --format=%h -- .) ./node_modules/.bin/hugo server --bind=0.0.0.0 --disableFastRender --noHTTPCache",
     "hugo": "./node_modules/.bin/hugo",
     "info": "npm list",
-    "lint:markdown": "markdownlint-cli2 \"*.md\" \"content/**/*.md\"",
+    "lint:markdown": "markdownlint-cli2 --config ../.github/config/website.markdownlint-cli2.yaml \"**/*.md\" \"!node_modules/**\" \"!content_versioned/version-legacy/**\"",
     "lint:scripts": "eslint --cache assets/js",
     "lint:styles": "stylelint --cache \"assets/scss/**/*.{css,sass,scss}\"",
     "lint": "npm run lint:scripts && npm run lint:styles && npm run lint:markdown",


### PR DESCRIPTION
## Summary

Cleans up the Sigstore (keyless) tabs of the Sign and Verify how-tos: tighter prerequisites, harmonised RSA-vs-Sigstore comparison tables across both pages, and replaces "tutorial in the works" callouts with `relref` links to the new dedicated tutorial. Conceptual context is now redirected to the concept page rather than blended into the how-to.

## Audit findings addressed

- **F5** — `_index.md`: section description and bullets now mention Sigstore as a first-class peer to RSA.
- **F6** — `sign-component-version.md` Sigstore tab: prerequisites tightened (explicit OIDC provider note, network access to `*.sigstore.dev`, cosign auto-fetch tip moved into prerequisites).
- **F7** — both files: harmonised the RSA-vs-Sigstore comparison table to a 3-row shape (`Before you start` / `What proves trust` / `What the verifier needs`); audit-trail aspect folded into closing prose.
- **F8** — both files: replaced "tutorial in the works" callouts with `relref` to the new Sigstore (keyless) tutorial; ADR 0017 kept as secondary reference.
- **F9** — `verify-component-version.md`: `--signature` example now uses `default` (the actual default name) and clarifies that `--signature` selects WHICH signature on the component to verify, while the verifier spec's `type` decides WHICH algorithm/handler to use.
- **F10** — `verify-component-version.md`: removed the standalone `## Inspect the recorded identity (optional)` section (moved to step 5 of the new tutorial); pointer added in the troubleshooting "no matching CertificateIdentity" fix.
- **F11** — `sign-component-version.md`: typo "version to low" → "version is too low" (fixed in the moved cosign auto-fetch bullet).
- **F16** — both files: removed the Diátaxis-blending "Mental model" paragraphs; replaced with one-liner pointing to [Identity-Based Trust (Sigstore)](https://github.com/open-component-model/open-component-model/blob/main/website/content/docs/concepts/signing-and-verification-concept.md#identity-based-trust-sigstore) on the concept page.

## Depends on

This is a **stacked PR**. It builds on top of:

- #2584 — `docs(website): add Sigstore to signing concept and trust models`
- #2588 — `docs(website): add Sigstore (keyless) signing tutorial`

Both must merge into upstream `main` BEFORE this PR. Once they have, the maintainer can rebase this branch onto fresh `upstream/main` and the merge commits at the base of this branch (`merge: PR 2584 base for stacked PR`, `merge: PR 2588 base for stacked PR`) will drop out automatically.

The `relref` links in F8 and F10 require `website/content/docs/tutorials/signing/sigstore.md` to exist at build time — that file is added by PR #2588.

## Test plan

- [x] Hugo build passes locally (`npm run build` — exit 0, no `REF_NOT_FOUND` errors)
- [x] Markdown lint passes against the CI config (`.github/config/website.markdownlint-cli2.yaml` — 0 errors on the three touched files)
- [x] All `relref` targets resolve (the build catches missing pages with `REF_NOT_FOUND`; anchor on the concept page verified to exist)