### PR TITLE
chore: combine internal dependency bumps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -167,6 +167,8 @@
       matchPackageNames: [
         'ocm.software/open-component-model/**',
       ],
+      // Combine minor and patch updates into a single PR.
+      separateMinorPatch: false,
       'schedule': [
         '* 22,0-6 * * *' // At every minute past hour 22 and every hour from 0 through 6.
       ],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Currently, we create at least one PR for bumping all the pseudo-versions and one PR for every patch-update of our modules. This PR would combine those PRs. I ran a [test](https://github.com/frewilhelm/open-component-model/pull/330) on my fork which looks fine.

