### PR TITLE
chore(website): add vanity URL for bindings/go/http module

### DIFF
--- a/website/static/open-component-model/bindings/go/http
+++ b/website/static/open-component-model/bindings/go/http
@@ -1,0 +1,10 @@
+<html><head>
+  <meta name="go-import"
+        content="ocm.software/open-component-model
+                 git https://github.com/open-component-model/open-component-model">
+  <meta name="go-source"
+        content="ocm.software/open-component-model
+                 https://github.com/open-component-model/open-component-model
+                 https://github.com/open-component-model/open-component-model/tree/main{/dir}
+                 https://github.com/open-component-model/open-component-model/blob/main{/dir}/{file}#L{line}">
+</head></html>


### PR DESCRIPTION
## Summary

Adds vanity URL static file for the \`bindings/go/http\` module so that \`go get ocm.software/open-component-model/bindings/go/http\` resolves correctly via the ocm.software domain.

- Adds \`website/static/open-component-model/bindings/go/http\` with standard \`go-import\` and \`go-source\` meta tags
- Follows identical format to all sibling vanity URL files (blob, cel, helm, oci, etc.)

## Test plan

- [ ] CI passes (static file addition, no code changes)
- [ ] After merge: \`go get ocm.software/open-component-model/bindings/go/http@latest\` resolves correctly