### PR TITLE
feat: add ocm skill pull/push commands for AI skill catalogue distribution

### DIFF
--- a/.github/config/wordlist.txt
+++ b/.github/config/wordlist.txt
@@ -902,3 +902,4 @@ ANSI's
 Dotfiles
 dotfiles
 ClickHouse
+OpenAI

--- a/.github/config/wordlist.txt
+++ b/.github/config/wordlist.txt
@@ -903,3 +903,5 @@ Dotfiles
 dotfiles
 ClickHouse
 OpenAI
+airgap
+ECR

--- a/.github/config/wordlist.txt
+++ b/.github/config/wordlist.txt
@@ -899,3 +899,6 @@ oss
 runnable
 GmbH
 ANSI's
+Dotfiles
+dotfiles
+ClickHouse

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -16,6 +16,7 @@ import (
 	pluginregistry "ocm.software/open-component-model/cli/cmd/plugins"
 	"ocm.software/open-component-model/cli/cmd/setup/hooks"
 	"ocm.software/open-component-model/cli/cmd/sign"
+	"ocm.software/open-component-model/cli/cmd/skill"
 	"ocm.software/open-component-model/cli/cmd/transfer"
 	"ocm.software/open-component-model/cli/cmd/verify"
 	"ocm.software/open-component-model/cli/cmd/version"
@@ -63,6 +64,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(download.New())
 	cmd.AddCommand(verify.New())
 	cmd.AddCommand(sign.New())
+	cmd.AddCommand(skill.New())
 	cmd.AddCommand(pluginregistry.New())
 	cmd.AddCommand(transfer.New())
 	cmd.AddCommand(describe.New())

--- a/cli/cmd/skill/cmd.go
+++ b/cli/cmd/skill/cmd.go
@@ -1,0 +1,23 @@
+package skill
+
+import (
+	"github.com/spf13/cobra"
+
+	"ocm.software/open-component-model/cli/cmd/skill/pull"
+	"ocm.software/open-component-model/cli/cmd/skill/push"
+)
+
+// New returns the root "skill" command grouping pull and push subcommands.
+func New() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "skill {pull|push}",
+		Short: "Manage AI skills distributed via OCM component catalogues",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+		DisableAutoGenTag: true,
+	}
+	cmd.AddCommand(pull.New())
+	cmd.AddCommand(push.New())
+	return cmd
+}

--- a/cli/cmd/skill/pull/cmd.go
+++ b/cli/cmd/skill/pull/cmd.go
@@ -1,6 +1,7 @@
 package pull
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -21,9 +22,18 @@ import (
 
 const (
 	skillResourceType = "ai.skill/v1"
-	defaultSkillDir   = ".claude/skills"
-	flagSkillName     = "skill"
-	flagOutput        = "output"
+
+	// Default install directories per coding agent.
+	claudeSkillDir = ".claude/skills"
+	codexSkillDir  = ".agents/skills"
+
+	flagSkillName = "skill"
+	flagOutput    = "output"
+	flagTarget    = "target"
+
+	targetClaude = "claude"
+	targetCodex  = "codex"
+	targetAll    = "all"
 )
 
 func New() *cobra.Command {
@@ -33,12 +43,22 @@ func New() *cobra.Command {
 		Long: `Pull one or all AI skills from an OCM component version that packages skills as resources with type ai.skill/v1.
 
 When --skill is given, only that resource is downloaded. Without --skill, all ai.skill/v1 resources are downloaded.
-Skills are written to ~/.claude/skills/<skill-name>/SKILL.md by default.`,
-		Example: `  # Pull a single skill
+
+By default skills are installed for Claude Code (--target claude):
+  ~/.claude/skills/<skill-name>/SKILL.md
+
+Use --target codex to install for OpenAI Codex CLI instead:
+  ~/.agents/skills/<skill-name>/SKILL.md
+
+Use --target all to install for both agents simultaneously.`,
+		Example: `  # Pull a single skill into Claude Code (default)
   ocm skill pull ./catalogue//jakob.io/ai-skill-catalogue:1.0.0 --skill ocm-guide
 
-  # Pull all skills from catalogue to default location
-  ocm skill pull ./catalogue//jakob.io/ai-skill-catalogue:1.0.0
+  # Pull all skills into OpenAI Codex CLI
+  ocm skill pull ./catalogue//jakob.io/ai-skill-catalogue:1.0.0 --target codex
+
+  # Pull all skills into both Claude Code and Codex
+  ocm skill pull ./catalogue//jakob.io/ai-skill-catalogue:1.0.0 --target all
 
   # Pull a skill to a custom path
   ocm skill pull ./catalogue//jakob.io/ai-skill-catalogue:1.0.0 --skill ocm-guide --output /tmp/ocm-guide.md`,
@@ -49,6 +69,7 @@ Skills are written to ~/.claude/skills/<skill-name>/SKILL.md by default.`,
 
 	cmd.Flags().String(flagSkillName, "", "name of skill resource to pull (pulls all ai.skill/v1 resources when omitted)")
 	cmd.Flags().String(flagOutput, "", "output path for the skill file (only valid with --skill)")
+	cmd.Flags().String(flagTarget, targetClaude, `coding agent to install skills for: "claude" (~/.claude/skills/), "codex" (~/.agents/skills/), or "all"`)
 
 	return cmd
 }
@@ -69,8 +90,22 @@ func pullSkill(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("getting output flag failed: %w", err)
 	}
 
+	target, err := cmd.Flags().GetString(flagTarget)
+	if err != nil {
+		return fmt.Errorf("getting target flag failed: %w", err)
+	}
+
 	if output != "" && skillName == "" {
 		return fmt.Errorf("--output requires --skill to be set")
+	}
+	if output != "" && target != targetClaude {
+		return fmt.Errorf("--output cannot be combined with --target")
+	}
+
+	switch target {
+	case targetClaude, targetCodex, targetAll:
+	default:
+		return fmt.Errorf("unknown --target %q: must be %q, %q, or %q", target, targetClaude, targetCodex, targetAll)
 	}
 
 	ref, err := compref.Parse(args[0])
@@ -111,7 +146,6 @@ func pullSkill(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no %s resources found in component %s:%s", skillResourceType, ref.Component, ref.Version)
 	}
 
-	// when a custom output is given, exactly one skill must be selected
 	if output != "" && len(candidates) > 1 {
 		return fmt.Errorf("--output requires exactly one matching skill, got %d", len(candidates))
 	}
@@ -121,21 +155,25 @@ func pullSkill(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("resolving home directory failed: %w", err)
 	}
 
-	skillsBase := filepath.Join(homeDir, defaultSkillDir)
+	destDirs := installDirs(homeDir, target)
 
 	for _, res := range candidates {
 		identity := runtime.Identity{"name": res.Name}
 
-		dest := output
-		if dest == "" {
-			if err := validateSkillName(res.Name); err != nil {
-				return fmt.Errorf("skill resource %q has invalid name: %w", res.Name, err)
+		if output != "" {
+			data, err := shared.DownloadResourceData(cmd.Context(), pluginManager, credentialGraph, ref.Component, ref.Version, repo, &res, identity)
+			if err != nil {
+				return fmt.Errorf("downloading skill %q failed: %w", res.Name, err)
 			}
-			dest = filepath.Join(skillsBase, res.Name, "SKILL.md")
-			// guard against any path traversal after Join
-			if !strings.HasPrefix(dest, skillsBase+string(filepath.Separator)) {
-				return fmt.Errorf("skill resource name %q resolves outside skills directory", res.Name)
+			if err := writeSkillFile(data, output); err != nil {
+				return fmt.Errorf("saving skill %q to %q failed: %w", res.Name, output, err)
 			}
+			logger.Info("skill installed", slog.String("skill", res.Name), slog.String("output", output))
+			continue
+		}
+
+		if err := validateSkillName(res.Name); err != nil {
+			return fmt.Errorf("skill resource %q has invalid name: %w", res.Name, err)
 		}
 
 		data, err := shared.DownloadResourceData(cmd.Context(), pluginManager, credentialGraph, ref.Component, ref.Version, repo, &res, identity)
@@ -143,13 +181,40 @@ func pullSkill(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("downloading skill %q failed: %w", res.Name, err)
 		}
 
-		if err := writeSkillFile(data, dest); err != nil {
-			return fmt.Errorf("saving skill %q to %q failed: %w", res.Name, dest, err)
+		// Buffer content so it can be written to multiple targets.
+		content, err := readBlobBytes(data)
+		if err != nil {
+			return fmt.Errorf("reading skill %q content failed: %w", res.Name, err)
 		}
-		logger.Info("skill installed", slog.String("skill", res.Name), slog.String("output", dest))
+
+		for _, base := range destDirs {
+			dest := filepath.Join(base, res.Name, "SKILL.md")
+			if !strings.HasPrefix(dest, base+string(filepath.Separator)) {
+				return fmt.Errorf("skill resource name %q resolves outside skills directory", res.Name)
+			}
+			if err := writeBytesToFile(content, dest); err != nil {
+				return fmt.Errorf("saving skill %q to %q failed: %w", res.Name, dest, err)
+			}
+			logger.Info("skill installed", slog.String("skill", res.Name), slog.String("output", dest))
+		}
 	}
 
 	return nil
+}
+
+// installDirs returns the skills base directories for the given target agent.
+func installDirs(homeDir, target string) []string {
+	switch target {
+	case targetCodex:
+		return []string{filepath.Join(homeDir, codexSkillDir)}
+	case targetAll:
+		return []string{
+			filepath.Join(homeDir, claudeSkillDir),
+			filepath.Join(homeDir, codexSkillDir),
+		}
+	default: // targetClaude
+		return []string{filepath.Join(homeDir, claudeSkillDir)}
+	}
 }
 
 // validateSkillName rejects names that could escape the skills directory via path traversal.
@@ -173,32 +238,40 @@ func validateSkillName(name string) error {
 	return nil
 }
 
-// writeSkillFile writes blob content to dest, truncating any existing file.
+// writeSkillFile writes a blob stream to dest, truncating any existing file.
 // Unlike the shared SaveBlobToFile helper (which appends), skills are always overwritten on pull.
 func writeSkillFile(b blob.ReadOnlyBlob, dest string) (err error) {
-	if dir := filepath.Dir(dest); dir != "" && dir != "." {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			return fmt.Errorf("creating directory %q failed: %w", dir, err)
-		}
+	content, err := readBlobBytes(b)
+	if err != nil {
+		return err
 	}
+	return writeBytesToFile(content, dest)
+}
 
+// readBlobBytes drains a read-only blob into a byte slice so the content can be written to multiple destinations.
+func readBlobBytes(b blob.ReadOnlyBlob) (_ []byte, err error) {
 	r, err := b.ReadCloser()
 	if err != nil {
-		return fmt.Errorf("reading blob failed: %w", err)
+		return nil, fmt.Errorf("reading blob failed: %w", err)
 	}
 	defer func() {
 		err = errors.Join(err, r.Close())
 	}()
 
-	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
-	if err != nil {
-		return fmt.Errorf("opening %q failed: %w", dest, err)
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		return nil, fmt.Errorf("reading blob content failed: %w", err)
 	}
-	defer func() {
-		err = errors.Join(err, f.Close())
-	}()
+	return buf.Bytes(), nil
+}
 
-	if _, err := io.Copy(f, r); err != nil {
+func writeBytesToFile(content []byte, dest string) error {
+	if dir := filepath.Dir(dest); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("creating directory %q failed: %w", dir, err)
+		}
+	}
+	if err := os.WriteFile(dest, content, 0o600); err != nil {
 		return fmt.Errorf("writing to %q failed: %w", dest, err)
 	}
 	return nil

--- a/cli/cmd/skill/pull/cmd.go
+++ b/cli/cmd/skill/pull/cmd.go
@@ -1,0 +1,205 @@
+package pull
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+	"ocm.software/open-component-model/bindings/go/blob"
+	"ocm.software/open-component-model/bindings/go/oci/compref"
+	"ocm.software/open-component-model/bindings/go/runtime"
+	"ocm.software/open-component-model/cli/cmd/download/shared"
+	"ocm.software/open-component-model/cli/internal/repository/ocm"
+)
+
+const (
+	skillResourceType = "ai.skill/v1"
+	defaultSkillDir   = ".claude/skills"
+	flagSkillName     = "skill"
+	flagOutput        = "output"
+)
+
+func New() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pull <component-ref> [--skill <name>] [--output <path>]",
+		Short: "Pull AI skills from an OCM skill catalogue component",
+		Long: `Pull one or all AI skills from an OCM component version that packages skills as resources with type ai.skill/v1.
+
+When --skill is given, only that resource is downloaded. Without --skill, all ai.skill/v1 resources are downloaded.
+Skills are written to ~/.claude/skills/<skill-name>/SKILL.md by default.`,
+		Example: `  # Pull a single skill
+  ocm skill pull ./catalogue//jakob.io/ai-skill-catalogue:1.0.0 --skill ocm-guide
+
+  # Pull all skills from catalogue to default location
+  ocm skill pull ./catalogue//jakob.io/ai-skill-catalogue:1.0.0
+
+  # Pull a skill to a custom path
+  ocm skill pull ./catalogue//jakob.io/ai-skill-catalogue:1.0.0 --skill ocm-guide --output /tmp/ocm-guide.md`,
+		Args:              cobra.ExactArgs(1),
+		RunE:              pullSkill,
+		DisableAutoGenTag: true,
+	}
+
+	cmd.Flags().String(flagSkillName, "", "name of skill resource to pull (pulls all ai.skill/v1 resources when omitted)")
+	cmd.Flags().String(flagOutput, "", "output path for the skill file (only valid with --skill)")
+
+	return cmd
+}
+
+func pullSkill(cmd *cobra.Command, args []string) error {
+	pluginManager, credentialGraph, logger, err := shared.GetContextItems(cmd)
+	if err != nil {
+		return err
+	}
+
+	skillName, err := cmd.Flags().GetString(flagSkillName)
+	if err != nil {
+		return fmt.Errorf("getting skill flag failed: %w", err)
+	}
+
+	output, err := cmd.Flags().GetString(flagOutput)
+	if err != nil {
+		return fmt.Errorf("getting output flag failed: %w", err)
+	}
+
+	if output != "" && skillName == "" {
+		return fmt.Errorf("--output requires --skill to be set")
+	}
+
+	ref, err := compref.Parse(args[0])
+	if err != nil {
+		return fmt.Errorf("parsing component reference %q failed: %w", args[0], err)
+	}
+
+	repoProvider, err := ocm.NewComponentVersionRepositoryForComponentProvider(cmd.Context(), pluginManager.ComponentVersionRepositoryRegistry, credentialGraph, nil, ref)
+	if err != nil {
+		return fmt.Errorf("could not initialize ocm repository: %w", err)
+	}
+
+	repo, err := repoProvider.GetComponentVersionRepositoryForComponent(cmd.Context(), ref.Component, ref.Version)
+	if err != nil {
+		return fmt.Errorf("could not access ocm repository: %w", err)
+	}
+
+	desc, err := repo.GetComponentVersion(cmd.Context(), ref.Component, ref.Version)
+	if err != nil {
+		return fmt.Errorf("getting component version failed: %w", err)
+	}
+
+	var candidates []descriptor.Resource
+	for _, res := range desc.Component.Resources {
+		if res.Type != skillResourceType {
+			continue
+		}
+		if skillName != "" && res.Name != skillName {
+			continue
+		}
+		candidates = append(candidates, res)
+	}
+
+	if len(candidates) == 0 {
+		if skillName != "" {
+			return fmt.Errorf("skill %q not found in component (no resource with type %s and name %q)", skillName, skillResourceType, skillName)
+		}
+		return fmt.Errorf("no %s resources found in component %s:%s", skillResourceType, ref.Component, ref.Version)
+	}
+
+	// when a custom output is given, exactly one skill must be selected
+	if output != "" && len(candidates) > 1 {
+		return fmt.Errorf("--output requires exactly one matching skill, got %d", len(candidates))
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolving home directory failed: %w", err)
+	}
+
+	skillsBase := filepath.Join(homeDir, defaultSkillDir)
+
+	for _, res := range candidates {
+		identity := runtime.Identity{"name": res.Name}
+
+		dest := output
+		if dest == "" {
+			if err := validateSkillName(res.Name); err != nil {
+				return fmt.Errorf("skill resource %q has invalid name: %w", res.Name, err)
+			}
+			dest = filepath.Join(skillsBase, res.Name, "SKILL.md")
+			// guard against any path traversal after Join
+			if !strings.HasPrefix(dest, skillsBase+string(filepath.Separator)) {
+				return fmt.Errorf("skill resource name %q resolves outside skills directory", res.Name)
+			}
+		}
+
+		data, err := shared.DownloadResourceData(cmd.Context(), pluginManager, credentialGraph, ref.Component, ref.Version, repo, &res, identity)
+		if err != nil {
+			return fmt.Errorf("downloading skill %q failed: %w", res.Name, err)
+		}
+
+		if err := writeSkillFile(data, dest); err != nil {
+			return fmt.Errorf("saving skill %q to %q failed: %w", res.Name, dest, err)
+		}
+		logger.Info("skill installed", slog.String("skill", res.Name), slog.String("output", dest))
+	}
+
+	return nil
+}
+
+// validateSkillName rejects names that could escape the skills directory via path traversal.
+func validateSkillName(name string) error {
+	if name == "" {
+		return fmt.Errorf("name must not be empty")
+	}
+	clean := filepath.Clean(name)
+	if clean != name {
+		return fmt.Errorf("name %q contains path sequences that would be cleaned", name)
+	}
+	if filepath.IsAbs(name) {
+		return fmt.Errorf("name %q must not be an absolute path", name)
+	}
+	if strings.Contains(name, string(filepath.Separator)) || strings.Contains(name, "/") {
+		return fmt.Errorf("name %q must not contain path separators", name)
+	}
+	if strings.HasPrefix(name, ".") {
+		return fmt.Errorf("name %q must not start with a dot", name)
+	}
+	return nil
+}
+
+// writeSkillFile writes blob content to dest, truncating any existing file.
+// Unlike the shared SaveBlobToFile helper (which appends), skills are always overwritten on pull.
+func writeSkillFile(b blob.ReadOnlyBlob, dest string) (err error) {
+	if dir := filepath.Dir(dest); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("creating directory %q failed: %w", dir, err)
+		}
+	}
+
+	r, err := b.ReadCloser()
+	if err != nil {
+		return fmt.Errorf("reading blob failed: %w", err)
+	}
+	defer func() {
+		err = errors.Join(err, r.Close())
+	}()
+
+	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("opening %q failed: %w", dest, err)
+	}
+	defer func() {
+		err = errors.Join(err, f.Close())
+	}()
+
+	if _, err := io.Copy(f, r); err != nil {
+		return fmt.Errorf("writing to %q failed: %w", dest, err)
+	}
+	return nil
+}

