### PR TITLE
fix: add stubs for removed release flows so they show up on the release branch

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -1,0 +1,17 @@
+name: CLI Release
+
+run-name: CLI Release from ${{ github.ref_name }}
+
+on:
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  print:
+    name: Stub print
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print something stubby
+        run: |
+          echo "Hello from stubby the stubbed cli release GitHub action."

--- a/.github/workflows/controller-release.yml
+++ b/.github/workflows/controller-release.yml
@@ -1,0 +1,16 @@
+name: Controller Release
+run-name: Controller Release from ${{ github.ref_name }}
+
+on:
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  print:
+    name: Stub print
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print something stubby
+        run: |
+          echo "Hello from stubby the stubbed controller release GitHub action."


### PR DESCRIPTION
On-behalf-of: Gergely Brautigam <gergely.brautigam@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

The release refactor removed the workflow for the "old" release processes. This means that we cannot release the current RCs which are releases/v0.7.0.rc2. These stubs make GitHub display the release flows in the UI again, and now, selecting the correct branch when trying to exectue the release for these rcs, the right branch will be used as source for the old release process.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Testing

##### How to test the changes

<!--
Required files to test the changes:

.ocmconfig
```yaml
type: generic.config.ocm.software/v1
configurations:
  - type: credentials.config.ocm.software
    repositories:
      - repository:
          type: DockerConfig/v1
          dockerConfigFile: "~/.docker/config.json"
```

Commands that test the change:

```bash
ocm get cv xxx

ocm transfer xxx
```
-->

##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
