### PR TITLE
fix: update constructor to use credentials.Resolver.Resolve (credentials v0.0.12 compat)

### DIFF
--- a/bindings/go/constructor/construct.go
+++ b/bindings/go/constructor/construct.go
@@ -779,7 +779,7 @@ func resolveCredentials(ctx context.Context, provider credentials.Resolver, cons
 		return nil, nil
 	}
 
-	creds, err := provider.ResolveTyped(ctx, consumerIdentity)
+	creds, err := provider.Resolve(ctx, consumerIdentity)
 	if errors.Is(err, credentials.ErrNotFound) {
 		logger.DebugContext(ctx, "no credentials found for consumer identity, proceeding without credentials")
 		return nil, nil

--- a/bindings/go/constructor/construct_resource_test.go
+++ b/bindings/go/constructor/construct_resource_test.go
@@ -157,20 +157,12 @@ type mockCredentialProvider struct {
 	fail        bool
 }
 
-func (m *mockCredentialProvider) Resolve(ctx context.Context, identity runtime.Identity) (map[string]string, error) {
+func (m *mockCredentialProvider) Resolve(ctx context.Context, identity runtime.Identity) (runtime.Typed, error) {
 	m.called[identity.GetType().String()]++
 	if m.fail {
 		return nil, fmt.Errorf("simulated credential resolution failure")
 	}
-	return m.credentials[identity.GetType().String()], nil
-}
-
-func (m *mockCredentialProvider) ResolveTyped(ctx context.Context, identity runtime.Identity) (runtime.Typed, error) {
-	creds, err := m.Resolve(ctx, identity)
-	if err != nil {
-		return nil, err
-	}
-	return runtime.Identity(creds), nil
+	return runtime.Identity(m.credentials[identity.GetType().String()]), nil
 }
 
 // setupTestComponent creates a basic component constructor for testing

--- a/bindings/go/constructor/go.mod
+++ b/bindings/go/constructor/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.20.0
 	ocm.software/open-component-model/bindings/go/blob v0.0.12
-	ocm.software/open-component-model/bindings/go/credentials v0.0.11
+	ocm.software/open-component-model/bindings/go/credentials v0.0.12
 	ocm.software/open-component-model/bindings/go/dag v0.0.6
 	ocm.software/open-component-model/bindings/go/descriptor/normalisation v0.0.0-20260505072254-1c17fcd5c971
 	ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20260505072254-1c17fcd5c971

--- a/bindings/go/constructor/go.sum
+++ b/bindings/go/constructor/go.sum
@@ -51,8 +51,8 @@ ocm.software/open-component-model/bindings/go/blob v0.0.12 h1:5YOFDxERzF6w+rPWYu
 ocm.software/open-component-model/bindings/go/blob v0.0.12/go.mod h1:YswKfR/kxhdHHK7bN98S2O73ZZlPLsHfHO2Bjsr6Zww=
 ocm.software/open-component-model/bindings/go/configuration v0.0.13 h1:fARaCEkyBvuZ8/3nUDMb0LZF3YuohBbJXCTkOqqUmkw=
 ocm.software/open-component-model/bindings/go/configuration v0.0.13/go.mod h1:B8rEZoPPL4bAYhsi5I4IZJ8EJSOwMupd95Lw/N0TBRA=
-ocm.software/open-component-model/bindings/go/credentials v0.0.11 h1:qMx5/NquYo3orpBkMimynJldQzSrE/p419Rqt4rxP6I=
-ocm.software/open-component-model/bindings/go/credentials v0.0.11/go.mod h1:RJ/pYi7SwCjzuTDvlMksRjJgRwaUwuziIv+ApxqCv0U=
+ocm.software/open-component-model/bindings/go/credentials v0.0.12 h1:GMedcclw/Nu7G8EJREIdXmAk/78j9xAQAIlRpd8QQO4=
+ocm.software/open-component-model/bindings/go/credentials v0.0.12/go.mod h1:XH9GR0kG2p5iaqBAAxTE1rX0fBE86Q2hCD7QodWRTpc=
 ocm.software/open-component-model/bindings/go/ctf v0.4.0 h1:E2kDGJk/ZR2wMK6fk3yFr2Uv6AhfLdMmvdvQ7Y64/2s=
 ocm.software/open-component-model/bindings/go/ctf v0.4.0/go.mod h1:XaVTQK/STJ64pq8vClsT+onD0kEs7P+Wzsq1k2tp9h4=
 ocm.software/open-component-model/bindings/go/dag v0.0.6 h1:To76QJAmFD88C101oB/HgYvtomp8mm0270ewDLcVncw=


### PR DESCRIPTION
## Summary

- `credentials v0.0.12` unified the `Resolver` interface to a single `Resolve(ctx, identity) (runtime.Typed, error)` method, removing the separate `ResolveTyped` method that existed in v0.0.11
- `constructor v0.0.8` (released as part of gate 4, PR #2598) still calls `provider.ResolveTyped` and depends on `credentials v0.0.11`
- This causes a build failure when any module depends on both `constructor v0.0.8` and `credentials v0.0.12`

This fix updates `construct.go` to call `provider.Resolve` and bumps the credentials dependency to `v0.0.12`.

## Dependency on
Must be released as `constructor/v0.0.9` before PR #2602 (gate 5 plugin migration) can drop its `replace` directive.