### PR TITLE
fix(transfer): check len instead of nil for optional descriptor fields in buildDescriptorSpec

### DIFF
--- a/bindings/go/transfer/internal/graph.go
+++ b/bindings/go/transfer/internal/graph.go
@@ -392,17 +392,17 @@ func buildDescriptorSpec(v2desc *descriptorv2.Descriptor, id string, resourceTra
 		"resources": resourcesArray,
 	}
 
-	setOptionalField(componentMap, "labels", id, v2desc.Component.Labels != nil)
-	setOptionalField(componentMap, "repositoryContexts", id, v2desc.Component.RepositoryContexts != nil)
-	setOptionalField(componentMap, "sources", id, v2desc.Component.Sources != nil)
-	setOptionalField(componentMap, "componentReferences", id, v2desc.Component.References != nil)
+	setOptionalField(componentMap, "labels", id, len(v2desc.Component.Labels) != 0)
+	setOptionalField(componentMap, "repositoryContexts", id, len(v2desc.Component.RepositoryContexts) != 0)
+	setOptionalField(componentMap, "sources", id, len(v2desc.Component.Sources) != 0)
+	setOptionalField(componentMap, "componentReferences", id, len(v2desc.Component.References) != 0)
 
 	descSpecMap := map[string]any{
 		"meta":      fmt.Sprintf("${environment.%s.meta}", id),
 		"component": componentMap,
 	}
 
-	if v2desc.Signatures != nil {
+	if len(v2desc.Signatures) != 0 {
 		descSpecMap["signatures"] = fmt.Sprintf("${environment.%s.signatures}", id)
 	}
 

--- a/bindings/go/transfer/internal/graph_test.go
+++ b/bindings/go/transfer/internal/graph_test.go
@@ -764,3 +764,35 @@ func TestBuildGraphDefinition_DockerManifestLocalBlob_FallsBackToLocalBlobWithou
 	assert.Equal(t, ociv1alpha1.OCIGetLocalResourceV1alpha1, tgd.Transformations[0].Type)
 	assert.Equal(t, ociv1alpha1.OCIAddLocalResourceV1alpha1, tgd.Transformations[1].Type)
 }
+
+// TestBuildAndCheck_Reproduce2742_EmptyNonNilLabels reproduces issue #2742.
+//
+// When a descriptor from an external registry has "labels":[] in its v2 JSON,
+// json.Unmarshal produces Labels=[]v2.Label{} (non-nil empty). ConvertFromV2Labels
+// propagates this as []descriptor.Label{} (non-nil). ConvertToV2 converts back to
+// []v2.Label{} but json:"labels,omitempty" omits it from the marshaled JSON — so the
+// CEL environment has no "labels" field. But buildDescriptorSpec's old `!= nil` check
+// emits ${environment.X.component.labels}, and CEL compilation fails:
+//   "undefined field 'labels'"
+//
+// Fix: use len() != 0 instead of != nil.
+func TestBuildAndCheck_Reproduce2742_EmptyNonNilLabels(t *testing.T) {
+	sourceRepo := testOCIRepo("ghcr.io/source")
+	targetRepo := testOCIRepo("ghcr.io/target")
+
+	// Descriptor with empty non-nil Labels and a resource so buildDescriptorSpec
+	// takes the per-field path (not the fast ${environment.X} single-ref path).
+	desc := testDescriptor("ocm.software/test", "1.0.0",
+		[]descriptor.Resource{localBlobResource("blob", "1.0.0")}, nil)
+	desc.Component.Labels = []descriptor.Label{} // non-nil empty — as from external registry
+
+	resolver := testResolverFor("ocm.software/test", "1.0.0", sourceRepo, desc)
+	roots := testTransferRoots("ocm.software/test", "1.0.0", targetRepo, resolver)
+
+	tgd, err := BuildGraphDefinition(t.Context(), roots, false, CopyModeLocalBlobResources, UploadAsDefault)
+	require.NoError(t, err)
+
+	b := NewDefaultBuilder(nil, nil, nil)
+	_, err = b.BuildAndCheck(tgd)
+	require.NoError(t, err, "BuildAndCheck must not fail with 'undefined field' for empty Labels")
+}


### PR DESCRIPTION
#### What this PR does / why we need it

When a descriptor from an external registry has \`"labels":[]\` (or similar) in its v2 JSON, \`json.Unmarshal\` produces a non-nil empty slice. \`ConvertToV2\` preserves this, but \`json:"labels,omitempty"\` then omits it from the marshaled environment JSON — so the CEL environment has no \`labels\` field at all.

The old \`!= nil\` check in \`buildDescriptorSpec\` emitted \`\${environment.X.component.labels}\` for any non-nil slice, including empty ones. The CEL compiler then failed with:

\`\`\`
cannot compile expression "environment.X.component.labels": ERROR: undefined field 'labels'
\`\`\`

**Fix:** use \`len() != 0\` instead of \`!= nil\` for \`labels\`, \`repositoryContexts\`, \`sources\`, \`componentReferences\`, and \`signatures\` — so CEL placeholders are only emitted when the field actually has content and will therefore be present in the environment.

#### Which issue(s) this PR fixes

Fixes #2742

#### Test

Added \`TestBuildAndCheck_Reproduce2742_EmptyNonNilLabels\` in \`bindings/go/transfer/internal/graph_test.go\` which injects a descriptor with \`Labels = []Label{}\` through the mock resolver (bypassing CTF normalisation) and reproduces the exact CEL compile error from the issue.