### PR TITLE
docs: Add `Task` to prerequisites for building

### DIFF
--- a/website/content/docs/getting-started/ocm-cli-installation.md
+++ b/website/content/docs/getting-started/ocm-cli-installation.md
@@ -46,6 +46,7 @@ Building from source is not officially supported. Use the pre-built binaries via
 
 - [Git](https://git-scm.com/)
 - [Go](https://go.dev/)
+- [Task](https://taskfile.dev)
 
 ### Clone and build
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
`Task` is missing in the list of perquisites to build from source. Its listed in the overall perquisites (https://ocm.software/community/onboarding/) but so is `Go`, so it would make sense to repeat it as well.

#### Which issue(s) this PR fixes
List of prerequisites is missing `Task`

#### Testing

##### How to test the changes

Its a one line change in the documentation 

##### Verification

- [ ] ~I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))~
- [ ] ~Tests pass locally (`task test` and `task test/integration` if applicable)~
- [ ] I~f touching multiple modules, `go work` is enabled (see `go.work`)~
- [x] My changes do not decrease test coverage
- [ ] ~I have tested the changes locally by running `ocm`~
