### PR TITLE
fix: add `component.labels`

### DIFF
--- a/bindings/go/constructor/runtime/convert_v1.go
+++ b/bindings/go/constructor/runtime/convert_v1.go
@@ -363,7 +363,7 @@ func ConvertToRuntimeConstructor(constructor *v1.ComponentConstructor) *Componen
 	for i, component := range constructor.Components {
 		target.Components[i] = Component{
 			ComponentMeta: ComponentMeta{
-				ObjectMeta:   ObjectMeta{Name: component.Name, Version: component.Version},
+				ObjectMeta:   ObjectMeta{Name: component.Name, Version: component.Version, Labels: ConvertFromV1Labels(component.Labels)},
 				CreationTime: component.CreationTime,
 			},
 			Provider: Provider{

--- a/bindings/go/constructor/runtime/convert_v1_test.go
+++ b/bindings/go/constructor/runtime/convert_v1_test.go
@@ -477,6 +477,53 @@ func TestConvertToRuntimeConstructor(t *testing.T) {
 			},
 		},
 		{
+			name: "constructor with component labels",
+			constructor: &v1.ComponentConstructor{
+				Components: []v1.Component{
+					{
+						ComponentMeta: v1.ComponentMeta{
+							ObjectMeta: v1.ObjectMeta{
+								Name:    "test-component",
+								Version: "1.0.0",
+								Labels: []v1.Label{
+									{
+										Name:    "component-label",
+										Value:   []byte("component-value"),
+										Signing: true,
+									},
+								},
+							},
+						},
+						Provider: v1.Provider{
+							Name: "test-provider",
+						},
+					},
+				},
+			},
+			want: &ComponentConstructor{
+				Components: []Component{
+					{
+						ComponentMeta: ComponentMeta{
+							ObjectMeta: ObjectMeta{
+								Name:    "test-component",
+								Version: "1.0.0",
+								Labels: []Label{
+									{
+										Name:    "component-label",
+										Value:   []byte("component-value"),
+										Signing: true,
+									},
+								},
+							},
+						},
+						Provider: Provider{
+							Name: "test-provider",
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "constructor with provider labels",
 			constructor: &v1.ComponentConstructor{
 				Components: []v1.Component{
@@ -538,6 +585,7 @@ func TestConvertToRuntimeConstructor(t *testing.T) {
 			if len(got.Components) > 0 {
 				assert.Equal(t, tt.want.Components[0].Name, got.Components[0].Name)
 				assert.Equal(t, tt.want.Components[0].Version, got.Components[0].Version)
+				assert.Equal(t, tt.want.Components[0].Labels, got.Components[0].Labels)
 				assert.Equal(t, tt.want.Components[0].Provider.Name, got.Components[0].Provider.Name)
 
 				// Check provider labels

--- a/bindings/go/constructor/runtime/convert_v1_test.go
+++ b/bindings/go/constructor/runtime/convert_v1_test.go
@@ -524,6 +524,41 @@ func TestConvertToRuntimeConstructor(t *testing.T) {
 			},
 		},
 		{
+			name: "constructor with empty component labels",
+			constructor: &v1.ComponentConstructor{
+				Components: []v1.Component{
+					{
+						ComponentMeta: v1.ComponentMeta{
+							ObjectMeta: v1.ObjectMeta{
+								Name:    "test-component",
+								Version: "1.0.0",
+								Labels:  []v1.Label{},
+							},
+						},
+						Provider: v1.Provider{
+							Name: "test-provider",
+						},
+					},
+				},
+			},
+			want: &ComponentConstructor{
+				Components: []Component{
+					{
+						ComponentMeta: ComponentMeta{
+							ObjectMeta: ObjectMeta{
+								Name:    "test-component",
+								Version: "1.0.0",
+								Labels:  []Label{},
+							},
+						},
+						Provider: Provider{
+							Name: "test-provider",
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "constructor with provider labels",
 			constructor: &v1.ComponentConstructor{
 				Components: []v1.Component{


### PR DESCRIPTION
Apparently, we did not write `component.labels` even when described in the component constructor. This PR fixes it by propagating the labels to the metadata when converting it.

Fixes #2758 

## Testing

Checkout `component-labels`

Init go.work
```bash
task init/go.work
```

Build the cli

```bash
task cli:build
```

Use such a `component-constructor.yaml`

```yaml
components:
  - name: ocm.software/labels
    version: "1.0.0"
    provider:
      name: ocm.software
    labels:
      - name: hello
        value: world
    resources:
      - name: helm-resource
        type: helmChart
        version: "1.0.0"
        labels:
          - name: hello
            value: world
        access:
           type: ociImage
           imageReference: "ghcr.io/stefanprodan/charts/podinfo:6.9.1@sha256:565d310746f1fa4be7f93ba7965bb393153a2d57a15cfe5befc909b790a73f8a"1
```

Create a component version

```bash
./cli/tmp/bin/ocm add cv -r ctf-v2 -c component-constructor.yaml
```

Take a look at the component version

```bash
./cli/tmp/bin/ocm get cv ctf-v2 -o yaml
```

```yaml
- component:
    componentReferences: null
    labels:
    - name: hello
      value: world
    name: ocm.software/labels
    provider: ocm.software
    repositoryContexts: null
    resources:
    - access:
        imageReference: ghcr.io/stefanprodan/charts/podinfo:6.9.1@sha256:565d310746f1fa4be7f93ba7965bb393153a2d57a15cfe5befc909b790a73f8a
        type: ociImage
      digest:
        hashAlgorithm: SHA-256
        normalisationAlgorithm: genericBlobDigest/v1
        value: 565d310746f1fa4be7f93ba7965bb393153a2d57a15cfe5befc909b790a73f8a
      labels:
      - name: hello
        value: world
      name: helm-resource
      relation: external
      type: helmChart
      version: 1.0.0
    sources: null
    version: 1.0.0
  meta:
    schemaVersion: v2
```