### PR TITLE
chore(fix): fix the ocm install script to work with the new canonical version

### DIFF
--- a/website/static/install-cli.sh
+++ b/website/static/install-cli.sh
@@ -156,9 +156,33 @@ get_release_version() {
 
     if [[ -n "${OCM_VERSION}" ]]; then
         info "Using ${OCM_VERSION} as release"
+        # Disclaimer: This logic is added so it works with the new _single_ canonical release.
+        # This means that the `cli` prefix for the CLI release dropped in the new release version.
+        # Therefore, for any version install that is 8 or above we strip the TAG_PREFIX='cli' from
+        # the constructed download URL.
+        if ! version_below "${OCM_VERSION}" 8; then
+          TAG_PREFIX=''
+        fi
     else
         fatal "Unable to determine release version"
     fi
+}
+
+# Returns 0 (true) if a "v0.x" version has x strictly below THRESHOLD.
+# Accepts: cli/v0.5, v0.5.0, v0.5.0-rc.1, cli/v0.12.3 ...
+version_below() {
+    local version="$1" threshold="$2"
+
+    [[ "$version" == *0.* ]] || fatal "Not a v0.x version: ${version}"
+
+    # Strip everything up to and including the last "v0." -> "5.0-rc.1"
+    local rest="${version##*0.}"
+
+    # Grab only the leading digits -> "5"
+    [[ "$rest" =~ ^([0-9]+) ]] || fatal "Cannot parse minor from: ${version}"
+    local minor="${BASH_REMATCH[1]}"
+
+    (( minor < threshold ))
 }
 
 # Download file from URL


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

The install script needs to work with the new canonical single release version and be backwards compatible with the old release versions as well.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Testing

##### How to test the changes

<!--
Required files to test the changes:

.ocmconfig
```yaml
type: generic.config.ocm.software/v1
configurations:
  - type: credentials.config.ocm.software
    repositories:
      - repository:
          type: DockerConfig/v1
          dockerConfigFile: "~/.docker/config.json"
```

Commands that test the change:

```bash
ocm get cv xxx

ocm transfer xxx
```
-->

##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
