### PR TITLE
chore: Add `yaml` struct tags to all configuration types

### DIFF
--- a/bindings/go/configuration/extract/v1alpha1/spec/config.go
+++ b/bindings/go/configuration/extract/v1alpha1/spec/config.go
@@ -30,9 +30,9 @@ func init() {
 type Config struct {
 	// +ocm:jsonschema-gen:enum=extract.oci.artifact.ocm.software/v1alpha1
 	// +ocm:jsonschema-gen:enum:deprecated=extract.oci.artifact.ocm.software
-	Type runtime.Type `json:"type"`
+	Type runtime.Type `json:"type" yaml:"type"`
 	// Rules defines rules for extracting layers to specific files.
-	Rules []Rule `json:"rules,omitempty"`
+	Rules []Rule `json:"rules,omitempty" yaml:"rules,omitempty"`
 }
 
 // Rule represents a rule for extracting selected layers to a target file.
@@ -42,10 +42,10 @@ type Config struct {
 // +ocm:jsonschema-gen=true
 type Rule struct {
 	// Filename is the target filename for the extracted layers.
-	Filename string `json:"filename,omitempty"`
+	Filename string `json:"filename,omitempty" yaml:"filename,omitempty"`
 	// LayerSelectors defines multiple selection criteria for layers to include in this file.
 	// Layers matching any of these selectors will be included.
-	LayerSelectors []*LayerSelector `json:"layerSelectors,omitempty"`
+	LayerSelectors []*LayerSelector `json:"layerSelectors,omitempty" yaml:"layerSelectors,omitempty"`
 }
 
 // LookupConfig creates a new extract configuration from a central V1 config.

--- a/bindings/go/configuration/extract/v1alpha1/spec/selector.go
+++ b/bindings/go/configuration/extract/v1alpha1/spec/selector.go
@@ -33,13 +33,13 @@ const (
 type LayerSelectorRequirement struct {
 	// Key is the property key that the selector applies to.
 	// Can be a custom annotation key or predefined keys like layer.index, layer.mediaType.
-	Key string `json:"key"`
+	Key string `json:"key" yaml:"key"`
 	// Operator represents the relationship between the key and values.
-	Operator LayerSelectorOperator `json:"operator"`
+	Operator LayerSelectorOperator `json:"operator" yaml:"operator"`
 	// Values is an array of string values. If the operator is In or NotIn,
 	// the value array must be non-empty. If the operator is Exists or DoesNotExist,
 	// the value array must be empty.
-	Values []string `json:"values,omitempty"`
+	Values []string `json:"values,omitempty" yaml:"values,omitempty"`
 }
 
 // LayerSelector allows selecting layers based on index, mediatype, and annotations.
@@ -49,10 +49,10 @@ type LayerSelector struct {
 	// MatchProperties is a map of {key,value} pairs. A single {key,value} in the matchLabels
 	// map is equivalent to an element of matchExpressions, whose key field is "key", the
 	// operator is "In", and the value array contains only "value".
-	MatchProperties map[string]string `json:"matchProperties,omitempty"`
+	MatchProperties map[string]string `json:"matchProperties,omitempty" yaml:"matchProperties,omitempty"`
 	// MatchExpressions is a list of selectors. The selectors are ANDed together.
 	// Use predefined keys like 'layer.index' and 'layer.mediaType' for built-in properties.
-	MatchExpressions []LayerSelectorRequirement `json:"matchExpressions,omitempty"`
+	MatchExpressions []LayerSelectorRequirement `json:"matchExpressions,omitempty" yaml:"matchExpressions,omitempty"`
 }
 
 // LayerInfo represents information about a layer for matching purposes.

--- a/bindings/go/configuration/filesystem/v1alpha1/spec/config.go
+++ b/bindings/go/configuration/filesystem/v1alpha1/spec/config.go
@@ -30,17 +30,17 @@ func init() {
 type Config struct {
 	// +ocm:jsonschema-gen:enum=filesystem.config.ocm.software/v1alpha1
 	// +ocm:jsonschema-gen:enum:deprecated=filesystem.config.ocm.software
-	Type runtime.Type `json:"type"`
+	Type runtime.Type `json:"type" yaml:"type"`
 
 	// TempFolder defines places where plugins and other functionalities can put ephemeral files under.
 	// If not defined, os.TempDir is used as a default.
-	TempFolder string `json:"tempFolder,omitempty"`
+	TempFolder string `json:"tempFolder,omitempty" yaml:"tempFolder,omitempty"`
 
 	// WorkingDirectory defines the working directory for the filesystem operations.
 	// This is typically the directory where the plugin operates, and it can be used
 	// to resolve relative paths for file operations.
 	// If not defined, the current working directory is used as a default for file operations.
-	WorkingDirectory string `json:"workingDirectory,omitempty"`
+	WorkingDirectory string `json:"workingDirectory,omitempty" yaml:"workingDirectory,omitempty"`
 }
 
 type Duration time.Duration

--- a/bindings/go/configuration/generic/v1/spec/config.go
+++ b/bindings/go/configuration/generic/v1/spec/config.go
@@ -24,6 +24,6 @@ const (
 type Config struct {
 	// +ocm:jsonschema-gen:enum=generic.config.ocm.software/v1
 	// +ocm:jsonschema-gen:enum:deprecated=generic.config.ocm.software
-	Type           runtime.Type   `json:"type"`
-	Configurations []*runtime.Raw `json:"configurations"`
+	Type           runtime.Type   `json:"type"           yaml:"type"`
+	Configurations []*runtime.Raw `json:"configurations" yaml:"configurations"`
 }

--- a/bindings/go/configuration/http/v1alpha1/spec/config.go
+++ b/bindings/go/configuration/http/v1alpha1/spec/config.go
@@ -66,11 +66,11 @@ func init() {
 type Config struct {
 	// +ocm:jsonschema-gen:enum=http.config.ocm.software/v1alpha1
 	// +ocm:jsonschema-gen:enum:deprecated=http.config.ocm.software
-	Type runtime.Type `json:"type"`
+	Type runtime.Type `json:"type" yaml:"type"`
 
 	// Timeout specifies the HTTP client timeout as a Go duration string
 	// (e.g. "30s", "5m", "1h"). If not set, the default timeout of 30s is used.
-	Timeout Timeout `json:"timeout,omitempty"`
+	Timeout Timeout `json:"timeout,omitempty" yaml:"timeout,omitempty"`
 }
 
 // LookupConfig creates an HTTP configuration from a central generic V1 config.

--- a/bindings/go/configuration/ocm/v1/spec/config.go
+++ b/bindings/go/configuration/ocm/v1/spec/config.go
@@ -52,13 +52,13 @@ func init() {
 type Config struct {
 	// +ocm:jsonschema-gen:enum=ocm.config.ocm.software/v1
 	// +ocm:jsonschema-gen:enum:deprecated=ocm.config.ocm.software
-	Type runtime.Type `json:"type"`
+	Type runtime.Type `json:"type" yaml:"type"`
 
 	//nolint:gocritic // Deprecated field is okay
 	// With aliases repository alias names can be mapped to a repository specification.
 	// The alias name can be used in a string notation for an OCM repository.
 	// Deprecated: Aliases are deprecated and are ignored with a warning message.
-	Aliases map[string]*runtime.Raw `json:"aliases,omitempty"`
+	Aliases map[string]*runtime.Raw `json:"aliases,omitempty" yaml:"aliases,omitempty"`
 
 	// Resolvers define a list of OCM repository specifications to be used to resolve
 	// dedicated component versions.
@@ -77,7 +77,7 @@ type Config struct {
 	//
 	// They are also used as default lookup repositories to lookup component references
 	// for recursive operations on component versions («--lookup» option).
-	Resolvers []*Resolver `json:"resolvers,omitempty"`
+	Resolvers []*Resolver `json:"resolvers,omitempty" yaml:"resolvers,omitempty"`
 }
 
 // Resolver assigns a priority and a prefix to a single OCM repository specification
@@ -91,19 +91,19 @@ type Config struct {
 type Resolver struct {
 	// Repository is the OCM repository specification to be used for resolving
 	// component versions.
-	Repository *runtime.Raw `json:"repository"`
+	Repository *runtime.Raw `json:"repository" yaml:"repository"`
 
 	// Optionally, a component name prefix can be given.
 	// It limits the usage of the repository to resolve only
 	// components with the given name prefix (always complete name segments).
-	Prefix string `json:"prefix,omitempty"`
+	Prefix string `json:"prefix,omitempty" yaml:"prefix,omitempty"`
 
 	// An optional priority can be used to influence the lookup order. Larger value
 	// means higher priority (default DefaultLookupPriority).
 	// Pointer because this is optional. To default the priority, we need to be
 	// able to distinguish between "not set" and "set to zero".
 	// +ocm:jsonschema-gen:minimum=0
-	Priority *int `json:"priority,omitempty"`
+	Priority *int `json:"priority,omitempty" yaml:"priority,omitempty"`
 }
 
 // Lookup creates a new Config from a central V1 config.

--- a/bindings/go/configuration/ownership/v1alpha1/spec/config.go
+++ b/bindings/go/configuration/ownership/v1alpha1/spec/config.go
@@ -58,7 +58,7 @@ const (
 type Config struct {
 	// +ocm:jsonschema-gen:enum=ownership.config.ocm.software/v1alpha1
 	// +ocm:jsonschema-gen:enum:deprecated=ownership.config.ocm.software
-	Type runtime.Type `json:"type"`
+	Type runtime.Type `json:"type" yaml:"type"`
 
 	// Policy is the default used for any repository without a matching entry
 	// in Repositories. When omitted, it behaves as Never.
@@ -68,10 +68,10 @@ type Config struct {
 	//
 	// +ocm:jsonschema-gen:enum=AddIfSupported
 	// +ocm:jsonschema-gen:enum=Never
-	Policy Policy `json:"policy,omitempty"`
+	Policy Policy `json:"policy,omitempty" yaml:"policy,omitempty"`
 
 	// Repositories overrides Policy for specific repositories.
-	Repositories []*RepositoryPolicy `json:"repositories,omitempty"`
+	Repositories []*RepositoryPolicy `json:"repositories,omitempty" yaml:"repositories,omitempty"`
 }
 
 // RepositoryPolicy pairs a repository with the Policy to use for uploads to
@@ -81,14 +81,14 @@ type Config struct {
 // +ocm:jsonschema-gen=true
 type RepositoryPolicy struct {
 	// Repository is the repository this entry applies to.
-	Repository *runtime.Raw `json:"repository"`
+	Repository *runtime.Raw `json:"repository" yaml:"repository"`
 
 	// Policy is used for uploads to Repository. When omitted, it behaves as
 	// Never.
 	//
 	// +ocm:jsonschema-gen:enum=AddIfSupported
 	// +ocm:jsonschema-gen:enum=Never
-	Policy Policy `json:"policy,omitempty"`
+	Policy Policy `json:"policy,omitempty" yaml:"policy,omitempty"`
 }
 
 // Lookup finds every ownership config entry in cfg and merges them into one

--- a/bindings/go/configuration/resolvers/v1alpha1/spec/config.go
+++ b/bindings/go/configuration/resolvers/v1alpha1/spec/config.go
@@ -39,7 +39,7 @@ func init() {
 type Config struct {
 	// +ocm:jsonschema-gen:enum=resolvers.config.ocm.software/v1alpha1
 	// +ocm:jsonschema-gen:enum:deprecated=resolvers.config.ocm.software
-	Type runtime.Type `json:"type"`
+	Type runtime.Type `json:"type" yaml:"type"`
 
 	// Resolvers define a list of OCM repository specifications to be used to resolve
 	// dedicated component versions using glob patterns.
@@ -55,7 +55,7 @@ type Config struct {
 	//
 	// They are also used as default lookup repositories to lookup component references
 	// for recursive operations on component versions («--lookup» option).
-	Resolvers []*Resolver `json:"resolvers,omitempty"`
+	Resolvers []*Resolver `json:"resolvers,omitempty" yaml:"resolvers,omitempty"`
 }
 
 // Resolver assigns a component name pattern to a single OCM repository specification
@@ -66,7 +66,7 @@ type Config struct {
 type Resolver struct {
 	// Repository is the OCM repository specification to be used for resolving
 	// component versions.
-	Repository *runtime.Raw `json:"repository"`
+	Repository *runtime.Raw `json:"repository" yaml:"repository"`
 
 	// ComponentNamePattern specifies a glob pattern for matching component names.
 	// It limits the usage of the repository to resolve only components with names
@@ -75,12 +75,12 @@ type Resolver struct {
 	//   - "ocm.software/core/*" (matches any component in the core namespace)
 	//   - "*.software/*/test" (matches test components in any software namespace)
 	//   - "ocm.software/core/[tc]est" (matches "test" or "cest" in core namespace)
-	ComponentNamePattern string `json:"componentNamePattern,omitempty"`
+	ComponentNamePattern string `json:"componentNamePattern,omitempty" yaml:"componentNamePattern,omitempty"`
 
 	// VersionConstraint specifies an optional semver constraint for matching component versions.
 	// It limits the usage of the repository to resolve only components with versions
 	// that satisfy the given constraint (e.g. ">=1.0.0 <2.0.0", "^1.2.0", "~1.2.0").
-	VersionConstraint string `json:"versionConstraint,omitempty"`
+	VersionConstraint string `json:"versionConstraint,omitempty" yaml:"versionConstraint,omitempty"`
 }
 
 // Lookup creates a new Config from a central V1 config.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Found while working on https://github.com/open-component-model/ocm-project/issues/949
#### Which issue(s) this PR fixes
`enc.Encode` expects yaml types to be deeply tagged, i.e. fixes:
https://github.com/open-component-model/open-component-model/pull/2752/changes#diff-0386a795ae1c3c97a163ab9dcee29c4a7159db7442901e2ef030bb2221802dccR86

#### Testing

##### How to test the changes

Only added equivalent `yaml` tags to the already existing `json` tags, which I assume does not need additional testing

##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
