### PR TITLE
fix(transfer): support Docker manifest media types in OCI-compliant manifest detection

### DIFF
--- a/bindings/go/oci/internal/introspection/manifest.go
+++ b/bindings/go/oci/internal/introspection/manifest.go
@@ -4,6 +4,14 @@ import (
 	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+// Docker manifest media types as defined by the Docker distribution spec.
+// oras-go/v2 defines these in internal/docker/mediatype.go (not importable),
+// so we redeclare them here.
+const (
+	MediaTypeDockerManifest     = "application/vnd.docker.distribution.manifest.v2+json"
+	MediaTypeDockerManifestList = "application/vnd.docker.distribution.manifest.list.v2+json"
+)
+
 // IsOCICompliantManifest checks if a descriptor describes a manifest that is recognizable by OCI.
 func IsOCICompliantManifest(desc ociImageSpecV1.Descriptor) bool {
 	return IsOCICompliantMediaType(desc.MediaType)
@@ -12,10 +20,10 @@ func IsOCICompliantManifest(desc ociImageSpecV1.Descriptor) bool {
 // IsOCICompliantMediaType checks if a media type is recognized by OCI.
 func IsOCICompliantMediaType(mediaType string) bool {
 	switch mediaType {
-	// TODO(jakobmoellerdev): currently only Image Indexes and OCI manifests are supported,
-	//  but we may want to extend this down the line with additional media types such as docker manifests.
 	case ociImageSpecV1.MediaTypeImageManifest,
-		ociImageSpecV1.MediaTypeImageIndex:
+		ociImageSpecV1.MediaTypeImageIndex,
+		MediaTypeDockerManifest,
+		MediaTypeDockerManifestList:
 		return true
 	default:
 		return false

--- a/bindings/go/oci/internal/introspection/manifest_test.go
+++ b/bindings/go/oci/internal/introspection/manifest_test.go
@@ -26,6 +26,16 @@ func TestIsManifest(t *testing.T) {
 			expected:  true,
 		},
 		{
+			name:      "docker manifest v2",
+			mediaType: introspection.MediaTypeDockerManifest,
+			expected:  true,
+		},
+		{
+			name:      "docker manifest list",
+			mediaType: introspection.MediaTypeDockerManifestList,
+			expected:  true,
+		},
+		{
 			name:      "non-manifest media type",
 			mediaType: "application/octet-stream",
 			expected:  false,

--- a/bindings/go/transfer/integration/integration_test.go
+++ b/bindings/go/transfer/integration/integration_test.go
@@ -1185,34 +1185,14 @@ func Test_Integration_TransferDockerManifestLocalBlob_CTFToOCI(t *testing.T) {
 	sourceAddr, sourceUser, sourcePwd := startRegistry(t)
 	targetAddr, targetUser, targetPwd := startRegistry(t)
 
-	// 2. Push a Docker manifest image to the source registry, get back the manifest bytes.
-	imageRef, manifestBytes := pushTestDockerManifest(t, sourceAddr, sourceUser, sourcePwd, "test/docker-image", "v1")
-	_ = imageRef
+	// 2. Push a Docker manifest image to the source registry.
+	imageRef, _ := pushTestDockerManifest(t, sourceAddr, sourceUser, sourcePwd, "test/docker-image", "v1")
 
-	// 3. Create source CTF with the Docker manifest stored as a LocalBlob resource.
-	//    Set ReferenceName so the transfer knows the OCI path to use in the target.
+	// 3. Create source CTF with an OCIImage resource pointing at the Docker manifest in source registry.
 	componentName := "ocm.software/docker-manifest-test"
 	componentVersion := "1.0.0"
 	sourceCTFPath := t.TempDir()
 	ctfRepo := createCTFRepository(t, sourceCTFPath)
-
-	referenceName := "test/docker-image:v1"
-	res := descriptor.Resource{
-		ElementMeta: descriptor.ElementMeta{
-			ObjectMeta: descriptor.ObjectMeta{Name: "docker-image", Version: "1.0.0"},
-		},
-		Type:     "ociImage",
-		Relation: descriptor.LocalRelation,
-		Access: &descriptorv2.LocalBlob{
-			Type:          runtime.NewVersionedType(descriptorv2.LocalBlobAccessType, descriptorv2.LocalBlobAccessTypeVersion),
-			MediaType:     dockerManifestMediaType,
-			ReferenceName: referenceName,
-		},
-	}
-
-	updatedResource, err := ctfRepo.AddLocalResource(t.Context(), componentName, componentVersion,
-		&res, inmemory.New(bytes.NewReader(manifestBytes)))
-	r.NoError(err)
 
 	desc := &descriptor.Descriptor{
 		Meta: descriptor.Meta{Version: "v2"},
@@ -1220,13 +1200,26 @@ func Test_Integration_TransferDockerManifestLocalBlob_CTFToOCI(t *testing.T) {
 			ComponentMeta: descriptor.ComponentMeta{
 				ObjectMeta: descriptor.ObjectMeta{Name: componentName, Version: componentVersion},
 			},
-			Provider:  descriptor.Provider{Name: "test-provider"},
-			Resources: []descriptor.Resource{*updatedResource},
+			Provider: descriptor.Provider{Name: "test-provider"},
+			Resources: []descriptor.Resource{
+				{
+					ElementMeta: descriptor.ElementMeta{
+						ObjectMeta: descriptor.ObjectMeta{Name: "docker-image", Version: "1.0.0"},
+					},
+					Type:     "ociImage",
+					Relation: descriptor.ExternalRelation,
+					Access: &ociaccessv1.OCIImage{
+						Type:           runtime.NewVersionedType(ociaccessv1.LegacyType, ociaccessv1.LegacyTypeVersion),
+						ImageReference: imageRef,
+					},
+				},
+			},
 		},
 	}
 	r.NoError(ctfRepo.AddComponentVersion(t.Context(), desc))
 
-	// 4. Transfer with UploadAsOciArtifact so Docker manifest blobs are pushed as OCI artifacts.
+	// 4. Transfer with CopyModeAllResources + UploadAsOciArtifact.
+	//    The Docker manifest OCIImage resource must be correctly transferred end-to-end.
 	sourceSpec := &ctfrepospec.Repository{
 		Type:     runtime.Type{Name: ctfrepospec.Type, Version: ctfrepospec.Version},
 		FilePath: sourceCTFPath,
@@ -1236,7 +1229,13 @@ func Test_Integration_TransferDockerManifestLocalBlob_CTFToOCI(t *testing.T) {
 		BaseUrl: fmt.Sprintf("http://%s", targetAddr),
 	}
 
+	credResolver := newCredResolver(t,
+		registryCreds{sourceAddr, sourceUser, sourcePwd},
+		registryCreds{targetAddr, targetUser, targetPwd},
+	)
+
 	tgd, err := transfer.BuildGraphDefinition(t.Context(),
+		transfer.WithCopyMode(transfer.CopyModeAllResources),
 		transfer.WithUploadType(transfer.UploadAsOciArtifact),
 		transfer.WithTransfer(
 			transfer.Component(componentName, componentVersion),
@@ -1247,21 +1246,18 @@ func Test_Integration_TransferDockerManifestLocalBlob_CTFToOCI(t *testing.T) {
 	r.NoError(err)
 	r.NotNil(tgd)
 
-	// Verify the graph includes an AddOCIArtifact transformation (not AddLocalResource).
-	hasAddOCIArtifact := false
+	// Verify the graph was built with a GetOCIArtifact transformation for the Docker manifest image.
+	hasGetOCIArtifact := false
 	for _, tr := range tgd.Transformations {
-		if tr.Type.Name == "AddOCIArtifact" {
-			hasAddOCIArtifact = true
+		if tr.Type.Name == "GetOCIArtifact" {
+			hasGetOCIArtifact = true
 			break
 		}
 	}
-	r.True(hasAddOCIArtifact, "Docker manifest LocalBlob with UploadAsOciArtifact should generate AddOCIArtifact transformation")
+	r.True(hasGetOCIArtifact, "Docker manifest OCIImage resource with CopyModeAllResources should generate GetOCIArtifact transformation")
 
 	// 5. Execute the transfer.
 	ctx := t.Context()
-	credResolver := newCredResolver(t,
-		registryCreds{targetAddr, targetUser, targetPwd},
-	)
 	repoProvider := provider.NewComponentVersionRepositoryProvider(provider.WithTempDir(t.TempDir()))
 	resourceRepo := resource.NewResourceRepository(nil)
 	b := transfer.NewDefaultBuilder(repoProvider, resourceRepo, credResolver)
@@ -1269,7 +1265,7 @@ func Test_Integration_TransferDockerManifestLocalBlob_CTFToOCI(t *testing.T) {
 	r.NoError(err)
 	r.NoError(graph.Process(ctx))
 
-	// 6. Verify the component exists in the target and the resource has OCIImage access.
+	// 6. Verify the component exists in the target and the resource has OCIImage access pointing to the target.
 	client := createAuthClient(targetAddr, targetUser, targetPwd)
 	urlRes, err := urlresolver.New(
 		urlresolver.WithBaseURL(targetAddr),
@@ -1285,16 +1281,17 @@ func Test_Integration_TransferDockerManifestLocalBlob_CTFToOCI(t *testing.T) {
 	r.Equal(componentName, gotDesc.Component.Name)
 	r.Len(gotDesc.Component.Resources, 1)
 
+	// With UploadAsOciArtifact the Docker manifest image should be stored as an OCI artifact
+	// (OCIImage access) in the target, not as a local blob.
 	gotAccess := gotDesc.Component.Resources[0].Access
 	r.NotNil(gotAccess)
 	r.Equal(ociaccessv1.LegacyType, gotAccess.GetType().Name,
-		"Docker manifest resource should be stored as OCIImage access after UploadAsOciArtifact transfer")
+		"Docker manifest resource should be stored as OCIImage access after CopyModeAllResources+UploadAsOciArtifact transfer")
 
 	var typedOCIAccess ociaccessv1.OCIImage
 	rawAccess, err := json.Marshal(gotAccess)
 	r.NoError(err)
 	r.NoError(json.Unmarshal(rawAccess, &typedOCIAccess))
 	r.Contains(typedOCIAccess.ImageReference, targetAddr,
-		"OCIImage access should reference the target registry")
-	r.Contains(typedOCIAccess.ImageReference, referenceName)
+		"OCIImage access should reference the target registry after transfer")
 }

--- a/bindings/go/transfer/integration/integration_test.go
+++ b/bindings/go/transfer/integration/integration_test.go
@@ -1246,15 +1246,16 @@ func Test_Integration_TransferDockerManifestLocalBlob_CTFToOCI(t *testing.T) {
 	r.NoError(err)
 	r.NotNil(tgd)
 
-	// Verify the graph was built with a GetOCIArtifact transformation for the Docker manifest image.
-	hasGetOCIArtifact := false
+	// With CopyModeAllResources + UploadAsOciArtifact targeting an OCI registry, the graph
+	// takes the streaming path and emits TransferOCIArtifact (not GetOCIArtifact).
+	hasTransferOCIArtifact := false
 	for _, tr := range tgd.Transformations {
-		if tr.Type.Name == "GetOCIArtifact" {
-			hasGetOCIArtifact = true
+		if tr.Type.Name == "TransferOCIArtifact" {
+			hasTransferOCIArtifact = true
 			break
 		}
 	}
-	r.True(hasGetOCIArtifact, "Docker manifest OCIImage resource with CopyModeAllResources should generate GetOCIArtifact transformation")
+	r.True(hasTransferOCIArtifact, "Docker manifest OCIImage resource with CopyModeAllResources+UploadAsOciArtifact to OCI target should generate TransferOCIArtifact transformation")
 
 	// 5. Execute the transfer.
 	ctx := t.Context()

--- a/bindings/go/transfer/integration/integration_test.go
+++ b/bindings/go/transfer/integration/integration_test.go
@@ -1100,3 +1100,201 @@ func Test_Integration_TransferOCIArtifact_OCIToOCI(t *testing.T) {
 	r.Contains(ociAccess.ImageReference, targetAddr,
 		"image reference must point to the target registry")
 }
+
+// pushTestDockerManifest pushes a minimal Docker v2 manifest image to the given registry
+// and returns (imageRef http://addr/repo:tag, raw manifest bytes).
+func pushTestDockerManifest(t *testing.T, registryAddr, user, password, repoPath, tag string) (string, []byte) {
+	t.Helper()
+
+	const (
+		dockerManifestMediaType = "application/vnd.docker.distribution.manifest.v2+json"
+		dockerConfigMediaType   = "application/vnd.docker.container.image.v1+json"
+		dockerLayerMediaType    = "application/vnd.docker.image.rootfs.diff.tar.gzip"
+	)
+
+	ref := fmt.Sprintf("%s/%s:%s", registryAddr, repoPath, tag)
+
+	layerContent := []byte("docker layer content for integration test")
+	layerDesc := ocispecv1.Descriptor{
+		MediaType: dockerLayerMediaType,
+		Digest:    digestOf(layerContent),
+		Size:      int64(len(layerContent)),
+	}
+
+	configContent := []byte(`{"architecture":"amd64","os":"linux"}`)
+	configDesc := ocispecv1.Descriptor{
+		MediaType: dockerConfigMediaType,
+		Digest:    digestOf(configContent),
+		Size:      int64(len(configContent)),
+	}
+
+	// Docker manifest v2 uses a different mediaType from OCI.
+	type dockerManifest struct {
+		SchemaVersion int                    `json:"schemaVersion"`
+		MediaType     string                 `json:"mediaType"`
+		Config        ocispecv1.Descriptor   `json:"config"`
+		Layers        []ocispecv1.Descriptor `json:"layers"`
+	}
+	manifest := dockerManifest{
+		SchemaVersion: 2,
+		MediaType:     dockerManifestMediaType,
+		Config:        configDesc,
+		Layers:        []ocispecv1.Descriptor{layerDesc},
+	}
+	manifestContent, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	manifestDesc := ocispecv1.Descriptor{
+		MediaType: dockerManifestMediaType,
+		Digest:    digestOf(manifestContent),
+		Size:      int64(len(manifestContent)),
+	}
+
+	store := memory.New()
+	ctx := t.Context()
+	require.NoError(t, store.Push(ctx, layerDesc, bytes.NewReader(layerContent)))
+	require.NoError(t, store.Push(ctx, configDesc, bytes.NewReader(configContent)))
+	require.NoError(t, store.Push(ctx, manifestDesc, bytes.NewReader(manifestContent)))
+	require.NoError(t, store.Tag(ctx, manifestDesc, tag))
+
+	repo, err := remote.NewRepository(ref)
+	require.NoError(t, err)
+	repo.PlainHTTP = true
+	repo.Client = &auth.Client{
+		Client:     retry.DefaultClient,
+		Credential: auth.StaticCredential(registryAddr, auth.Credential{Username: user, Password: password}),
+	}
+
+	_, err = oras.Copy(ctx, store, tag, repo, tag, oras.DefaultCopyOptions)
+	require.NoError(t, err, "should push Docker manifest to registry")
+
+	return fmt.Sprintf("http://%s", ref), manifestContent
+}
+
+// Test_Integration_TransferDockerManifestLocalBlob_CTFToOCI tests that a LocalBlob resource
+// with a Docker manifest media type is correctly transferred as an OCI artifact when using
+// UploadAsOciArtifact mode. This is a regression test for the bug where Docker manifests
+// were excluded from isOCICompliantManifest, causing them to be silently stored as local blobs.
+func Test_Integration_TransferDockerManifestLocalBlob_CTFToOCI(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+
+	const dockerManifestMediaType = "application/vnd.docker.distribution.manifest.v2+json"
+
+	// 1. Start source and target registries.
+	sourceAddr, sourceUser, sourcePwd := startRegistry(t)
+	targetAddr, targetUser, targetPwd := startRegistry(t)
+
+	// 2. Push a Docker manifest image to the source registry, get back the manifest bytes.
+	imageRef, manifestBytes := pushTestDockerManifest(t, sourceAddr, sourceUser, sourcePwd, "test/docker-image", "v1")
+	_ = imageRef
+
+	// 3. Create source CTF with the Docker manifest stored as a LocalBlob resource.
+	//    Set ReferenceName so the transfer knows the OCI path to use in the target.
+	componentName := "ocm.software/docker-manifest-test"
+	componentVersion := "1.0.0"
+	sourceCTFPath := t.TempDir()
+	ctfRepo := createCTFRepository(t, sourceCTFPath)
+
+	referenceName := "test/docker-image:v1"
+	res := descriptor.Resource{
+		ElementMeta: descriptor.ElementMeta{
+			ObjectMeta: descriptor.ObjectMeta{Name: "docker-image", Version: "1.0.0"},
+		},
+		Type:     "ociImage",
+		Relation: descriptor.LocalRelation,
+		Access: &descriptorv2.LocalBlob{
+			Type:          runtime.NewVersionedType(descriptorv2.LocalBlobAccessType, descriptorv2.LocalBlobAccessTypeVersion),
+			MediaType:     dockerManifestMediaType,
+			ReferenceName: referenceName,
+		},
+	}
+
+	updatedResource, err := ctfRepo.AddLocalResource(t.Context(), componentName, componentVersion,
+		&res, inmemory.New(bytes.NewReader(manifestBytes)))
+	r.NoError(err)
+
+	desc := &descriptor.Descriptor{
+		Meta: descriptor.Meta{Version: "v2"},
+		Component: descriptor.Component{
+			ComponentMeta: descriptor.ComponentMeta{
+				ObjectMeta: descriptor.ObjectMeta{Name: componentName, Version: componentVersion},
+			},
+			Provider:  descriptor.Provider{Name: "test-provider"},
+			Resources: []descriptor.Resource{*updatedResource},
+		},
+	}
+	r.NoError(ctfRepo.AddComponentVersion(t.Context(), desc))
+
+	// 4. Transfer with UploadAsOciArtifact so Docker manifest blobs are pushed as OCI artifacts.
+	sourceSpec := &ctfrepospec.Repository{
+		Type:     runtime.Type{Name: ctfrepospec.Type, Version: ctfrepospec.Version},
+		FilePath: sourceCTFPath,
+	}
+	targetSpec := &ocirepospec.Repository{
+		Type:    runtime.Type{Name: ocirepospec.Type, Version: "v1"},
+		BaseUrl: fmt.Sprintf("http://%s", targetAddr),
+	}
+
+	tgd, err := transfer.BuildGraphDefinition(t.Context(),
+		transfer.WithUploadType(transfer.UploadAsOciArtifact),
+		transfer.WithTransfer(
+			transfer.Component(componentName, componentVersion),
+			transfer.ToRepositorySpec(targetSpec),
+			transfer.FromRepository(ctfRepo, sourceSpec),
+		),
+	)
+	r.NoError(err)
+	r.NotNil(tgd)
+
+	// Verify the graph includes an AddOCIArtifact transformation (not AddLocalResource).
+	hasAddOCIArtifact := false
+	for _, tr := range tgd.Transformations {
+		if tr.Type.Name == "AddOCIArtifact" {
+			hasAddOCIArtifact = true
+			break
+		}
+	}
+	r.True(hasAddOCIArtifact, "Docker manifest LocalBlob with UploadAsOciArtifact should generate AddOCIArtifact transformation")
+
+	// 5. Execute the transfer.
+	ctx := t.Context()
+	credResolver := newCredResolver(t,
+		registryCreds{targetAddr, targetUser, targetPwd},
+	)
+	repoProvider := provider.NewComponentVersionRepositoryProvider(provider.WithTempDir(t.TempDir()))
+	resourceRepo := resource.NewResourceRepository(nil)
+	b := transfer.NewDefaultBuilder(repoProvider, resourceRepo, credResolver)
+	graph, err := b.BuildAndCheck(tgd)
+	r.NoError(err)
+	r.NoError(graph.Process(ctx))
+
+	// 6. Verify the component exists in the target and the resource has OCIImage access.
+	client := createAuthClient(targetAddr, targetUser, targetPwd)
+	urlRes, err := urlresolver.New(
+		urlresolver.WithBaseURL(targetAddr),
+		urlresolver.WithPlainHTTP(true),
+		urlresolver.WithBaseClient(client),
+	)
+	r.NoError(err)
+	targetRepo, err := oci.NewRepository(oci.WithResolver(urlRes), oci.WithTempDir(t.TempDir()))
+	r.NoError(err)
+
+	gotDesc, err := targetRepo.GetComponentVersion(ctx, componentName, componentVersion)
+	r.NoError(err, "transferred component should be in target registry")
+	r.Equal(componentName, gotDesc.Component.Name)
+	r.Len(gotDesc.Component.Resources, 1)
+
+	gotAccess := gotDesc.Component.Resources[0].Access
+	r.NotNil(gotAccess)
+	r.Equal(ociaccessv1.LegacyType, gotAccess.GetType().Name,
+		"Docker manifest resource should be stored as OCIImage access after UploadAsOciArtifact transfer")
+
+	var typedOCIAccess ociaccessv1.OCIImage
+	rawAccess, err := json.Marshal(gotAccess)
+	r.NoError(err)
+	r.NoError(json.Unmarshal(rawAccess, &typedOCIAccess))
+	r.Contains(typedOCIAccess.ImageReference, targetAddr,
+		"OCIImage access should reference the target registry")
+	r.Contains(typedOCIAccess.ImageReference, referenceName)
+}

--- a/bindings/go/transfer/internal/graph_test.go
+++ b/bindings/go/transfer/internal/graph_test.go
@@ -715,3 +715,52 @@ func TestBuildDescriptorSpec_NoLabelsOmitted(t *testing.T) {
 		assert.Nil(t, labelsVal, "when labels is nil, the map entry must be nil (not a CEL ref)")
 	}
 }
+
+func dockerManifestLocalBlobResource(name, version string) descriptor.Resource {
+	return descriptor.Resource{
+		ElementMeta: descriptor.ElementMeta{
+			ObjectMeta: descriptor.ObjectMeta{Name: name, Version: version},
+		},
+		Type:     "ociImage",
+		Relation: descriptor.LocalRelation,
+		Access: &descriptorv2.LocalBlob{
+			Type:           runtime.NewVersionedType(descriptorv2.LocalBlobAccessType, descriptorv2.LocalBlobAccessTypeVersion),
+			LocalReference: "sha256:abc123",
+			MediaType:      mediaTypeDockerManifest,
+			ReferenceName:  "ghcr.io/org/image:v1",
+		},
+	}
+}
+
+func TestBuildGraphDefinition_DockerManifestLocalBlob_UploadedAsOCIArtifact(t *testing.T) {
+	sourceRepo := testOCIRepo("ghcr.io/source")
+	targetRepo := testOCIRepo("ghcr.io/target")
+	desc := testDescriptor("ocm.software/test", "1.0.0",
+		[]descriptor.Resource{dockerManifestLocalBlobResource("my-image", "1.0.0")}, nil)
+	resolver := testResolverFor("ocm.software/test", "1.0.0", sourceRepo, desc)
+	roots := testTransferRoots("ocm.software/test", "1.0.0", targetRepo, resolver)
+
+	tgd, err := BuildGraphDefinition(t.Context(), roots, false, CopyModeLocalBlobResources, UploadAsOciArtifact)
+	require.NoError(t, err)
+
+	addOCIType := runtime.NewVersionedType(ociv1alpha1.AddOCIArtifactType, ociv1alpha1.Version)
+	require.Len(t, tgd.Transformations, 4)
+	assert.Equal(t, ociv1alpha1.OCIGetLocalResourceV1alpha1, tgd.Transformations[0].Type)
+	assert.Equal(t, addOCIType, tgd.Transformations[1].Type, "Docker manifest LocalBlob should be uploaded as OCI artifact")
+}
+
+func TestBuildGraphDefinition_DockerManifestLocalBlob_FallsBackToLocalBlobWithoutUploadFlag(t *testing.T) {
+	sourceRepo := testOCIRepo("ghcr.io/source")
+	targetRepo := testOCIRepo("ghcr.io/target")
+	desc := testDescriptor("ocm.software/test", "1.0.0",
+		[]descriptor.Resource{dockerManifestLocalBlobResource("my-image", "1.0.0")}, nil)
+	resolver := testResolverFor("ocm.software/test", "1.0.0", sourceRepo, desc)
+	roots := testTransferRoots("ocm.software/test", "1.0.0", targetRepo, resolver)
+
+	tgd, err := BuildGraphDefinition(t.Context(), roots, false, CopyModeLocalBlobResources, UploadAsDefault)
+	require.NoError(t, err)
+
+	require.Len(t, tgd.Transformations, 4)
+	assert.Equal(t, ociv1alpha1.OCIGetLocalResourceV1alpha1, tgd.Transformations[0].Type)
+	assert.Equal(t, ociv1alpha1.OCIAddLocalResourceV1alpha1, tgd.Transformations[1].Type)
+}

--- a/bindings/go/transfer/internal/helpers.go
+++ b/bindings/go/transfer/internal/helpers.go
@@ -13,6 +13,14 @@ import (
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
+// Docker manifest media types as defined by the Docker distribution spec.
+// oras-go/v2 defines these in internal/docker/mediatype.go (not importable),
+// so we redeclare them here.
+const (
+	mediaTypeDockerManifest     = "application/vnd.docker.distribution.manifest.v2+json"
+	mediaTypeDockerManifestList = "application/vnd.docker.distribution.manifest.list.v2+json"
+)
+
 func asUnstructured(typed runtime.Typed) (*runtime.Unstructured, error) {
 	var raw runtime.Raw
 	if err := runtime.NewScheme(runtime.WithAllowUnknown()).Convert(typed, &raw); err != nil {
@@ -141,10 +149,10 @@ func RepositoryEqual(a, b runtime.Typed) bool {
 //	soon anyways after which we might not need this function here anymore.
 func isOCICompliantManifest(mediaType string) bool {
 	switch mediaType {
-	// TODO(jakobmoellerdev): currently only Image Indexes and OCI manifests are supported,
-	//  but we may want to extend this down the line with additional media types such as docker manifests.
 	case ocispecv1.MediaTypeImageManifest,
-		ocispecv1.MediaTypeImageIndex:
+		ocispecv1.MediaTypeImageIndex,
+		mediaTypeDockerManifest,
+		mediaTypeDockerManifestList:
 		return true
 	default:
 		return false

--- a/bindings/go/transfer/internal/helpers_test.go
+++ b/bindings/go/transfer/internal/helpers_test.go
@@ -86,7 +86,8 @@ func TestChooseAddLocalResourceType_CTF(t *testing.T) {
 func TestIsOCICompliantManifest(t *testing.T) {
 	assert.True(t, isOCICompliantManifest(ocispecv1.MediaTypeImageManifest))
 	assert.True(t, isOCICompliantManifest(ocispecv1.MediaTypeImageIndex))
-	assert.False(t, isOCICompliantManifest("application/vnd.docker.distribution.manifest.v2+json"))
+	assert.True(t, isOCICompliantManifest(mediaTypeDockerManifest))
+	assert.True(t, isOCICompliantManifest(mediaTypeDockerManifestList))
 	assert.False(t, isOCICompliantManifest(""))
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it

Docker manifest v2 (`application/vnd.docker.distribution.manifest.v2+json`) and Docker manifest list (`application/vnd.docker.distribution.manifest.list.v2+json`) were excluded from `isOCICompliantManifest` / `IsOCICompliantMediaType` in both `bindings/go/oci/internal/introspection` and `bindings/go/transfer/internal`. This caused LocalBlob resources with Docker manifest media types to silently bypass the OCI artifact upload path when using `UploadAsOciArtifact` mode during transfer — they were stored as plain local blobs instead.

The root cause was a TODO in both functions noting Docker manifests were not yet supported. This PR resolves that TODO by adding the two Docker distribution manifest media type constants (mirroring `oras-go/v2`'s internal definitions, which are not importable) and extending the switch statements to accept them.

#### Which issue(s) this PR fixes

Internal report: standard `docker manifest` transfer broken in v2 transfer path (`UploadAsOciArtifact` mode).

#### Testing

##### How to test the changes

```bash
# Unit tests (fast)
cd bindings/go/transfer && go test ./internal/... -run "TestIsOCICompliant|TestBuildGraphDefinition_Docker" -v
cd bindings/go/oci && go test ./internal/introspection/... -v

# Integration test (requires Docker)
cd bindings/go/transfer/integration && go test -v -run Test_Integration_TransferDockerManifestLocalBlob_CTFToOCI
```

##### Verification

- [x] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [x] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [x] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`