### PR TITLE
chore: Add `yaml` marshalling for `config.timeout`

### DIFF
--- a/bindings/go/configuration/go.mod
+++ b/bindings/go/configuration/go.mod
@@ -4,6 +4,7 @@ go 1.26.3
 
 require (
 	github.com/stretchr/testify v1.11.1
+	gopkg.in/yaml.v3 v3.0.1
 	ocm.software/open-component-model/bindings/go/runtime v0.0.8
 )
 
@@ -13,6 +14,5 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/bindings/go/configuration/http/v1alpha1/spec/config.go
+++ b/bindings/go/configuration/http/v1alpha1/spec/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"gopkg.in/yaml.v3"
 	genericv1 "ocm.software/open-component-model/bindings/go/configuration/generic/v1/spec"
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
@@ -24,6 +25,14 @@ type Timeout time.Duration
 
 func (d Timeout) MarshalJSON() ([]byte, error) {
 	return json.Marshal(time.Duration(d).String())
+}
+
+func (d Timeout) MarshalYAML() (*yaml.Node, error) {
+	return &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Value: time.Duration(d).String(),
+		Tag:   "!!str",
+	}, nil
 }
 
 func (d *Timeout) UnmarshalJSON(b []byte) error {

--- a/bindings/go/configuration/http/v1alpha1/spec/config.go
+++ b/bindings/go/configuration/http/v1alpha1/spec/config.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"gopkg.in/yaml.v3"
-
 	genericv1 "ocm.software/open-component-model/bindings/go/configuration/generic/v1/spec"
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
@@ -28,12 +26,8 @@ func (d Timeout) MarshalJSON() ([]byte, error) {
 	return json.Marshal(time.Duration(d).String())
 }
 
-func (d Timeout) MarshalYAML() (*yaml.Node, error) {
-	return &yaml.Node{
-		Kind:  yaml.ScalarNode,
-		Value: time.Duration(d).String(),
-		Tag:   "!!str",
-	}, nil
+func (d Timeout) MarshalYAML() (interface{}, error) {
+	return time.Duration(d).String(), nil
 }
 
 func (d *Timeout) UnmarshalJSON(b []byte) error {

--- a/bindings/go/configuration/http/v1alpha1/spec/config.go
+++ b/bindings/go/configuration/http/v1alpha1/spec/config.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v3"
+
 	genericv1 "ocm.software/open-component-model/bindings/go/configuration/generic/v1/spec"
 	"ocm.software/open-component-model/bindings/go/runtime"
 )

--- a/bindings/go/configuration/http/v1alpha1/spec/config_test.go
+++ b/bindings/go/configuration/http/v1alpha1/spec/config_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	genericv1 "ocm.software/open-component-model/bindings/go/configuration/generic/v1/spec"
 	httpspec "ocm.software/open-component-model/bindings/go/configuration/http/v1alpha1/spec"
@@ -122,7 +123,7 @@ configurations:
 
 func TestTimeout_MarshalYAML(t *testing.T) {
 	timeout := httpspec.Timeout(1*time.Hour + 30*time.Minute + 5*time.Second)
-	node, err := timeout.MarshalYAML()
+	out, err := yaml.Marshal(timeout)
 	require.NoError(t, err)
-	assert.Equal(t, "1h30m5s", node.Value)
+	assert.Equal(t, "1h30m5s\n", string(out))
 }

--- a/bindings/go/configuration/http/v1alpha1/spec/config_test.go
+++ b/bindings/go/configuration/http/v1alpha1/spec/config_test.go
@@ -119,3 +119,10 @@ configurations:
 		}
 	})
 }
+
+func TestTimeout_MarshalYAML(t *testing.T) {
+	timeout := httpspec.Timeout(1*time.Hour + 30*time.Minute + 5*time.Second)
+	node, err := timeout.MarshalYAML()
+	require.NoError(t, err)
+	assert.Equal(t, "1h30m5s", node.Value)
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Noticed during https://github.com/open-component-model/ocm-project/issues/949

While `timeout` already has a marshalling function for JSON, it doesn't have one for YAML

#### Which issue(s) this PR fixes
Prettier config printing (`timeout: 60000000000` vs `timeout: 60s`). Addresses https://github.com/jneisener/open-component-model/blob/14c9daed0ed72b3ff89ea74c76b1771b134a63bf/cli/cmd/cmd_test.go#L2107-L2108

#### Testing

##### How to test the changes
Added a unit test

##### Verification

- [x] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [x] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [x] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