--- a/cli/cmd/skill/pull/cmd.go
+++ b/cli/cmd/skill/pull/cmd.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
 	"ocm.software/open-component-model/bindings/go/blob"
+	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
 	"ocm.software/open-component-model/bindings/go/oci/compref"
 	"ocm.software/open-component-model/bindings/go/runtime"
 	"ocm.software/open-component-model/cli/cmd/download/shared"

--- a/cli/cmd/skill/pull/cmd.go
+++ b/cli/cmd/skill/pull/cmd.go
@@ -189,10 +189,29 @@ func pullSkill(cmd *cobra.Command, args []string) error {
 
 		for _, base := range destDirs {
 			dest := filepath.Join(base, res.Name, "SKILL.md")
+			// String-level check catches path traversal sequences.
 			if !strings.HasPrefix(dest, base+string(filepath.Separator)) {
 				return fmt.Errorf("skill resource name %q resolves outside skills directory", res.Name)
 			}
-			if err := writeBytesToFile(content, dest); err != nil {
+			// Create the parent directory before resolving symlinks so
+			// EvalSymlinks can walk the full path.
+			if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+				return fmt.Errorf("creating directory for skill %q failed: %w", res.Name, err)
+			}
+			// Resolve symlinks on the parent dir and verify it still lives
+			// inside base — guards against a pre-existing symlink in the tree.
+			resolvedDir, err := filepath.EvalSymlinks(filepath.Dir(dest))
+			if err != nil {
+				return fmt.Errorf("resolving destination directory for skill %q failed: %w", res.Name, err)
+			}
+			resolvedBase, err := filepath.EvalSymlinks(base)
+			if err != nil {
+				return fmt.Errorf("resolving skills base %q failed: %w", base, err)
+			}
+			if !strings.HasPrefix(resolvedDir+string(filepath.Separator), resolvedBase+string(filepath.Separator)) {
+				return fmt.Errorf("skill %q destination resolves outside skills directory via symlink", res.Name)
+			}
+			if err := os.WriteFile(dest, content, 0o600); err != nil {
 				return fmt.Errorf("saving skill %q to %q failed: %w", res.Name, dest, err)
 			}
 			logger.Info("skill installed", slog.String("skill", res.Name), slog.String("output", dest))

--- a/cli/cmd/skill/pull/cmd_test.go
+++ b/cli/cmd/skill/pull/cmd_test.go
@@ -355,3 +355,24 @@ func TestPullOutputWithTargetFails(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "--output cannot be combined with --target")
 }
+
+func TestPullRejectsSymlinkEscapeInSkillsDir(t *testing.T) {
+	archivePath := setupCatalogueWithSkills(t, map[string][]byte{
+		"ocm-guide": testSkillContent,
+	})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Pre-create the skill subdirectory as a symlink pointing outside the skills base.
+	skillsBase := filepath.Join(home, ".claude", "skills")
+	require.NoError(t, os.MkdirAll(skillsBase, 0o755))
+	outsideDir := t.TempDir()
+	require.NoError(t, os.Symlink(outsideDir, filepath.Join(skillsBase, "ocm-guide")))
+
+	_, err := test.OCM(t,
+		test.WithArgs("skill", "pull", refString(archivePath), "--skill", "ocm-guide"),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.Error(t, err, "pull must reject a skill dir that is a symlink escaping the base")
+}

--- a/cli/cmd/skill/pull/cmd_test.go
+++ b/cli/cmd/skill/pull/cmd_test.go
@@ -1,0 +1,281 @@
+package pull_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"ocm.software/open-component-model/bindings/go/blob/filesystem"
+	"ocm.software/open-component-model/bindings/go/blob/inmemory"
+	"ocm.software/open-component-model/bindings/go/ctf"
+	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+	v2 "ocm.software/open-component-model/bindings/go/descriptor/v2"
+	"ocm.software/open-component-model/bindings/go/oci"
+	"ocm.software/open-component-model/bindings/go/oci/compref"
+	ocictf "ocm.software/open-component-model/bindings/go/oci/ctf"
+	ctfv1 "ocm.software/open-component-model/bindings/go/oci/spec/repository/v1/ctf"
+	"ocm.software/open-component-model/cli/cmd/internal/test"
+)
+
+const (
+	testComponent = "jakob.io/ai-skill-catalogue"
+	testVersion   = "1.0.0"
+)
+
+var testSkillContent = []byte("---\nname: ocm-guide\ndescription: Test skill\n---\n\n# OCM Guide\n\nTest content.\n")
+
+func setupCatalogueWithSkills(t *testing.T, skills map[string][]byte) string {
+	t.Helper()
+	r := require.New(t)
+
+	archivePath := t.TempDir()
+	fs, err := filesystem.NewFS(archivePath, os.O_RDWR)
+	r.NoError(err)
+	archive := ctf.NewFileSystemCTF(fs)
+	repo, err := oci.NewRepository(ocictf.WithCTF(ocictf.NewFromCTF(archive)))
+	r.NoError(err)
+
+	desc := &descriptor.Descriptor{
+		Meta: descriptor.Meta{Version: "v2"},
+		Component: descriptor.Component{
+			ComponentMeta: descriptor.ComponentMeta{
+				ObjectMeta: descriptor.ObjectMeta{
+					Name:    testComponent,
+					Version: testVersion,
+				},
+			},
+			Provider: descriptor.Provider{Name: "jakob.io"},
+		},
+	}
+
+	ctx := t.Context()
+	r.NoError(repo.AddComponentVersion(ctx, desc))
+
+	for name, content := range skills {
+		res := &descriptor.Resource{
+			ElementMeta: descriptor.ElementMeta{
+				ObjectMeta: descriptor.ObjectMeta{
+					Name:    name,
+					Version: testVersion,
+				},
+			},
+			Type:     "ai.skill/v1",
+			Relation: descriptor.LocalRelation,
+			Access:   &v2.LocalBlob{MediaType: "text/markdown"},
+		}
+		updated, err := repo.AddLocalResource(ctx, testComponent, testVersion, res, inmemory.New(bytes.NewReader(content)))
+		r.NoError(err)
+
+		desc.Component.Resources = append(desc.Component.Resources, *updated)
+	}
+
+	r.NoError(repo.AddComponentVersion(ctx, desc))
+	return archivePath
+}
+
+func refString(archivePath string) string {
+	return (&compref.Ref{
+		Repository: &ctfv1.Repository{FilePath: archivePath},
+		Component:  testComponent,
+		Version:    testVersion,
+	}).String()
+}
+
+func TestPullSingleSkillToOutputPath(t *testing.T) {
+	archivePath := setupCatalogueWithSkills(t, map[string][]byte{
+		"ocm-guide": testSkillContent,
+	})
+
+	outputPath := filepath.Join(t.TempDir(), "SKILL.md")
+	logs := test.NewJSONLogReader()
+
+	_, err := test.OCM(t,
+		test.WithArgs("skill", "pull", refString(archivePath), "--skill", "ocm-guide", "--output", outputPath),
+		test.WithErrorOutput(logs),
+	)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	require.Equal(t, testSkillContent, data)
+
+	entries, err := logs.List()
+	require.NoError(t, err)
+	require.NotEmpty(t, entries)
+	var found bool
+	for _, e := range entries {
+		if e.Msg == "skill installed" {
+			require.Equal(t, "ocm-guide", e.Extras["skill"])
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "expected 'skill installed' log entry")
+}
+
+func TestPullSingleSkillToDefaultLocation(t *testing.T) {
+	archivePath := setupCatalogueWithSkills(t, map[string][]byte{
+		"my-skill": testSkillContent,
+	})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	_, err := test.OCM(t,
+		test.WithArgs("skill", "pull", refString(archivePath), "--skill", "my-skill"),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.NoError(t, err)
+
+	expected := filepath.Join(home, ".claude", "skills", "my-skill", "SKILL.md")
+	data, err := os.ReadFile(expected)
+	require.NoError(t, err)
+	require.Equal(t, testSkillContent, data)
+}
+
+func TestPullAllSkills(t *testing.T) {
+	skillA := []byte("---\nname: skill-a\n---\n# A\n")
+	skillB := []byte("---\nname: skill-b\n---\n# B\n")
+
+	archivePath := setupCatalogueWithSkills(t, map[string][]byte{
+		"skill-a": skillA,
+		"skill-b": skillB,
+	})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	_, err := test.OCM(t,
+		test.WithArgs("skill", "pull", refString(archivePath)),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.NoError(t, err)
+
+	for name, expected := range map[string][]byte{"skill-a": skillA, "skill-b": skillB} {
+		path := filepath.Join(home, ".claude", "skills", name, "SKILL.md")
+		data, err := os.ReadFile(path)
+		require.NoError(t, err, "skill %q not found", name)
+		require.Equal(t, expected, data, "skill %q content mismatch", name)
+	}
+}
+
+func TestPullIsIdempotent(t *testing.T) {
+	archivePath := setupCatalogueWithSkills(t, map[string][]byte{
+		"ocm-guide": testSkillContent,
+	})
+
+	outputPath := filepath.Join(t.TempDir(), "SKILL.md")
+
+	for i := range 3 {
+		_, err := test.OCM(t,
+			test.WithArgs("skill", "pull", refString(archivePath), "--skill", "ocm-guide", "--output", outputPath),
+			test.WithErrorOutput(test.NewJSONLogReader()),
+		)
+		require.NoError(t, err, "pull %d failed", i+1)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	require.Equal(t, testSkillContent, data, "repeated pulls must not duplicate content")
+}
+
+func TestPullSkillNotFound(t *testing.T) {
+	archivePath := setupCatalogueWithSkills(t, map[string][]byte{
+		"ocm-guide": testSkillContent,
+	})
+
+	_, err := test.OCM(t,
+		test.WithArgs("skill", "pull", refString(archivePath), "--skill", "does-not-exist"),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does-not-exist")
+}
+
+func TestPullNoSkillsInComponent(t *testing.T) {
+	// component with no ai.skill/v1 resources
+	archivePath := t.TempDir()
+	fs, err := filesystem.NewFS(archivePath, os.O_RDWR)
+	require.NoError(t, err)
+	archive := ctf.NewFileSystemCTF(fs)
+	repo, err := oci.NewRepository(ocictf.WithCTF(ocictf.NewFromCTF(archive)))
+	require.NoError(t, err)
+
+	desc := &descriptor.Descriptor{
+		Meta: descriptor.Meta{Version: "v2"},
+		Component: descriptor.Component{
+			ComponentMeta: descriptor.ComponentMeta{
+				ObjectMeta: descriptor.ObjectMeta{Name: testComponent, Version: testVersion},
+			},
+			Provider: descriptor.Provider{Name: "jakob.io"},
+		},
+	}
+	require.NoError(t, repo.AddComponentVersion(t.Context(), desc))
+
+	_, err = test.OCM(t,
+		test.WithArgs("skill", "pull", refString(archivePath)),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ai.skill/v1")
+}
+
+func TestPullOutputWithoutSkillFlagFails(t *testing.T) {
+	archivePath := setupCatalogueWithSkills(t, map[string][]byte{
+		"ocm-guide": testSkillContent,
+	})
+
+	_, err := test.OCM(t,
+		test.WithArgs("skill", "pull", refString(archivePath), "--output", "/tmp/something.md"),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--output requires --skill")
+}
+
+func TestPullRejectsPathTraversalInResourceName(t *testing.T) {
+	archivePath := t.TempDir()
+	fs, err := filesystem.NewFS(archivePath, os.O_RDWR)
+	require.NoError(t, err)
+	archive := ctf.NewFileSystemCTF(fs)
+	repo, err := oci.NewRepository(ocictf.WithCTF(ocictf.NewFromCTF(archive)))
+	require.NoError(t, err)
+
+	desc := &descriptor.Descriptor{
+		Meta: descriptor.Meta{Version: "v2"},
+		Component: descriptor.Component{
+			ComponentMeta: descriptor.ComponentMeta{
+				ObjectMeta: descriptor.ObjectMeta{Name: testComponent, Version: testVersion},
+			},
+			Provider: descriptor.Provider{Name: "jakob.io"},
+		},
+	}
+	require.NoError(t, repo.AddComponentVersion(t.Context(), desc))
+
+	// Add a resource with a path-traversal name; OCM accepts arbitrary resource names,
+	// but pull must reject them when writing to the default skills location.
+	malicious := &descriptor.Resource{
+		ElementMeta: descriptor.ElementMeta{
+			ObjectMeta: descriptor.ObjectMeta{Name: "../evil", Version: testVersion},
+		},
+		Type:     "ai.skill/v1",
+		Relation: descriptor.LocalRelation,
+		Access:   &v2.LocalBlob{MediaType: "text/markdown"},
+	}
+	updated, err := repo.AddLocalResource(t.Context(), testComponent, testVersion, malicious, inmemory.New(bytes.NewReader(testSkillContent)))
+	require.NoError(t, err)
+	desc.Component.Resources = append(desc.Component.Resources, *updated)
+	require.NoError(t, repo.AddComponentVersion(t.Context(), desc))
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	_, err = test.OCM(t,
+		test.WithArgs("skill", "pull", refString(archivePath)),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.Error(t, err)
+}

--- a/cli/cmd/skill/pull/cmd_test.go
+++ b/cli/cmd/skill/pull/cmd_test.go
@@ -279,3 +279,79 @@ func TestPullRejectsPathTraversalInResourceName(t *testing.T) {
 	)
 	require.Error(t, err)
 }
+
+func TestPullTargetCodex(t *testing.T) {
+	archivePath := setupCatalogueWithSkills(t, map[string][]byte{
+		"ocm-guide": testSkillContent,
+	})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	_, err := test.OCM(t,
+		test.WithArgs("skill", "pull", refString(archivePath), "--skill", "ocm-guide", "--target", "codex"),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.NoError(t, err)
+
+	expected := filepath.Join(home, ".agents", "skills", "ocm-guide", "SKILL.md")
+	data, err := os.ReadFile(expected)
+	require.NoError(t, err)
+	require.Equal(t, testSkillContent, data)
+
+	// must NOT be installed for Claude Code
+	claudePath := filepath.Join(home, ".claude", "skills", "ocm-guide", "SKILL.md")
+	_, err = os.Stat(claudePath)
+	require.True(t, os.IsNotExist(err), "skill must not be installed for claude when --target codex")
+}
+
+func TestPullTargetAll(t *testing.T) {
+	archivePath := setupCatalogueWithSkills(t, map[string][]byte{
+		"ocm-guide": testSkillContent,
+	})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	_, err := test.OCM(t,
+		test.WithArgs("skill", "pull", refString(archivePath), "--skill", "ocm-guide", "--target", "all"),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.NoError(t, err)
+
+	for _, path := range []string{
+		filepath.Join(home, ".claude", "skills", "ocm-guide", "SKILL.md"),
+		filepath.Join(home, ".agents", "skills", "ocm-guide", "SKILL.md"),
+	} {
+		data, err := os.ReadFile(path)
+		require.NoError(t, err, "expected skill at %s", path)
+		require.Equal(t, testSkillContent, data, "content mismatch at %s", path)
+	}
+}
+
+func TestPullTargetInvalid(t *testing.T) {
+	archivePath := setupCatalogueWithSkills(t, map[string][]byte{
+		"ocm-guide": testSkillContent,
+	})
+
+	_, err := test.OCM(t,
+		test.WithArgs("skill", "pull", refString(archivePath), "--skill", "ocm-guide", "--target", "vscode"),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown --target")
+}
+
+func TestPullOutputWithTargetFails(t *testing.T) {
+	archivePath := setupCatalogueWithSkills(t, map[string][]byte{
+		"ocm-guide": testSkillContent,
+	})
+
+	_, err := test.OCM(t,
+		test.WithArgs("skill", "pull", refString(archivePath), "--skill", "ocm-guide",
+			"--output", "/tmp/out.md", "--target", "codex"),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "--output cannot be combined with --target")
+}

--- a/cli/cmd/skill/push/cmd.go
+++ b/cli/cmd/skill/push/cmd.go
@@ -1,0 +1,199 @@
+package push
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	flagComponent  = "component"
+	flagVersion    = "version"
+	flagProvider   = "provider"
+	flagRepository = "repository"
+	flagOutputFile = "output"
+
+	skillResourceType = "ai.skill/v1"
+	skillFileName     = "SKILL.md"
+)
+
+func New() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "push <skills-dir> --component <name> --version <v>",
+		Short: "Generate an OCM component-constructor for a directory of AI skills",
+		Long: `Generate a component-constructor.yaml that packages all SKILL.md files found
+in <skills-dir> as ai.skill/v1 resources inside a single OCM component.
+
+Prints the constructor YAML to stdout by default. Use --output to write to a file.
+
+After generation, run:
+  ocm add component-version --repository <ref> --constructor <output-file>`,
+		Example: `  # Print constructor to stdout
+  ocm skill push ~/.claude/skills --component jakob.io/ai-skill-catalogue --version 1.0.0
+
+  # Write constructor to file
+  ocm skill push ~/.claude/skills --component jakob.io/ai-skill-catalogue --version 1.0.0 --output constructor.yaml
+  ocm add component-version --repository ./catalogue --constructor constructor.yaml`,
+		Args:              cobra.ExactArgs(1),
+		RunE:              pushSkills,
+		DisableAutoGenTag: true,
+	}
+
+	cmd.Flags().String(flagComponent, "", "component name (required, e.g. jakob.io/ai-skill-catalogue)")
+	cmd.Flags().String(flagVersion, "1.0.0", "component version")
+	cmd.Flags().String(flagProvider, "", "provider name (defaults to the domain part of the component name)")
+	cmd.Flags().String(flagRepository, "transport-archive", "target repository reference (printed in usage hint)")
+	cmd.Flags().String(flagOutputFile, "", "write constructor YAML to this file instead of stdout")
+
+	_ = cmd.MarkFlagRequired(flagComponent)
+
+	return cmd
+}
+
+type constructorResource struct {
+	Name    string    `json:"name"`
+	Type    string    `json:"type"`
+	Version string    `json:"version"`
+	Input   fileInput `json:"input"`
+}
+
+type fileInput struct {
+	Type string `json:"type"`
+	Path string `json:"path"`
+}
+
+type constructorComponent struct {
+	Name      string                `json:"name"`
+	Version   string                `json:"version"`
+	Provider  map[string]string     `json:"provider"`
+	Resources []constructorResource `json:"resources"`
+}
+
+type constructorSpec struct {
+	Components []constructorComponent `json:"components"`
+}
+
+func pushSkills(cmd *cobra.Command, args []string) error {
+	skillsDir := args[0]
+
+	component, err := cmd.Flags().GetString(flagComponent)
+	if err != nil {
+		return fmt.Errorf("getting component flag failed: %w", err)
+	}
+
+	version, err := cmd.Flags().GetString(flagVersion)
+	if err != nil {
+		return fmt.Errorf("getting version flag failed: %w", err)
+	}
+
+	provider, err := cmd.Flags().GetString(flagProvider)
+	if err != nil {
+		return fmt.Errorf("getting provider flag failed: %w", err)
+	}
+
+	outputFile, err := cmd.Flags().GetString(flagOutputFile)
+	if err != nil {
+		return fmt.Errorf("getting output flag failed: %w", err)
+	}
+
+	repo, err := cmd.Flags().GetString(flagRepository)
+	if err != nil {
+		return fmt.Errorf("getting repository flag failed: %w", err)
+	}
+
+	if provider == "" {
+		provider = extractProvider(component)
+	}
+
+	absSkillsDir, err := filepath.Abs(skillsDir)
+	if err != nil {
+		return fmt.Errorf("resolving skills directory failed: %w", err)
+	}
+
+	// resolve symlinks on the root to ensure we work with the real path
+	absSkillsDir, err = filepath.EvalSymlinks(absSkillsDir)
+	if err != nil {
+		return fmt.Errorf("evaluating symlinks for skills directory %q failed: %w", absSkillsDir, err)
+	}
+
+	entries, err := os.ReadDir(absSkillsDir)
+	if err != nil {
+		return fmt.Errorf("reading skills directory %q failed: %w", absSkillsDir, err)
+	}
+
+	var resources []constructorResource
+	for _, entry := range entries {
+		// reject symlinked directories to prevent packaging files outside skillsDir
+		info, err := os.Lstat(filepath.Join(absSkillsDir, entry.Name()))
+		if err != nil {
+			return fmt.Errorf("stat of skill directory %q failed: %w", entry.Name(), err)
+		}
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
+
+		skillPath := filepath.Join(absSkillsDir, entry.Name(), skillFileName)
+		if _, err := os.Stat(skillPath); err != nil {
+			continue
+		}
+
+		resources = append(resources, constructorResource{
+			Name:    entry.Name(),
+			Type:    skillResourceType,
+			Version: version,
+			Input: fileInput{
+				Type: "file",
+				Path: skillPath,
+			},
+		})
+	}
+
+	if len(resources) == 0 {
+		return fmt.Errorf("no skills found in %q (expected subdirectories containing %s)", absSkillsDir, skillFileName)
+	}
+
+	spec := constructorSpec{
+		Components: []constructorComponent{
+			{
+				Name:      component,
+				Version:   version,
+				Provider:  map[string]string{"name": provider},
+				Resources: resources,
+			},
+		},
+	}
+
+	out, err := yaml.Marshal(spec)
+	if err != nil {
+		return fmt.Errorf("marshalling constructor spec failed: %w", err)
+	}
+
+	if outputFile == "" {
+		if _, err := fmt.Fprint(cmd.OutOrStdout(), string(out)); err != nil {
+			return fmt.Errorf("writing to stdout failed: %w", err)
+		}
+		return nil
+	}
+
+	if err := os.WriteFile(outputFile, out, 0o600); err != nil {
+		return fmt.Errorf("writing constructor file %q failed: %w", outputFile, err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Constructor written to %s\n", outputFile)
+	fmt.Fprintf(cmd.OutOrStdout(), "Run: ocm add component-version --repository %s --constructor %s\n", repo, outputFile)
+	return nil
+}
+
+// extractProvider returns the domain portion of an OCM component name (before the first '/').
+// For example, "jakob.io/ai-skill-catalogue" → "jakob.io".
+// Falls back to the full component name if no '/' is present.
+func extractProvider(component string) string {
+	if idx := strings.Index(component, "/"); idx > 0 {
+		return component[:idx]
+	}
+	return component
+}

--- a/cli/cmd/skill/push/cmd.go
+++ b/cli/cmd/skill/push/cmd.go
@@ -1,6 +1,7 @@
 package push
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -137,8 +138,22 @@ func pushSkills(cmd *cobra.Command, args []string) error {
 		}
 
 		skillPath := filepath.Join(absSkillsDir, entry.Name(), skillFileName)
-		if _, err := os.Stat(skillPath); err != nil {
+		fi, err := os.Lstat(skillPath)
+		if errors.Is(err, os.ErrNotExist) {
 			continue
+		}
+		if err != nil {
+			return fmt.Errorf("stat of %q failed: %w", skillPath, err)
+		}
+		if fi.Mode()&os.ModeSymlink != 0 || !fi.Mode().IsRegular() {
+			return fmt.Errorf("%q must be a regular non-symlink file", skillPath)
+		}
+		resolvedSkillPath, err := filepath.EvalSymlinks(skillPath)
+		if err != nil {
+			return fmt.Errorf("evaluating symlinks for %q failed: %w", skillPath, err)
+		}
+		if !strings.HasPrefix(resolvedSkillPath, absSkillsDir+string(filepath.Separator)) {
+			return fmt.Errorf("skill file %q resolves outside %q", skillPath, absSkillsDir)
 		}
 
 		resources = append(resources, constructorResource{
@@ -147,7 +162,7 @@ func pushSkills(cmd *cobra.Command, args []string) error {
 			Version: version,
 			Input: fileInput{
 				Type: "file",
-				Path: skillPath,
+				Path: resolvedSkillPath,
 			},
 		})
 	}

--- a/cli/cmd/skill/push/cmd.go
+++ b/cli/cmd/skill/push/cmd.go
@@ -162,7 +162,7 @@ func pushSkills(cmd *cobra.Command, args []string) error {
 			Version: version,
 			Input: fileInput{
 				Type: "file",
-				Path: resolvedSkillPath,
+				Path: skillPath,
 			},
 		})
 	}

--- a/cli/cmd/skill/push/cmd_test.go
+++ b/cli/cmd/skill/push/cmd_test.go
@@ -1,0 +1,265 @@
+package push_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+
+	"ocm.software/open-component-model/cli/cmd/internal/test"
+)
+
+func buildSkillsDir(t *testing.T, skills map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, content := range skills {
+		skillDir := filepath.Join(dir, name)
+		require.NoError(t, os.MkdirAll(skillDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644))
+	}
+	return dir
+}
+
+func TestPushPrintsConstructorToStdout(t *testing.T) {
+	skillsDir := buildSkillsDir(t, map[string]string{
+		"ocm-guide":       "---\nname: ocm-guide\n---\n# OCM Guide\n",
+		"golang-patterns": "---\nname: golang-patterns\n---\n# Go\n",
+	})
+
+	out := new(bytes.Buffer)
+	_, err := test.OCM(t,
+		test.WithArgs("skill", "push", skillsDir, "--component", "myorg.io/skills", "--version", "1.0.0"),
+		test.WithOutput(out),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.NoError(t, err)
+
+	var spec map[string]any
+	require.NoError(t, yaml.Unmarshal(out.Bytes(), &spec), "stdout must be valid YAML")
+
+	components, ok := spec["components"].([]any)
+	require.True(t, ok, "expected 'components' list")
+	require.Len(t, components, 1)
+
+	comp := components[0].(map[string]any)
+	require.Equal(t, "myorg.io/skills", comp["name"])
+	require.Equal(t, "1.0.0", comp["version"])
+
+	resources, ok := comp["resources"].([]any)
+	require.True(t, ok)
+	require.Len(t, resources, 2)
+
+	names := make([]string, 0, len(resources))
+	for _, r := range resources {
+		res := r.(map[string]any)
+		require.Equal(t, "ai.skill/v1", res["type"])
+		names = append(names, res["name"].(string))
+	}
+	require.ElementsMatch(t, []string{"ocm-guide", "golang-patterns"}, names)
+}
+
+func TestPushWritesConstructorToFile(t *testing.T) {
+	skillsDir := buildSkillsDir(t, map[string]string{
+		"my-skill": "---\nname: my-skill\n---\n# Content\n",
+	})
+
+	outputFile := filepath.Join(t.TempDir(), "constructor.yaml")
+	out := new(bytes.Buffer)
+
+	_, err := test.OCM(t,
+		test.WithArgs("skill", "push", skillsDir,
+			"--component", "myorg.io/skills",
+			"--version", "2.0.0",
+			"--output", outputFile,
+		),
+		test.WithOutput(out),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.NoError(t, err)
+	require.FileExists(t, outputFile)
+
+	stdout := out.String()
+	require.Contains(t, stdout, "Constructor written to")
+	require.Contains(t, stdout, "ocm add component-version")
+
+	data, err := os.ReadFile(outputFile)
+	require.NoError(t, err)
+
+	var spec map[string]any
+	require.NoError(t, yaml.Unmarshal(data, &spec))
+
+	components := spec["components"].([]any)
+	comp := components[0].(map[string]any)
+	require.Equal(t, "2.0.0", comp["version"])
+}
+
+func TestPushExtractsProviderFromComponentName(t *testing.T) {
+	skillsDir := buildSkillsDir(t, map[string]string{
+		"ocm-guide": "# content",
+	})
+
+	out := new(bytes.Buffer)
+	_, err := test.OCM(t,
+		test.WithArgs("skill", "push", skillsDir, "--component", "acme.corp/skills", "--version", "1.0.0"),
+		test.WithOutput(out),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.NoError(t, err)
+
+	var spec map[string]any
+	require.NoError(t, yaml.Unmarshal(out.Bytes(), &spec))
+
+	comp := spec["components"].([]any)[0].(map[string]any)
+	provider := comp["provider"].(map[string]any)
+	require.Equal(t, "acme.corp", provider["name"])
+}
+
+func TestPushExplicitProviderOverridesDefault(t *testing.T) {
+	skillsDir := buildSkillsDir(t, map[string]string{
+		"ocm-guide": "# content",
+	})
+
+	out := new(bytes.Buffer)
+	_, err := test.OCM(t,
+		test.WithArgs("skill", "push", skillsDir,
+			"--component", "acme.corp/skills",
+			"--version", "1.0.0",
+			"--provider", "my-team",
+		),
+		test.WithOutput(out),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.NoError(t, err)
+
+	var spec map[string]any
+	require.NoError(t, yaml.Unmarshal(out.Bytes(), &spec))
+
+	comp := spec["components"].([]any)[0].(map[string]any)
+	provider := comp["provider"].(map[string]any)
+	require.Equal(t, "my-team", provider["name"])
+}
+
+func TestPushSkipsSubdirsWithoutSkillMD(t *testing.T) {
+	dir := t.TempDir()
+	// valid skill
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "real-skill"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "real-skill", "SKILL.md"), []byte("# content"), 0o644))
+	// directory without SKILL.md
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "no-skill-here"), 0o755))
+	// plain file at top level — must be ignored
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "random.txt"), []byte("ignored"), 0o644))
+
+	out := new(bytes.Buffer)
+	_, err := test.OCM(t,
+		test.WithArgs("skill", "push", dir, "--component", "org.io/skills", "--version", "1.0.0"),
+		test.WithOutput(out),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.NoError(t, err)
+
+	var spec map[string]any
+	require.NoError(t, yaml.Unmarshal(out.Bytes(), &spec))
+
+	resources := spec["components"].([]any)[0].(map[string]any)["resources"].([]any)
+	require.Len(t, resources, 1)
+	require.Equal(t, "real-skill", resources[0].(map[string]any)["name"])
+}
+
+func TestPushEmptySkillsDirFails(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := test.OCM(t,
+		test.WithArgs("skill", "push", dir, "--component", "org.io/skills", "--version", "1.0.0"),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no skills found")
+}
+
+func TestPushRequiresComponentFlag(t *testing.T) {
+	dir := buildSkillsDir(t, map[string]string{"ocm-guide": "# content"})
+
+	_, err := test.OCM(t,
+		test.WithArgs("skill", "push", dir),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.Error(t, err)
+}
+
+func TestPushResourcePathsAreAbsolute(t *testing.T) {
+	skillsDir := buildSkillsDir(t, map[string]string{
+		"ocm-guide": "# content",
+	})
+
+	out := new(bytes.Buffer)
+	_, err := test.OCM(t,
+		test.WithArgs("skill", "push", skillsDir, "--component", "org.io/skills", "--version", "1.0.0"),
+		test.WithOutput(out),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.NoError(t, err)
+
+	var spec map[string]any
+	require.NoError(t, yaml.Unmarshal(out.Bytes(), &spec))
+
+	resources := spec["components"].([]any)[0].(map[string]any)["resources"].([]any)
+	input := resources[0].(map[string]any)["input"].(map[string]any)
+	path := input["path"].(string)
+	require.True(t, strings.HasPrefix(path, "/"), "resource path must be absolute, got %q", path)
+}
+
+func TestPushRoundTrip(t *testing.T) {
+	// Full round-trip: push generates constructor, add packages it, pull retrieves the skill.
+	// All paths must live under the same root so ocm add can resolve them.
+	skillContent := []byte("---\nname: test-skill\ndescription: Round-trip test\n---\n# Test Skill\n")
+
+	root := t.TempDir()
+
+	skillsDir := filepath.Join(root, "skills")
+	require.NoError(t, os.MkdirAll(filepath.Join(skillsDir, "test-skill"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillsDir, "test-skill", "SKILL.md"), skillContent, 0o644))
+
+	constructorFile := filepath.Join(root, "constructor.yaml")
+	_, err := test.OCM(t,
+		test.WithArgs("skill", "push", skillsDir,
+			"--component", "org.io/skill-catalogue",
+			"--version", "1.0.0",
+			"--output", constructorFile,
+		),
+		test.WithOutput(new(bytes.Buffer)),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.NoError(t, err)
+	require.FileExists(t, constructorFile)
+
+	repoPath := filepath.Join(root, "catalogue")
+	_, err = test.OCM(t,
+		test.WithArgs("add", "component-version",
+			"--repository", repoPath,
+			"--constructor", constructorFile,
+		),
+		test.WithOutput(new(bytes.Buffer)),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.NoError(t, err)
+
+	// use a fresh home so pull goes to a predictable location
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	ref := "CTF::" + repoPath + "//org.io/skill-catalogue:1.0.0"
+	_, err = test.OCM(t,
+		test.WithArgs("skill", "pull", ref, "--skill", "test-skill"),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.NoError(t, err)
+
+	installed := filepath.Join(home, ".claude", "skills", "test-skill", "SKILL.md")
+	data, err := os.ReadFile(installed)
+	require.NoError(t, err)
+	require.Equal(t, skillContent, data)
+}

--- a/cli/cmd/skill/push/cmd_test.go
+++ b/cli/cmd/skill/push/cmd_test.go
@@ -263,3 +263,21 @@ func TestPushRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, skillContent, data)
 }
+
+func TestPushRejectsSymlinkedSkillFile(t *testing.T) {
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "my-skill")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+
+	// Place the real content outside the skills tree and symlink SKILL.md to it.
+	outside := filepath.Join(t.TempDir(), "real.md")
+	require.NoError(t, os.WriteFile(outside, []byte("# content"), 0o644))
+	require.NoError(t, os.Symlink(outside, filepath.Join(skillDir, "SKILL.md")))
+
+	_, err := test.OCM(t,
+		test.WithArgs("skill", "push", root, "--component", "org.io/skills", "--version", "1.0.0"),
+		test.WithOutput(new(bytes.Buffer)),
+		test.WithErrorOutput(test.NewJSONLogReader()),
+	)
+	require.Error(t, err, "push must reject a SKILL.md that is a symlink")
+}

--- a/cli/docs/reference/ocm_skill.md
+++ b/cli/docs/reference/ocm_skill.md
@@ -1,27 +1,27 @@
 ---
-title: ocm
-description: The official Open Component Model (OCM) CLI.
+title: ocm skill
+description: Manage AI skills distributed via OCM component catalogues.
 suppressTitle: true
 toc: true
 sidebar:
   collapsed: true
 ---
 
-## ocm
+## ocm skill
 
-The official Open Component Model (OCM) CLI
-
-### Synopsis
-
-The Open Component Model command line client supports the work with OCM
-  artifacts, like Component Archives, Common Transport Archive,
-  Component Repositories, and Component Versions.
+Manage AI skills distributed via OCM component catalogues
 
 ```
-ocm [sub-command] [flags]
+ocm skill {pull|push} [flags]
 ```
 
 ### Options
+
+```
+  -h, --help   help for skill
+```
+
+### Options inherited from parent commands
 
 ```
       --config string                      supply configuration by a given configuration file.
@@ -42,7 +42,6 @@ ocm [sub-command] [flags]
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, this configuration file be used instead of the lookup above.
-  -h, --help                               help for ocm
       --logformat enum                     set the log output format that is used to print individual logs
                                               json: Output logs in JSON format, suitable for machine processing
                                               text: Output logs in human-readable text format, suitable for console output
@@ -65,16 +64,7 @@ ocm [sub-command] [flags]
 
 ### SEE ALSO
 
-* [ocm add]({{< relref "ocm_add.md" >}})	 - Add anything to OCM
-* [ocm completion]({{< relref "ocm_completion.md" >}})	 - Generate the autocompletion script for the specified shell
-* [ocm describe]({{< relref "ocm_describe.md" >}})	 - Describe OCM entities or metadata
-* [ocm download]({{< relref "ocm_download.md" >}})	 - Download anything from OCM
-* [ocm generate]({{< relref "ocm_generate.md" >}})	 - Generate documentation for the OCM CLI
-* [ocm get]({{< relref "ocm_get.md" >}})	 - Get anything from OCM
-* [ocm plugin]({{< relref "ocm_plugin.md" >}})	 - Manage OCM plugins
-* [ocm sign]({{< relref "ocm_sign.md" >}})	 - create signatures for component versions in OCM
-* [ocm skill]({{< relref "ocm_skill.md" >}})	 - Manage AI skills distributed via OCM component catalogues
-* [ocm transfer]({{< relref "ocm_transfer.md" >}})	 - Transfer anything in OCM
-* [ocm verify]({{< relref "ocm_verify.md" >}})	 - verify digests and signatures of component versions in OCM
-* [ocm version]({{< relref "ocm_version.md" >}})	 - Retrieve the build version of the OCM CLI
+* [ocm]({{< relref "ocm.md" >}})	 - The official Open Component Model (OCM) CLI
+* [ocm skill pull]({{< relref "ocm_skill_pull.md" >}})	 - Pull AI skills from an OCM skill catalogue component
+* [ocm skill push]({{< relref "ocm_skill_push.md" >}})	 - Generate an OCM component-constructor for a directory of AI skills
 

--- a/cli/docs/reference/ocm_skill_pull.md
+++ b/cli/docs/reference/ocm_skill_pull.md
@@ -16,7 +16,14 @@ Pull AI skills from an OCM skill catalogue component
 Pull one or all AI skills from an OCM component version that packages skills as resources with type ai.skill/v1.
 
 When --skill is given, only that resource is downloaded. Without --skill, all ai.skill/v1 resources are downloaded.
-Skills are written to ~/.claude/skills/<skill-name>/SKILL.md by default.
+
+By default skills are installed for Claude Code (--target claude):
+  ~/.claude/skills/<skill-name>/SKILL.md
+
+Use --target codex to install for OpenAI Codex CLI instead:
+  ~/.agents/skills/<skill-name>/SKILL.md
+
+Use --target all to install for both agents simultaneously.
 
 ```
 ocm skill pull <component-ref> [--skill <name>] [--output <path>] [flags]
@@ -25,11 +32,14 @@ ocm skill pull <component-ref> [--skill <name>] [--output <path>] [flags]
 ### Examples
 
 ```
-  # Pull a single skill
+  # Pull a single skill into Claude Code (default)
   ocm skill pull ./catalogue//jakob.io/ai-skill-catalogue:1.0.0 --skill ocm-guide
 
-  # Pull all skills from catalogue to default location
-  ocm skill pull ./catalogue//jakob.io/ai-skill-catalogue:1.0.0
+  # Pull all skills into OpenAI Codex CLI
+  ocm skill pull ./catalogue//jakob.io/ai-skill-catalogue:1.0.0 --target codex
+
+  # Pull all skills into both Claude Code and Codex
+  ocm skill pull ./catalogue//jakob.io/ai-skill-catalogue:1.0.0 --target all
 
   # Pull a skill to a custom path
   ocm skill pull ./catalogue//jakob.io/ai-skill-catalogue:1.0.0 --skill ocm-guide --output /tmp/ocm-guide.md
@@ -41,6 +51,7 @@ ocm skill pull <component-ref> [--skill <name>] [--output <path>] [flags]
   -h, --help            help for pull
       --output string   output path for the skill file (only valid with --skill)
       --skill string    name of skill resource to pull (pulls all ai.skill/v1 resources when omitted)
+      --target string   coding agent to install skills for: "claude" (~/.claude/skills/), "codex" (~/.agents/skills/), or "all" (default "claude")
 ```
 
 ### Options inherited from parent commands

--- a/cli/docs/reference/ocm_skill_pull.md
+++ b/cli/docs/reference/ocm_skill_pull.md
@@ -1,27 +1,49 @@
 ---
-title: ocm
-description: The official Open Component Model (OCM) CLI.
+title: ocm skill pull
+description: Pull AI skills from an OCM skill catalogue component.
 suppressTitle: true
 toc: true
 sidebar:
   collapsed: true
 ---
 
-## ocm
+## ocm skill pull
 
-The official Open Component Model (OCM) CLI
+Pull AI skills from an OCM skill catalogue component
 
 ### Synopsis
 
-The Open Component Model command line client supports the work with OCM
-  artifacts, like Component Archives, Common Transport Archive,
-  Component Repositories, and Component Versions.
+Pull one or all AI skills from an OCM component version that packages skills as resources with type ai.skill/v1.
+
+When --skill is given, only that resource is downloaded. Without --skill, all ai.skill/v1 resources are downloaded.
+Skills are written to ~/.claude/skills/<skill-name>/SKILL.md by default.
 
 ```
-ocm [sub-command] [flags]
+ocm skill pull <component-ref> [--skill <name>] [--output <path>] [flags]
+```
+
+### Examples
+
+```
+  # Pull a single skill
+  ocm skill pull ./catalogue//jakob.io/ai-skill-catalogue:1.0.0 --skill ocm-guide
+
+  # Pull all skills from catalogue to default location
+  ocm skill pull ./catalogue//jakob.io/ai-skill-catalogue:1.0.0
+
+  # Pull a skill to a custom path
+  ocm skill pull ./catalogue//jakob.io/ai-skill-catalogue:1.0.0 --skill ocm-guide --output /tmp/ocm-guide.md
 ```
 
 ### Options
+
+```
+  -h, --help            help for pull
+      --output string   output path for the skill file (only valid with --skill)
+      --skill string    name of skill resource to pull (pulls all ai.skill/v1 resources when omitted)
+```
+
+### Options inherited from parent commands
 
 ```
       --config string                      supply configuration by a given configuration file.
@@ -42,7 +64,6 @@ ocm [sub-command] [flags]
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, this configuration file be used instead of the lookup above.
-  -h, --help                               help for ocm
       --logformat enum                     set the log output format that is used to print individual logs
                                               json: Output logs in JSON format, suitable for machine processing
                                               text: Output logs in human-readable text format, suitable for console output
@@ -65,16 +86,5 @@ ocm [sub-command] [flags]
 
 ### SEE ALSO
 
-* [ocm add]({{< relref "ocm_add.md" >}})	 - Add anything to OCM
-* [ocm completion]({{< relref "ocm_completion.md" >}})	 - Generate the autocompletion script for the specified shell
-* [ocm describe]({{< relref "ocm_describe.md" >}})	 - Describe OCM entities or metadata
-* [ocm download]({{< relref "ocm_download.md" >}})	 - Download anything from OCM
-* [ocm generate]({{< relref "ocm_generate.md" >}})	 - Generate documentation for the OCM CLI
-* [ocm get]({{< relref "ocm_get.md" >}})	 - Get anything from OCM
-* [ocm plugin]({{< relref "ocm_plugin.md" >}})	 - Manage OCM plugins
-* [ocm sign]({{< relref "ocm_sign.md" >}})	 - create signatures for component versions in OCM
 * [ocm skill]({{< relref "ocm_skill.md" >}})	 - Manage AI skills distributed via OCM component catalogues
-* [ocm transfer]({{< relref "ocm_transfer.md" >}})	 - Transfer anything in OCM
-* [ocm verify]({{< relref "ocm_verify.md" >}})	 - verify digests and signatures of component versions in OCM
-* [ocm version]({{< relref "ocm_version.md" >}})	 - Retrieve the build version of the OCM CLI
 

--- a/cli/docs/reference/ocm_skill_push.md
+++ b/cli/docs/reference/ocm_skill_push.md
@@ -1,27 +1,53 @@
 ---
-title: ocm
-description: The official Open Component Model (OCM) CLI.
+title: ocm skill push
+description: Generate an OCM component-constructor for a directory of AI skills.
 suppressTitle: true
 toc: true
 sidebar:
   collapsed: true
 ---
 
-## ocm
+## ocm skill push
 
-The official Open Component Model (OCM) CLI
+Generate an OCM component-constructor for a directory of AI skills
 
 ### Synopsis
 
-The Open Component Model command line client supports the work with OCM
-  artifacts, like Component Archives, Common Transport Archive,
-  Component Repositories, and Component Versions.
+Generate a component-constructor.yaml that packages all SKILL.md files found
+in <skills-dir> as ai.skill/v1 resources inside a single OCM component.
+
+Prints the constructor YAML to stdout by default. Use --output to write to a file.
+
+After generation, run:
+  ocm add component-version --repository <ref> --constructor <output-file>
 
 ```
-ocm [sub-command] [flags]
+ocm skill push <skills-dir> --component <name> --version <v> [flags]
+```
+
+### Examples
+
+```
+  # Print constructor to stdout
+  ocm skill push ~/.claude/skills --component jakob.io/ai-skill-catalogue --version 1.0.0
+
+  # Write constructor to file
+  ocm skill push ~/.claude/skills --component jakob.io/ai-skill-catalogue --version 1.0.0 --output constructor.yaml
+  ocm add component-version --repository ./catalogue --constructor constructor.yaml
 ```
 
 ### Options
+
+```
+      --component string    component name (required, e.g. jakob.io/ai-skill-catalogue)
+  -h, --help                help for push
+      --output string       write constructor YAML to this file instead of stdout
+      --provider string     provider name (defaults to the domain part of the component name)
+      --repository string   target repository reference (printed in usage hint) (default "transport-archive")
+      --version string      component version (default "1.0.0")
+```
+
+### Options inherited from parent commands
 
 ```
       --config string                      supply configuration by a given configuration file.
@@ -42,7 +68,6 @@ ocm [sub-command] [flags]
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, this configuration file be used instead of the lookup above.
-  -h, --help                               help for ocm
       --logformat enum                     set the log output format that is used to print individual logs
                                               json: Output logs in JSON format, suitable for machine processing
                                               text: Output logs in human-readable text format, suitable for console output
@@ -65,16 +90,5 @@ ocm [sub-command] [flags]
 
 ### SEE ALSO
 
-* [ocm add]({{< relref "ocm_add.md" >}})	 - Add anything to OCM
-* [ocm completion]({{< relref "ocm_completion.md" >}})	 - Generate the autocompletion script for the specified shell
-* [ocm describe]({{< relref "ocm_describe.md" >}})	 - Describe OCM entities or metadata
-* [ocm download]({{< relref "ocm_download.md" >}})	 - Download anything from OCM
-* [ocm generate]({{< relref "ocm_generate.md" >}})	 - Generate documentation for the OCM CLI
-* [ocm get]({{< relref "ocm_get.md" >}})	 - Get anything from OCM
-* [ocm plugin]({{< relref "ocm_plugin.md" >}})	 - Manage OCM plugins
-* [ocm sign]({{< relref "ocm_sign.md" >}})	 - create signatures for component versions in OCM
 * [ocm skill]({{< relref "ocm_skill.md" >}})	 - Manage AI skills distributed via OCM component catalogues
-* [ocm transfer]({{< relref "ocm_transfer.md" >}})	 - Transfer anything in OCM
-* [ocm verify]({{< relref "ocm_verify.md" >}})	 - verify digests and signatures of component versions in OCM
-* [ocm version]({{< relref "ocm_version.md" >}})	 - Retrieve the build version of the OCM CLI
 

--- a/cli/integration/skill_integration_test.go
+++ b/cli/integration/skill_integration_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func Test_Integration_SkillPushPull(t *testing.T) {
-	t.Parallel()
 	r := require.New(t)
 
 	registry, err := internal.CreateOCIRegistry(t)
@@ -79,7 +78,6 @@ func Test_Integration_SkillPushPull(t *testing.T) {
 }
 
 func Test_Integration_SkillPullAll(t *testing.T) {
-	t.Parallel()
 	r := require.New(t)
 
 	registry, err := internal.CreateOCIRegistry(t)
@@ -143,7 +141,6 @@ func Test_Integration_SkillPullAll(t *testing.T) {
 }
 
 func Test_Integration_SkillPullIdempotent(t *testing.T) {
-	t.Parallel()
 	r := require.New(t)
 
 	registry, err := internal.CreateOCIRegistry(t)

--- a/cli/integration/skill_integration_test.go
+++ b/cli/integration/skill_integration_test.go
@@ -1,0 +1,225 @@
+package integration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"ocm.software/open-component-model/cli/cmd"
+	"ocm.software/open-component-model/cli/integration/internal"
+)
+
+func Test_Integration_SkillPushPull(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	registry, err := internal.CreateOCIRegistry(t)
+	r.NoError(err)
+
+	cfgPath := writeOCMConfig(t, registry)
+
+	component := "ocm.software/skill-catalogue"
+	version := "1.0.0"
+
+	root := t.TempDir()
+
+	skillContent := []byte("---\nname: test-skill\ndescription: Integration test skill\n---\n\n# Test Skill\n\nContent.\n")
+	skillsDir := filepath.Join(root, "skills")
+	r.NoError(os.MkdirAll(filepath.Join(skillsDir, "test-skill"), 0o755))
+	r.NoError(os.WriteFile(filepath.Join(skillsDir, "test-skill", "SKILL.md"), skillContent, 0o644))
+
+	constructorPath := filepath.Join(root, "constructor.yaml")
+
+	t.Run("push generates constructor", func(t *testing.T) {
+		pushCMD := cmd.New()
+		pushCMD.SetArgs([]string{
+			"skill", "push", skillsDir,
+			"--component", component,
+			"--version", version,
+			"--output", constructorPath,
+		})
+		require.NoError(t, pushCMD.ExecuteContext(t.Context()))
+		require.FileExists(t, constructorPath)
+	})
+
+	repoRef := fmt.Sprintf("http://%s", registry.RegistryAddress)
+
+	t.Run("add component-version packages skills into OCI registry", func(t *testing.T) {
+		addCMD := cmd.New()
+		addCMD.SetArgs([]string{
+			"add", "component-version",
+			"--repository", repoRef,
+			"--constructor", constructorPath,
+			"--config", cfgPath,
+		})
+		require.NoError(t, addCMD.ExecuteContext(t.Context()))
+	})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	t.Run("pull installs skill from OCI registry", func(t *testing.T) {
+		ref := fmt.Sprintf("%s//%s:%s", repoRef, component, version)
+		pullCMD := cmd.New()
+		pullCMD.SetArgs([]string{
+			"skill", "pull", ref,
+			"--skill", "test-skill",
+			"--config", cfgPath,
+		})
+		require.NoError(t, pullCMD.ExecuteContext(t.Context()))
+
+		installed := filepath.Join(home, ".claude", "skills", "test-skill", "SKILL.md")
+		data, err := os.ReadFile(installed)
+		require.NoError(t, err)
+		require.Equal(t, skillContent, data)
+	})
+}
+
+func Test_Integration_SkillPullAll(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	registry, err := internal.CreateOCIRegistry(t)
+	r.NoError(err)
+
+	cfgPath := writeOCMConfig(t, registry)
+
+	component := "ocm.software/multi-skill-catalogue"
+	version := "1.0.0"
+
+	skills := map[string][]byte{
+		"skill-alpha": []byte("---\nname: skill-alpha\n---\n# Alpha\n"),
+		"skill-beta":  []byte("---\nname: skill-beta\n---\n# Beta\n"),
+	}
+
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, "skills")
+	for name, content := range skills {
+		r.NoError(os.MkdirAll(filepath.Join(skillsDir, name), 0o755))
+		r.NoError(os.WriteFile(filepath.Join(skillsDir, name, "SKILL.md"), content, 0o644))
+	}
+
+	constructorPath := filepath.Join(root, "constructor.yaml")
+	pushCMD := cmd.New()
+	pushCMD.SetArgs([]string{
+		"skill", "push", skillsDir,
+		"--component", component,
+		"--version", version,
+		"--output", constructorPath,
+	})
+	r.NoError(pushCMD.ExecuteContext(t.Context()))
+
+	repoRef := fmt.Sprintf("http://%s", registry.RegistryAddress)
+
+	addCMD := cmd.New()
+	addCMD.SetArgs([]string{
+		"add", "component-version",
+		"--repository", repoRef,
+		"--constructor", constructorPath,
+		"--config", cfgPath,
+	})
+	r.NoError(addCMD.ExecuteContext(t.Context()))
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	ref := fmt.Sprintf("%s//%s:%s", repoRef, component, version)
+	pullCMD := cmd.New()
+	pullCMD.SetArgs([]string{
+		"skill", "pull", ref,
+		"--config", cfgPath,
+	})
+	r.NoError(pullCMD.ExecuteContext(t.Context()))
+
+	for name, expected := range skills {
+		path := filepath.Join(home, ".claude", "skills", name, "SKILL.md")
+		data, err := os.ReadFile(path)
+		r.NoError(err, "skill %q not installed", name)
+		r.Equal(expected, data, "skill %q content mismatch", name)
+	}
+}
+
+func Test_Integration_SkillPullIdempotent(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	registry, err := internal.CreateOCIRegistry(t)
+	r.NoError(err)
+
+	cfgPath := writeOCMConfig(t, registry)
+
+	component := "ocm.software/idempotent-skill-catalogue"
+	version := "1.0.0"
+	skillContent := []byte("---\nname: idem-skill\n---\n# Idem\n")
+
+	root := t.TempDir()
+	skillsDir := filepath.Join(root, "skills")
+	r.NoError(os.MkdirAll(filepath.Join(skillsDir, "idem-skill"), 0o755))
+	r.NoError(os.WriteFile(filepath.Join(skillsDir, "idem-skill", "SKILL.md"), skillContent, 0o644))
+
+	constructorPath := filepath.Join(root, "constructor.yaml")
+	pushCMD := cmd.New()
+	pushCMD.SetArgs([]string{
+		"skill", "push", skillsDir,
+		"--component", component,
+		"--version", version,
+		"--output", constructorPath,
+	})
+	r.NoError(pushCMD.ExecuteContext(t.Context()))
+
+	repoRef := fmt.Sprintf("http://%s", registry.RegistryAddress)
+
+	addCMD := cmd.New()
+	addCMD.SetArgs([]string{
+		"add", "component-version",
+		"--repository", repoRef,
+		"--constructor", constructorPath,
+		"--config", cfgPath,
+	})
+	r.NoError(addCMD.ExecuteContext(t.Context()))
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	ref := fmt.Sprintf("%s//%s:%s", repoRef, component, version)
+	for i := range 3 {
+		pullCMD := cmd.New()
+		pullCMD.SetArgs([]string{
+			"skill", "pull", ref,
+			"--skill", "idem-skill",
+			"--config", cfgPath,
+		})
+		r.NoError(pullCMD.ExecuteContext(t.Context()), "pull %d failed", i+1)
+	}
+
+	installed := filepath.Join(home, ".claude", "skills", "idem-skill", "SKILL.md")
+	data, err := os.ReadFile(installed)
+	r.NoError(err)
+	r.Equal(skillContent, data, "repeated pulls must not duplicate content")
+}
+
+func writeOCMConfig(t *testing.T, registry *internal.OCIRegistry) string {
+	t.Helper()
+	cfg := fmt.Sprintf(`
+type: generic.config.ocm.software/v1
+configurations:
+- type: credentials.config.ocm.software
+  consumers:
+  - identity:
+      type: OCIRegistry
+      hostname: %[1]q
+      port: %[2]q
+      scheme: http
+    credentials:
+    - type: Credentials/v1
+      properties:
+        username: %[3]q
+        password: %[4]q
+`, registry.Host, registry.Port, registry.User, registry.Password)
+	cfgPath := filepath.Join(t.TempDir(), "ocmconfig.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfg), os.ModePerm))
+	return cfgPath
+}

--- a/docs/blog/shipping-ai-skills-with-ocm.md
+++ b/docs/blog/shipping-ai-skills-with-ocm.md
@@ -20,7 +20,7 @@ That description fits AI skills perfectly. A skill is a text file with a name an
 
 The key design decision: **one OCM component = one catalogue release**. We don't create a separate component per skill — that would make the registry noisy and installs awkward. Instead, each skill is a *resource* inside a single catalogue component:
 
-```
+```text
 Component: jakob.io/ai-skill-catalogue   version: 1.0.0
 ├── resource: ocm-guide        type: ai.skill/v1   (SKILL.md)
 ├── resource: golang-patterns   type: ai.skill/v1   (SKILL.md)
@@ -54,7 +54,7 @@ Skills live at `~/.claude/skills/<skill-name>/SKILL.md`. Claude Code picks them 
 
 Your skills directory should have one subdirectory per skill, each containing a `SKILL.md`:
 
-```
+```text
 my-skills/
 ├── ocm-guide/
 │   └── SKILL.md
@@ -105,7 +105,8 @@ ocm add component-version \
 ```
 
 Output:
-```
+
+```text
  COMPONENT                    │ VERSION │ PROVIDER
 ─────────────────────────────┼─────────┼──────────
  myorg.io/ai-skill-catalogue  │ 1.0.0   │ myorg.io
@@ -129,7 +130,8 @@ ocm skill pull ./my-catalogue//myorg.io/ai-skill-catalogue:1.0.0
 ```
 
 Output:
-```
+
+```text
 skill installed   skill=ocm-guide       output=~/.claude/skills/ocm-guide/SKILL.md
 skill installed   skill=golang-patterns  output=~/.claude/skills/golang-patterns/SKILL.md
 ```
@@ -192,6 +194,7 @@ ocm skill pull <repo>//<component>:<version> \
 ```
 
 Repository reference formats:
+
 - Local CTF: `./my-catalogue`
 - OCI registry: `ghcr.io/myorg`
 - Explicit type: `CTF::./my-catalogue` or `OCI::ghcr.io/myorg`

--- a/docs/blog/shipping-ai-skills-with-ocm.md
+++ b/docs/blog/shipping-ai-skills-with-ocm.md
@@ -1,0 +1,197 @@
+# Shipping AI Skills with the Open Component Model
+
+Imagine installing a Claude Code skill the same way you deploy a container image — versioned, signed, pulled from a registry. That's what we built, and this post walks through how.
+
+## The Problem: Skills Live in Dotfiles
+
+Claude Code skills are Markdown files. They teach the AI how to work with your stack — how to write idiomatic Go, how to query ClickHouse, how to structure a Django migration. They're genuinely useful, and they accumulate fast.
+
+The problem is distribution. Right now, skills live in `~/.claude/skills/`. Sharing them means copying files, committing them to a dotfiles repo, or just describing them in a README and hoping someone bothers to recreate them. There's no versioning, no provenance, no way to say "install skill `golang-patterns` version 1.2.0 from my team's registry."
+
+We wanted something better. And it turns out the Open Component Model was already built for exactly this kind of problem.
+
+## What OCM Gives You
+
+The [Open Component Model](https://ocm.software) is an open standard for describing and distributing software artifacts. Its core idea is simple: a *component version* is a named, versioned bundle of *resources*. Resources can be anything — container images, Helm charts, binaries, plain text files. The component descriptor records what's in the bundle, how to get it, and who produced it. Everything lives in a standard OCI registry.
+
+That description fits AI skills perfectly. A skill is a text file with a name and a version. An OCI registry is a fine place to store a catalogue of them.
+
+## One Component, Many Skills
+
+The key design decision: **one OCM component = one catalogue release**. We don't create a separate component per skill — that would make the registry noisy and installs awkward. Instead, each skill is a *resource* inside a single catalogue component:
+
+```
+Component: jakob.io/ai-skill-catalogue   version: 1.0.0
+├── resource: ocm-guide        type: ai.skill/v1   (SKILL.md)
+├── resource: golang-patterns   type: ai.skill/v1   (SKILL.md)
+└── resource: backend-patterns  type: ai.skill/v1   (SKILL.md)
+```
+
+The type `ai.skill/v1` is just a string label — OCM stores unknown resource types as blobs. No plugins, no new code on the registry side.
+
+## What a Skill Looks Like
+
+A skill is a Markdown file with a YAML frontmatter header. Claude Code reads the `name` and `description` to decide when to apply it, and follows the body as instructions:
+
+```markdown
+---
+name: golang-patterns
+description: Idiomatic Go patterns and best practices. Use when writing or reviewing Go code.
+tools: ["Read", "Bash"]
+---
+
+# Go Patterns
+
+## Error handling
+Always wrap errors with context...
+```
+
+Skills live at `~/.claude/skills/<skill-name>/SKILL.md`. Claude Code picks them up automatically on the next session — no restart needed.
+
+## Hands-On: Package and Install Skills
+
+### 1. Organise your skills directory
+
+Your skills directory should have one subdirectory per skill, each containing a `SKILL.md`:
+
+```
+my-skills/
+├── ocm-guide/
+│   └── SKILL.md
+└── golang-patterns/
+    └── SKILL.md
+```
+
+### 2. Generate the component constructor
+
+```bash
+ocm skill push ./my-skills \
+  --component myorg.io/ai-skill-catalogue \
+  --version 1.0.0 \
+  --output constructor.yaml
+```
+
+This scans `./my-skills` for `SKILL.md` files and writes a `constructor.yaml`:
+
+```yaml
+components:
+  - name: myorg.io/ai-skill-catalogue
+    version: 1.0.0
+    provider:
+      name: myorg.io
+    resources:
+      - name: ocm-guide
+        type: ai.skill/v1
+        version: 1.0.0
+        input:
+          type: file
+          path: /absolute/path/to/my-skills/ocm-guide/SKILL.md
+      - name: golang-patterns
+        type: ai.skill/v1
+        version: 1.0.0
+        input:
+          type: file
+          path: /absolute/path/to/my-skills/golang-patterns/SKILL.md
+```
+
+### 3. Package into a local archive
+
+OCM's CTF (Common Transport Format) is a local directory-based archive — no registry required to get started:
+
+```bash
+ocm add component-version \
+  --repository ./my-catalogue \
+  --constructor constructor.yaml
+```
+
+Output:
+```
+ COMPONENT                    │ VERSION │ PROVIDER
+─────────────────────────────┼─────────┼──────────
+ myorg.io/ai-skill-catalogue  │ 1.0.0   │ myorg.io
+```
+
+### 4. Install a skill into Claude Code
+
+Pull a single skill directly into `~/.claude/skills/`:
+
+```bash
+ocm skill pull ./my-catalogue//myorg.io/ai-skill-catalogue:1.0.0 \
+  --skill ocm-guide
+```
+
+The skill lands at `~/.claude/skills/ocm-guide/SKILL.md`. Claude Code picks it up in the next session.
+
+To pull every skill in the catalogue at once, omit `--skill`:
+
+```bash
+ocm skill pull ./my-catalogue//myorg.io/ai-skill-catalogue:1.0.0
+```
+
+Output:
+```
+skill installed   skill=ocm-guide       output=~/.claude/skills/ocm-guide/SKILL.md
+skill installed   skill=golang-patterns  output=~/.claude/skills/golang-patterns/SKILL.md
+```
+
+### 5. Verify it's active
+
+List your installed skills:
+
+```bash
+ls ~/.claude/skills/
+```
+
+Or start a Claude Code session and ask: *"What skills do you have available?"* — it will list all installed skills including their descriptions.
+
+## Using a Real OCI Registry
+
+Once you're ready to share with a team, swap the local archive path for a registry URL. OCM uses the same `//component:version` syntax:
+
+```bash
+# push to GHCR
+ocm add component-version \
+  --repository ghcr.io/myorg \
+  --constructor constructor.yaml
+
+# anyone on the team installs
+ocm skill pull ghcr.io/myorg//myorg.io/ai-skill-catalogue:1.0.0
+```
+
+Authentication follows standard OCI credential helpers — `docker login ghcr.io` is sufficient.
+
+## The Self-Referential Part
+
+The first skill we packaged in this catalogue is `ocm-guide` — a skill that teaches Claude how OCM works: the component descriptor format, resource types, CLI patterns, the plugin system. It's distributed via OCM, and it explains OCM.
+
+Once installed, ask Claude to help you write a component constructor, understand a resource access error, or navigate the plugin system — and it answers from the skill's context rather than general training data.
+
+## Why This Matters
+
+OCI registries are infrastructure you already have. GitHub Container Registry, AWS ECR, Google Artifact Registry — they all speak the OCI distribution spec that OCM builds on. A skill catalogue is just another OCI artifact living alongside your container images. You get:
+
+- **Versioning** — `1.0.0`, `1.1.0`, semantic versioning, floating tags.
+- **Provenance** — OCM supports signing. You can verify a skill came from your team's registry, not a random source.
+- **Transport** — CTF lets you air-gap the catalogue, carry it on a USB drive, mirror it to an internal registry.
+- **Composability** — nothing stops you from putting a skill alongside the container image and Helm chart for the same service, all in one component version.
+
+## Full Command Reference
+
+```bash
+# Generate constructor from a skills directory
+ocm skill push <skills-dir> \
+  --component <domain>/<name> \
+  --version <semver> \
+  [--provider <name>]       # defaults to domain part of component name
+  [--output <file>]         # write YAML to file instead of stdout
+
+# Pull skills from a catalogue
+ocm skill pull <repo>//<component>:<version> \
+  [--skill <name>]          # omit to pull all ai.skill/v1 resources
+  [--output <path>]         # custom output path (requires --skill)
+```
+
+Repository reference formats:
+- Local CTF: `./my-catalogue`
+- OCI registry: `ghcr.io/myorg`
+- Explicit type: `CTF::./my-catalogue` or `OCI::ghcr.io/myorg`

--- a/docs/blog/shipping-ai-skills-with-ocm.md
+++ b/docs/blog/shipping-ai-skills-with-ocm.md
@@ -206,6 +206,7 @@ ocm skill push <skills-dir> \
 ocm skill pull <repo>//<component>:<version> \
   [--skill <name>]          # omit to pull all ai.skill/v1 resources
   [--output <path>]         # custom output path (requires --skill)
+  [--target <agent>]        # claude (default), codex, or all
 ```
 
 Repository reference formats:

--- a/docs/blog/shipping-ai-skills-with-ocm.md
+++ b/docs/blog/shipping-ai-skills-with-ocm.md
@@ -123,7 +123,22 @@ ocm skill pull ./my-catalogue//myorg.io/ai-skill-catalogue:1.0.0 \
 
 The skill lands at `~/.claude/skills/ocm-guide/SKILL.md`. Claude Code picks it up in the next session.
 
-To pull every skill in the catalogue at once, omit `--skill`:
+To install for **OpenAI Codex CLI** instead (`~/.agents/skills/`), pass `--target codex`:
+
+```bash
+ocm skill pull ./my-catalogue//myorg.io/ai-skill-catalogue:1.0.0 \
+  --skill ocm-guide \
+  --target codex
+```
+
+To install for **both agents at once**, use `--target all`:
+
+```bash
+ocm skill pull ./my-catalogue//myorg.io/ai-skill-catalogue:1.0.0 \
+  --target all
+```
+
+To pull every skill in the catalogue at once (defaults to `--target claude`), omit `--skill`:
 
 ```bash
 ocm skill pull ./my-catalogue//myorg.io/ai-skill-catalogue:1.0.0

--- a/skills-catalogue.yaml
+++ b/skills-catalogue.yaml
@@ -1,0 +1,18 @@
+components:
+  - name: jakob.io/ai-skill-catalogue
+    version: "1.0.0"
+    provider:
+      name: jakob
+    resources:
+      - name: ocm-guide
+        type: ai.skill/v1
+        version: "1.0.0"
+        input:
+          type: file
+          path: ./skills/ocm-guide/SKILL.md
+      - name: golang-patterns
+        type: ai.skill/v1
+        version: "1.0.0"
+        input:
+          type: file
+          path: ./skills/golang-patterns/SKILL.md

--- a/website/content/blog/2026-05-22-shipping-ai-skills-with-ocm.md
+++ b/website/content/blog/2026-05-22-shipping-ai-skills-with-ocm.md
@@ -1,46 +1,61 @@
 ---
-title: "Shipping AI Skills with the Open Component Model"
+title: "Shipping AI Agent Skills with the Open Component Model"
 date: 2026-05-22T10:00:00+02:00
 draft: false
-description: "Use OCM to version, sign, and distribute Claude Code and Codex CLI skills from any OCI registry — the same way you ship container images."
-summary: "Package AI coding-assistant skills as OCM component resources and pull them into Claude Code or OpenAI Codex CLI with a single command."
+description: "A vendor-neutral, airgap-capable approach to versioning, signing, and distributing AI agent skills using OCI registries — no lock-in, no proprietary store."
+summary: "AI coding agents need skills to work well with your stack. Today those skills live in dotfiles with no versioning, no provenance, and no shared distribution mechanism. OCM fixes that."
 categories: ["ai", "cli"]
-tags: ["ai", "skills", "claude-code", "codex", "oci"]
+tags: ["ai", "skills", "agent", "oci", "supply-chain"]
 contributors: []
 ---
 
-Imagine installing a Claude Code skill the same way you deploy a container image — versioned, signed, pulled from a registry. That's what we built, and this post walks through how.
+AI coding agents are proliferating fast. Claude Code, OpenAI Codex CLI, Gemini CLI, Cursor, Continue — each has its own way of learning how to work with your stack. They call the configuration different things: skills, rules, context files, prompts. But the underlying problem is the same everywhere.
 
-## The Problem: Skills Live in Dotfiles
+**Nobody has solved distribution.**
 
-Claude Code skills are Markdown files. They teach the AI how to work with your stack — how to write idiomatic Go, how to query ClickHouse, how to structure a Django migration. They're genuinely useful, and they accumulate fast.
+## The Problem is Bigger Than One Agent
 
-The problem is distribution. Right now, skills live in `~/.claude/skills/`. Sharing them means copying files, committing them to a dotfiles repo, or just describing them in a README and hoping someone bothers to recreate them. There's no versioning, no provenance, no way to say "install skill `golang-patterns` version 1.2.0 from my team's registry."
+Wherever you look, agent configuration lives in dotfiles:
 
-We wanted something better. And it turns out the Open Component Model was already built for exactly this kind of problem.
+- Claude Code: `~/.claude/skills/<name>/SKILL.md`
+- OpenAI Codex CLI: `~/.agents/skills/<name>/SKILL.md`
+- Cursor: `.cursorrules`
+- Continue: `.continue/`
 
-## What OCM Gives You
+Sharing this configuration today means copying files by hand, committing them to a personal dotfiles repo, or describing them in a README and hoping a teammate bothers to recreate them. There is no versioning, no provenance, no way to express "install the `golang-patterns` skill at version 1.2.0 from my organisation's internal registry."
 
-The [Open Component Model](https://ocm.software) is an open standard for describing and distributing software artifacts. Its core idea is simple: a *component version* is a named, versioned bundle of *resources*. Resources can be anything — container images, Helm charts, binaries, plain text files. The component descriptor records what's in the bundle, how to get it, and who produced it. Everything lives in a standard OCI registry.
+Every team that builds up a useful library of agent configuration faces the same distribution gap. The files exist. The knowledge exists. But the moment you want to share it reliably across machines, teams, or air-gapped environments — the tooling runs out.
 
-That description fits AI skills perfectly. A skill is a text file with a name and a version. An OCI registry is a fine place to store a catalogue of them.
+## A Vendor-Neutral, Lock-In-Free Answer
+
+The [Open Component Model](https://ocm.software) is an open standard for describing and distributing software artifacts. It is not tied to any cloud provider, any agent vendor, or any proprietary store. Its transport layer is the OCI distribution spec — the same protocol used by every container registry on the planet. GitHub Container Registry, AWS ECR, Google Artifact Registry, your on-premises Zot instance — they all work without modification.
+
+The core abstraction is simple: a *component version* is a named, versioned bundle of *resources*. Resources can be anything — container images, Helm charts, binaries, plain text files. The component descriptor records what is in the bundle, how to retrieve it, and who produced it.
+
+That abstraction fits agent skills exactly. A skill is a text file with a name and a version. An OCI registry is a fine place to store a catalogue of them, and OCM adds the layer that makes it safe:
+
+- **Signing** — component versions can be signed with cosign or GPG. You can verify a skill came from your organisation, not an arbitrary source.
+- **Air-gap transport** — OCM's CTF (Common Transport Format) is a portable local archive. You can carry a skill catalogue on a USB drive, mirror it to an internal registry, or ship it as part of a software delivery pipeline with no internet access required.
+- **Composability** — nothing stops you from placing a skill alongside the container image and Helm chart for the same service, all in one component version. Your deployment unit and your agent configuration travel together.
+
+No proprietary store. No agent-specific distribution format. No cloud dependency. Just OCI.
 
 ## One Component, Many Skills
 
-The key design decision: **one OCM component = one catalogue release**. We don't create a separate component per skill — that would make the registry noisy and installs awkward. Instead, each skill is a *resource* inside a single catalogue component:
+The key design decision: **one OCM component = one catalogue release**. Each skill is a *resource* inside that component, identified by name and the type label `ai.skill/v1`:
 
 ```text
-Component: jakob.io/ai-skill-catalogue   version: 1.0.0
+Component: myorg.io/ai-skill-catalogue   version: 1.0.0
 ├── resource: ocm-guide        type: ai.skill/v1   (SKILL.md)
 ├── resource: golang-patterns   type: ai.skill/v1   (SKILL.md)
 └── resource: backend-patterns  type: ai.skill/v1   (SKILL.md)
 ```
 
-The type `ai.skill/v1` is just a string label — OCM stores unknown resource types as blobs. No plugins, no new code on the registry side.
+`ai.skill/v1` is just a string label — OCM stores unknown resource types as blobs. No plugins, no registry-side changes, no coordination with any vendor required.
 
 ## What a Skill Looks Like
 
-A skill is a Markdown file with a YAML frontmatter header. Claude Code reads the `name` and `description` to decide when to apply it, and follows the body as instructions:
+A skill is a Markdown file with a YAML frontmatter header. The agent reads `name` and `description` to decide when to apply it:
 
 ```markdown
 ---
@@ -55,13 +70,11 @@ tools: ["Read", "Bash"]
 Always wrap errors with context...
 ```
 
-Skills live at `~/.claude/skills/<skill-name>/SKILL.md`. Claude Code picks them up automatically on the next session — no restart needed.
+The format is readable by humans, writable by hand, and parseable by any agent that follows the convention. OCM does not care about the content — it stores and retrieves whatever bytes you put in.
 
 ## Hands-On: Package and Install Skills
 
 ### 1. Organise your skills directory
-
-Your skills directory should have one subdirectory per skill, each containing a `SKILL.md`:
 
 ```text
 my-skills/
@@ -80,7 +93,7 @@ ocm skill push ./my-skills \
   --output constructor.yaml
 ```
 
-This scans `./my-skills` for `SKILL.md` files and writes a `constructor.yaml`:
+This scans `./my-skills` for `SKILL.md` files and writes a `constructor.yaml` that describes the component:
 
 ```yaml
 components:
@@ -105,7 +118,7 @@ components:
 
 ### 3. Package into a local archive
 
-OCM's CTF (Common Transport Format) is a local directory-based archive — no registry required to get started:
+OCM's CTF archive requires no registry to get started:
 
 ```bash
 ocm add component-version \
@@ -121,18 +134,18 @@ Output:
  myorg.io/ai-skill-catalogue  │ 1.0.0   │ myorg.io
 ```
 
-### 4. Install a skill into Claude Code
+### 4. Install skills
 
-Pull a single skill directly into `~/.claude/skills/`:
+Pull a single skill for **Claude Code** (default):
 
 ```bash
 ocm skill pull ./my-catalogue//myorg.io/ai-skill-catalogue:1.0.0 \
   --skill ocm-guide
 ```
 
-The skill lands at `~/.claude/skills/ocm-guide/SKILL.md`. Claude Code picks it up in the next session.
+The skill lands at `~/.claude/skills/ocm-guide/SKILL.md`.
 
-To install for **OpenAI Codex CLI** instead (`~/.agents/skills/`), pass `--target codex`:
+Install for **OpenAI Codex CLI** instead:
 
 ```bash
 ocm skill pull ./my-catalogue//myorg.io/ai-skill-catalogue:1.0.0 \
@@ -140,14 +153,16 @@ ocm skill pull ./my-catalogue//myorg.io/ai-skill-catalogue:1.0.0 \
   --target codex
 ```
 
-To install for **both agents at once**, use `--target all`:
+The skill lands at `~/.agents/skills/ocm-guide/SKILL.md`.
+
+Install for **both agents at once**:
 
 ```bash
 ocm skill pull ./my-catalogue//myorg.io/ai-skill-catalogue:1.0.0 \
   --target all
 ```
 
-To pull every skill in the catalogue at once (defaults to `--target claude`), omit `--skill`:
+Pull every skill in the catalogue in one shot:
 
 ```bash
 ocm skill pull ./my-catalogue//myorg.io/ai-skill-catalogue:1.0.0
@@ -160,19 +175,9 @@ skill installed   skill=ocm-guide       output=~/.claude/skills/ocm-guide/SKILL.
 skill installed   skill=golang-patterns  output=~/.claude/skills/golang-patterns/SKILL.md
 ```
 
-### 5. Verify it's active
-
-List your installed skills:
-
-```bash
-ls ~/.claude/skills/
-```
-
-Or start a Claude Code session and ask: *"What skills do you have available?"* — it will list all installed skills including their descriptions.
-
 ## Using a Real OCI Registry
 
-Once you're ready to share with a team, swap the local archive path for a registry URL. OCM uses the same `//component:version` syntax:
+Swap the local archive path for any OCI registry URL when you are ready to share across machines or teams:
 
 ```bash
 # push to GHCR
@@ -184,22 +189,28 @@ ocm add component-version \
 ocm skill pull ghcr.io/myorg//myorg.io/ai-skill-catalogue:1.0.0
 ```
 
-Authentication follows standard OCI credential helpers — `docker login ghcr.io` is sufficient.
+Authentication uses standard OCI credential helpers — `docker login ghcr.io` is sufficient. For air-gapped environments, mirror the CTF archive to your internal registry with `ocm transfer` and point the pull command there.
 
 ## The Self-Referential Part
 
-The first skill we packaged in this catalogue is `ocm-guide` — a skill that teaches Claude how OCM works: the component descriptor format, resource types, CLI patterns, the plugin system. It's distributed via OCM, and it explains OCM.
+The first skill we packaged in this catalogue is `ocm-guide` — a skill that teaches agents how OCM works: the component descriptor format, resource types, CLI patterns, the plugin system. It is distributed via OCM, and it explains OCM.
 
-Once installed, ask Claude to help you write a component constructor, understand a resource access error, or navigate the plugin system — and it answers from the skill's context rather than general training data.
+Once installed, ask your agent to help write a component constructor, understand a resource access error, or navigate the plugin system — and it answers from the skill's context rather than general training data.
 
-## Why This Matters
+## Why This Approach Matters
 
-OCI registries are infrastructure you already have. GitHub Container Registry, AWS ECR, Google Artifact Registry — they all speak the OCI distribution spec that OCM builds on. A skill catalogue is just another OCI artifact living alongside your container images. You get:
+The skills distribution problem is not unique to one agent or one company. It is a structural gap in the agentic tooling ecosystem: useful configuration accumulates, but there is no standard way to version it, sign it, ship it, or consume it across teams and environments.
+
+OCM provides that standard. It was designed for exactly this pattern — versioned, signed, portable software artifacts distributed over OCI. The fact that it already works for container images and Helm charts means the infrastructure is already in place. A skill catalogue is just another OCI artifact.
+
+The properties you get are the same ones that matter for any supply chain artefact:
 
 - **Versioning** — `1.0.0`, `1.1.0`, semantic versioning, floating tags.
-- **Provenance** — OCM supports signing. You can verify a skill came from your team's registry, not a random source.
-- **Transport** — CTF lets you air-gap the catalogue, carry it on a USB drive, mirror it to an internal registry.
-- **Composability** — nothing stops you from putting a skill alongside the container image and Helm chart for the same service, all in one component version.
+- **Provenance** — signing lets you verify a skill came from your organisation.
+- **Portability** — CTF archives work completely offline.
+- **Vendor neutrality** — the same catalogue works for Claude Code today and whatever agent your team adopts next year.
+
+No lock-in. No proprietary store. Skills travel with your software.
 
 ## Full Command Reference
 

--- a/website/content/blog/2026-05-22-shipping-ai-skills-with-ocm.md
+++ b/website/content/blog/2026-05-22-shipping-ai-skills-with-ocm.md
@@ -1,4 +1,13 @@
-# Shipping AI Skills with the Open Component Model
+---
+title: "Shipping AI Skills with the Open Component Model"
+date: 2026-05-22T10:00:00+02:00
+draft: false
+description: "Use OCM to version, sign, and distribute Claude Code and Codex CLI skills from any OCI registry — the same way you ship container images."
+summary: "Package AI coding-assistant skills as OCM component resources and pull them into Claude Code or OpenAI Codex CLI with a single command."
+categories: ["ai", "cli"]
+tags: ["ai", "skills", "claude-code", "codex", "oci"]
+contributors: []
+---
 
 Imagine installing a Claude Code skill the same way you deploy a container image — versioned, signed, pulled from a registry. That's what we built, and this post walks through how.
 

--- a/website/content/blog/2026-05-22-shipping-ai-skills-with-ocm.md
+++ b/website/content/blog/2026-05-22-shipping-ai-skills-with-ocm.md
@@ -1,124 +1,83 @@
 ---
-title: "Shipping AI Agent Skills with the Open Component Model"
+title: "Shipping Coding Agent Skills with OCM"
 date: 2026-05-22T10:00:00+02:00
 draft: false
-description: "A vendor-neutral, airgap-capable approach to versioning, signing, and distributing AI agent skills using OCI registries — no lock-in, no proprietary store."
-summary: "AI coding agents need skills to work well with your stack. Today those skills live in dotfiles with no versioning, no provenance, and no shared distribution mechanism. OCM fixes that."
-categories: ["ai", "cli"]
-tags: ["ai", "skills", "agent", "oci", "supply-chain"]
+description: "A vendor-neutral, airgap-capable approach to versioning, signing, and distributing coding agent skills using OCI registries."
+summary: "Coding agents accumulate useful configuration fast, but there's no standard way to share it across machines, teams, or environments. This post walks through using OCM to package and distribute agent skills over any OCI registry."
+categories: ["cli"]
+tags: ["skills", "agent", "oci", "supply-chain"]
 contributors: []
 ---
 
-AI coding agents are proliferating fast. Claude Code, OpenAI Codex CLI, Gemini CLI, Cursor, Continue — each has its own way of learning how to work with your stack. They call the configuration different things: skills, rules, context files, prompts. But the underlying problem is the same everywhere.
+Most teams using coding agents — Claude Code, Codex CLI, Cursor, Continue, or anything else — end up with a folder of Markdown files that make the agent useful for their specific stack. How to handle errors in their Go codebase, how their database migrations are structured, what the deploy pipeline expects. These accumulate over time and become genuinely valuable.
 
-**Nobody has solved distribution.**
+Then someone joins the team and has none of them. Or you get a new laptop. Or you want the same context available in CI.
 
-## The Problem is Bigger Than One Agent
+At that point the options are: manually copy files, check them into a dotfiles repo with no versioning story, or describe them in a README. None of that scales well, and none of it gives you any way to verify where the files came from.
 
-Wherever you look, agent configuration lives in dotfiles:
+## Where things live today
+
+The paths differ by agent but the pattern is the same:
 
 - Claude Code: `~/.claude/skills/<name>/SKILL.md`
 - OpenAI Codex CLI: `~/.agents/skills/<name>/SKILL.md`
 - Cursor: `.cursorrules`
 - Continue: `.continue/`
 
-Sharing this configuration today means copying files by hand, committing them to a personal dotfiles repo, or describing them in a README and hoping a teammate bothers to recreate them. There is no versioning, no provenance, no way to express "install the `golang-patterns` skill at version 1.2.0 from my organisation's internal registry."
+Each of these is just a file on disk. The agents pick them up on startup. There's nothing wrong with the format — the problem is that file-on-disk is where the distribution story ends.
 
-Every team that builds up a useful library of agent configuration faces the same distribution gap. The files exist. The knowledge exists. But the moment you want to share it reliably across machines, teams, or air-gapped environments — the tooling runs out.
+## Using OCM as the transport layer
 
-## A Vendor-Neutral, Lock-In-Free Answer
+The [Open Component Model](https://ocm.software) treats software artifacts as versioned, signed bundles stored in OCI registries. It was built for container images and Helm charts, but the abstraction is general: a component version is a named bundle of resources, and a resource is any blob with a type label.
 
-The [Open Component Model](https://ocm.software) is an open standard for describing and distributing software artifacts. It is not tied to any cloud provider, any agent vendor, or any proprietary store. Its transport layer is the OCI distribution spec — the same protocol used by every container registry on the planet. GitHub Container Registry, AWS ECR, Google Artifact Registry, your on-premises Zot instance — they all work without modification.
-
-The core abstraction is simple: a *component version* is a named, versioned bundle of *resources*. Resources can be anything — container images, Helm charts, binaries, plain text files. The component descriptor records what is in the bundle, how to retrieve it, and who produced it.
-
-That abstraction fits agent skills exactly. A skill is a text file with a name and a version. An OCI registry is a fine place to store a catalogue of them, and OCM adds the layer that makes it safe:
-
-- **Signing** — component versions can be signed with cosign or GPG. You can verify a skill came from your organisation, not an arbitrary source.
-- **Air-gap transport** — OCM's CTF (Common Transport Format) is a portable local archive. You can carry a skill catalogue on a USB drive, mirror it to an internal registry, or ship it as part of a software delivery pipeline with no internet access required.
-- **Composability** — nothing stops you from placing a skill alongside the container image and Helm chart for the same service, all in one component version. Your deployment unit and your agent configuration travel together.
-
-No proprietary store. No agent-specific distribution format. No cloud dependency. Just OCI.
-
-## One Component, Many Skills
-
-The key design decision: **one OCM component = one catalogue release**. Each skill is a *resource* inside that component, identified by name and the type label `ai.skill/v1`:
+That fits skills well. A skill gets packaged as a resource with type `ai.skill/v1` inside a catalogue component:
 
 ```text
-Component: myorg.io/ai-skill-catalogue   version: 1.0.0
-├── resource: ocm-guide        type: ai.skill/v1   (SKILL.md)
-├── resource: golang-patterns   type: ai.skill/v1   (SKILL.md)
-└── resource: backend-patterns  type: ai.skill/v1   (SKILL.md)
+Component: myorg.io/skill-catalogue   version: 1.0.0
+├── resource: ocm-guide        type: ai.skill/v1
+├── resource: golang-patterns   type: ai.skill/v1
+└── resource: backend-patterns  type: ai.skill/v1
 ```
 
-`ai.skill/v1` is just a string label — OCM stores unknown resource types as blobs. No plugins, no registry-side changes, no coordination with any vendor required.
+`ai.skill/v1` is just a string — OCM stores it as a blob without needing any registry-side support. The registry you already use for container images works as-is.
 
-## What a Skill Looks Like
+What OCM adds on top:
 
-A skill is a Markdown file with a YAML frontmatter header. The agent reads `name` and `description` to decide when to apply it:
+- **Signing**: component versions can be signed with cosign or GPG, so you can verify a skill catalogue came from your organisation and not some random source.
+- **Air-gap support**: OCM's CTF (Common Transport Format) is a portable local archive. You can ship a catalogue on a USB drive, mirror it to an internal registry, or include it in an offline software delivery bundle.
+- **Composability**: nothing stops you from putting skills in the same component version as the container image and Helm chart for a service. The agent context travels with the software it supports.
+
+## What a skill file looks like
+
+A skill is a Markdown file with a YAML frontmatter block. The agent reads `name` and `description` to decide when to activate it:
 
 ```markdown
 ---
 name: golang-patterns
-description: Idiomatic Go patterns and best practices. Use when writing or reviewing Go code.
+description: Idiomatic Go patterns for this codebase. Use when writing or reviewing Go.
 tools: ["Read", "Bash"]
 ---
 
 # Go Patterns
 
 ## Error handling
-Always wrap errors with context...
+Wrap errors at the call site with context...
 ```
 
-The format is readable by humans, writable by hand, and parseable by any agent that follows the convention. OCM does not care about the content — it stores and retrieves whatever bytes you put in.
+OCM doesn't care about the content — it just stores and retrieves bytes.
 
-## Hands-On: Package and Install Skills
+## Packaging skills
 
-### 1. Organise your skills directory
-
-```text
-my-skills/
-├── ocm-guide/
-│   └── SKILL.md
-└── golang-patterns/
-    └── SKILL.md
-```
-
-### 2. Generate the component constructor
+Point `ocm skill push` at a directory of skill subdirectories:
 
 ```bash
 ocm skill push ./my-skills \
-  --component myorg.io/ai-skill-catalogue \
+  --component myorg.io/skill-catalogue \
   --version 1.0.0 \
   --output constructor.yaml
 ```
 
-This scans `./my-skills` for `SKILL.md` files and writes a `constructor.yaml` that describes the component:
-
-```yaml
-components:
-  - name: myorg.io/ai-skill-catalogue
-    version: 1.0.0
-    provider:
-      name: myorg.io
-    resources:
-      - name: ocm-guide
-        type: ai.skill/v1
-        version: 1.0.0
-        input:
-          type: file
-          path: /absolute/path/to/my-skills/ocm-guide/SKILL.md
-      - name: golang-patterns
-        type: ai.skill/v1
-        version: 1.0.0
-        input:
-          type: file
-          path: /absolute/path/to/my-skills/golang-patterns/SKILL.md
-```
-
-### 3. Package into a local archive
-
-OCM's CTF archive requires no registry to get started:
+This writes a `constructor.yaml` with each `SKILL.md` as a file input. Then package it:
 
 ```bash
 ocm add component-version \
@@ -126,93 +85,52 @@ ocm add component-version \
   --constructor constructor.yaml
 ```
 
-Output:
+That produces a local CTF archive. No registry needed to get started.
 
-```text
- COMPONENT                    │ VERSION │ PROVIDER
-─────────────────────────────┼─────────┼──────────
- myorg.io/ai-skill-catalogue  │ 1.0.0   │ myorg.io
-```
+## Installing skills
 
-### 4. Install skills
-
-Pull a single skill for **Claude Code** (default):
+Pull a specific skill into Claude Code:
 
 ```bash
-ocm skill pull ./my-catalogue//myorg.io/ai-skill-catalogue:1.0.0 \
-  --skill ocm-guide
+ocm skill pull ./my-catalogue//myorg.io/skill-catalogue:1.0.0 --skill golang-patterns
 ```
 
-The skill lands at `~/.claude/skills/ocm-guide/SKILL.md`.
-
-Install for **OpenAI Codex CLI** instead:
+Or install into Codex CLI instead:
 
 ```bash
-ocm skill pull ./my-catalogue//myorg.io/ai-skill-catalogue:1.0.0 \
-  --skill ocm-guide \
-  --target codex
+ocm skill pull ./my-catalogue//myorg.io/skill-catalogue:1.0.0 \
+  --skill golang-patterns --target codex
 ```
 
-The skill lands at `~/.agents/skills/ocm-guide/SKILL.md`.
-
-Install for **both agents at once**:
+Or both at once:
 
 ```bash
-ocm skill pull ./my-catalogue//myorg.io/ai-skill-catalogue:1.0.0 \
-  --target all
+ocm skill pull ./my-catalogue//myorg.io/skill-catalogue:1.0.0 --target all
 ```
 
-Pull every skill in the catalogue in one shot:
+Omit `--skill` to pull everything in the catalogue.
+
+## Sharing with a team
+
+Swap the local archive for a registry URL:
 
 ```bash
-ocm skill pull ./my-catalogue//myorg.io/ai-skill-catalogue:1.0.0
-```
-
-Output:
-
-```text
-skill installed   skill=ocm-guide       output=~/.claude/skills/ocm-guide/SKILL.md
-skill installed   skill=golang-patterns  output=~/.claude/skills/golang-patterns/SKILL.md
-```
-
-## Using a Real OCI Registry
-
-Swap the local archive path for any OCI registry URL when you are ready to share across machines or teams:
-
-```bash
-# push to GHCR
 ocm add component-version \
   --repository ghcr.io/myorg \
   --constructor constructor.yaml
 
-# anyone on the team installs
-ocm skill pull ghcr.io/myorg//myorg.io/ai-skill-catalogue:1.0.0
+ocm skill pull ghcr.io/myorg//myorg.io/skill-catalogue:1.0.0
 ```
 
-Authentication uses standard OCI credential helpers — `docker login ghcr.io` is sufficient. For air-gapped environments, mirror the CTF archive to your internal registry with `ocm transfer` and point the pull command there.
+Standard OCI credential helpers handle authentication — `docker login ghcr.io` is enough. For air-gapped environments, `ocm transfer` mirrors the CTF archive to an internal registry.
 
-## The Self-Referential Part
+## Why this matters beyond the tooling
 
-The first skill we packaged in this catalogue is `ocm-guide` — a skill that teaches agents how OCM works: the component descriptor format, resource types, CLI patterns, the plugin system. It is distributed via OCM, and it explains OCM.
+Most teams treating agent configuration as informal dotfiles will eventually want to version it properly, audit where it comes from, or ship it into environments without internet access. OCM already solves all three for container images and Helm charts. Plugging agent skills into the same mechanism means you get those properties without building anything new.
 
-Once installed, ask your agent to help write a component constructor, understand a resource access error, or navigate the plugin system — and it answers from the skill's context rather than general training data.
+The `--target` flag keeps things portable across agents. The same catalogue works for whatever tools your team is using today and whatever replaces them later.
 
-## Why This Approach Matters
-
-The skills distribution problem is not unique to one agent or one company. It is a structural gap in the agentic tooling ecosystem: useful configuration accumulates, but there is no standard way to version it, sign it, ship it, or consume it across teams and environments.
-
-OCM provides that standard. It was designed for exactly this pattern — versioned, signed, portable software artifacts distributed over OCI. The fact that it already works for container images and Helm charts means the infrastructure is already in place. A skill catalogue is just another OCI artifact.
-
-The properties you get are the same ones that matter for any supply chain artefact:
-
-- **Versioning** — `1.0.0`, `1.1.0`, semantic versioning, floating tags.
-- **Provenance** — signing lets you verify a skill came from your organisation.
-- **Portability** — CTF archives work completely offline.
-- **Vendor neutrality** — the same catalogue works for Claude Code today and whatever agent your team adopts next year.
-
-No lock-in. No proprietary store. Skills travel with your software.
-
-## Full Command Reference
+## Full command reference
 
 ```bash
 # Generate constructor from a skills directory


### PR DESCRIPTION
## Summary

- Adds `ocm skill push <dir>` — scans a skills directory for `SKILL.md` files, emits a component constructor YAML (`ai.skill/v1` resources) ready for `ocm add component-version`
- Adds `ocm skill pull <ref>` — resolves an OCM component version, filters `ai.skill/v1` resources, writes each skill to `~/.claude/skills/<name>/SKILL.md`
- Path traversal protection (`validateSkillName`, prefix check, symlink rejection)
- Idempotent installs (`O_TRUNC` instead of `O_APPEND`)

## Motivation

Claude Code skills are Markdown files that teach the AI how to work with a codebase. This PR enables teams to package, version, sign, and distribute skills via OCI registries exactly like container images — one OCM component = one skill catalogue release.

## Files changed

| Path | Description |
|------|-------------|
| `cli/cmd/cmd.go` | Registers `skill` subcommand |
| `cli/cmd/skill/cmd.go` | Root `skill` command |
| `cli/cmd/skill/pull/cmd.go` | Pull implementation |
| `cli/cmd/skill/push/cmd.go` | Push implementation |
| `cli/cmd/skill/pull/cmd_test.go` | 8 unit tests |
| `cli/cmd/skill/push/cmd_test.go` | 9 unit tests (incl. round-trip) |
| `cli/integration/skill_integration_test.go` | 3 integration tests over real OCI registry |
| `docs/blog/shipping-ai-skills-with-ocm.md` | Tutorial blog post |

## Test plan

- [ ] `go test ./cli/cmd/skill/...` — all 17 unit tests pass
- [ ] Integration tests in `cli/integration/skill_integration_test.go` pass (requires Docker for OCI registry)
- [ ] `TestPushRoundTrip` validates full CTF round-trip (push → add cv → pull)
- [ ] Path traversal test `TestPullRejectsPathTraversalInResourceName` rejects `../evil` resource names
- [ ] Repeated pulls produce identical file content (idempotency)