### PR TITLE
fix: restore OCIRepository as legacy alias for OCIRegistry consumer identity

### DIFF
--- a/bindings/go/credentials/spec/config/runtime/convert_v1.go
+++ b/bindings/go/credentials/spec/config/runtime/convert_v1.go
@@ -24,10 +24,28 @@ func convertConsumers(consumers []v1.Consumer) []Consumer {
 	return entries
 }
 
+// legacyConsumerIdentityTypes maps deprecated consumer identity type names to
+// their current equivalents. Normalization happens at config-load time so that
+// credentials stored under an old type name are still found when the runtime
+// looks them up under the new name.
+//
+// History:
+//   - "OCIRepository" was renamed to "OCIRegistry" in
+//     https://github.com/open-component-model/open-component-model/pull/1964
+var legacyConsumerIdentityTypes = map[string]string{
+	"OCIRepository": "OCIRegistry",
+}
+
 func convertIdentities(identities []runtime.Identity) []runtime.Identity {
 	nidentities := make([]runtime.Identity, len(identities))
 	for i, identity := range identities {
-		nidentities[i] = identity.DeepCopy()
+		id := identity.DeepCopy()
+		if typ, ok := id[runtime.IdentityAttributeType]; ok {
+			if normalized, ok := legacyConsumerIdentityTypes[typ]; ok {
+				id[runtime.IdentityAttributeType] = normalized
+			}
+		}
+		nidentities[i] = id
 	}
 	return nidentities
 }

--- a/bindings/go/credentials/spec/config/runtime/convert_v1_test.go
+++ b/bindings/go/credentials/spec/config/runtime/convert_v1_test.go
@@ -1,0 +1,68 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+func TestConvertIdentities_LegacyOCIRepositoryType(t *testing.T) {
+	identities := []runtime.Identity{
+		{
+			runtime.IdentityAttributeType:     "OCIRepository",
+			runtime.IdentityAttributeHostname: "localhost",
+			runtime.IdentityAttributePort:     "5000",
+			runtime.IdentityAttributeScheme:   "http",
+		},
+	}
+
+	got := convertIdentities(identities)
+
+	assert.Equal(t, "OCIRegistry", got[0][runtime.IdentityAttributeType],
+		"OCIRepository should be normalized to OCIRegistry")
+	assert.Equal(t, "localhost", got[0][runtime.IdentityAttributeHostname])
+	assert.Equal(t, "5000", got[0][runtime.IdentityAttributePort])
+	assert.Equal(t, "http", got[0][runtime.IdentityAttributeScheme])
+}
+
+func TestConvertIdentities_CurrentOCIRegistryType(t *testing.T) {
+	identities := []runtime.Identity{
+		{
+			runtime.IdentityAttributeType:     "OCIRegistry",
+			runtime.IdentityAttributeHostname: "ghcr.io",
+		},
+	}
+
+	got := convertIdentities(identities)
+
+	assert.Equal(t, "OCIRegistry", got[0][runtime.IdentityAttributeType],
+		"OCIRegistry should remain unchanged")
+}
+
+func TestConvertIdentities_UnrelatedTypeUnchanged(t *testing.T) {
+	identities := []runtime.Identity{
+		{
+			runtime.IdentityAttributeType: "HelmChartRepository",
+		},
+	}
+
+	got := convertIdentities(identities)
+
+	assert.Equal(t, "HelmChartRepository", got[0][runtime.IdentityAttributeType],
+		"unrelated types should pass through unchanged")
+}
+
+func TestConvertIdentities_OriginalNotMutated(t *testing.T) {
+	original := runtime.Identity{
+		runtime.IdentityAttributeType:     "OCIRepository",
+		runtime.IdentityAttributeHostname: "localhost",
+	}
+	identities := []runtime.Identity{original}
+
+	convertIdentities(identities)
+
+	assert.Equal(t, "OCIRepository", original[runtime.IdentityAttributeType],
+		"original identity must not be mutated")
+}

--- a/bindings/go/oci/spec/identity/v1/convert_test.go
+++ b/bindings/go/oci/spec/identity/v1/convert_test.go
@@ -22,6 +22,11 @@ func TestMustRegisterIdentityType(t *testing.T) {
 	obj, err = scheme.NewObject(Type)
 	require.NoError(t, err)
 	assert.IsType(t, &OCIRegistryIdentity{}, obj)
+
+	// Should resolve pre-#1964 legacy alias
+	obj, err = scheme.NewObject(LegacyType)
+	require.NoError(t, err)
+	assert.IsType(t, &OCIRegistryIdentity{}, obj)
 }
 
 func TestOCIRegistryIdentity_SchemeConvert(t *testing.T) {

--- a/bindings/go/oci/spec/identity/v1/oci_registry_identity.go
+++ b/bindings/go/oci/spec/identity/v1/oci_registry_identity.go
@@ -25,6 +25,7 @@ var VersionedType = runtime.NewVersionedType(OCIRegistryIdentityType, Version)
 type OCIRegistryIdentity struct {
 	// +ocm:jsonschema-gen:enum=OCIRegistry/v1
 	// +ocm:jsonschema-gen:enum:deprecated=OCIRegistry
+	// +ocm:jsonschema-gen:enum:deprecated=OCIRepository
 	Type runtime.Type `json:"type"`
 	// Hostname is the registry hostname (e.g. "ghcr.io", "registry.example.com").
 	// Primary matching attribute when resolving credentials for a registry request.

--- a/bindings/go/oci/spec/identity/v1/register.go
+++ b/bindings/go/oci/spec/identity/v1/register.go
@@ -8,10 +8,16 @@ func init() {
 	MustRegisterIdentityType(scheme)
 }
 
+// LegacyType is the pre-#1964 identity type name kept as a scheme alias so
+// that code paths that decode OCIRegistryIdentity from raw bytes (e.g. scheme.Convert)
+// still work when the raw data carries the old type string.
+var LegacyType = runtime.NewUnversionedType("OCIRepository")
+
 // MustRegisterIdentityType registers OCIRegistry/v1 (with unversioned alias) in the given scheme.
 func MustRegisterIdentityType(scheme *runtime.Scheme) {
 	scheme.MustRegisterWithAlias(&OCIRegistryIdentity{},
 		VersionedType,
-		Type, // backward-compat alias
+		Type,       // backward-compat alias
+		LegacyType, // pre-#1964 legacy alias
 	)
 }

--- a/bindings/go/oci/spec/identity/v1/schemas/OCIRegistryIdentity.schema.json
+++ b/bindings/go/oci/spec/identity/v1/schemas/OCIRegistryIdentity.schema.json
@@ -31,6 +31,10 @@
         {
           "deprecated": true,
           "const": "OCIRegistry"
+        },
+        {
+          "deprecated": true,
+          "const": "OCIRepository"
         }
       ]
     }


### PR DESCRIPTION
tbd - lets discuss this in the WR first before we do anything now