### PR TITLE
chore: prep lint config for golangci-lint v2.12

### DIFF
--- a/bindings/go/descriptor/normalisation/json/v4alpha1/normalisation.go
+++ b/bindings/go/descriptor/normalisation/json/v4alpha1/normalisation.go
@@ -16,6 +16,9 @@ const (
 	NoneLegacyType = "None"
 )
 
+// labelsKey is the descriptor field name carrying labels.
+const labelsKey = "labels"
+
 // Algorithm is the registered name for this normalisation algorithm.
 // It is used to identify and retrieve this specific normalisation implementation
 // from the normalisation registry.
@@ -49,27 +52,27 @@ var ExclusionRules = jcs.MapExcludes{
 		"provider": jcs.MapValue{
 			Mapping: ProviderAsMap,
 			Continue: jcs.MapExcludes{
-				"labels": LabelExcludes,
+				labelsKey: LabelExcludes,
 			},
 		},
-		"labels": LabelExcludes,
+		labelsKey: LabelExcludes,
 		"resources": jcs.DynamicArrayExcludes{
 			ValueMapper: MapResourcesWithNoneAccess,
 			Continue: jcs.MapExcludes{
 				"access":  nil,
 				"srcRefs": nil,
-				"labels":  LabelExcludes,
+				labelsKey: LabelExcludes,
 			},
 		},
 		"sources": jcs.ArrayExcludes{
 			Continue: jcs.MapExcludes{
-				"access": nil,
-				"labels": LabelExcludes,
+				"access":  nil,
+				labelsKey: LabelExcludes,
 			},
 		},
 		"references": jcs.ArrayExcludes{
 			Continue: jcs.MapExcludes{
-				"labels": LabelExcludes,
+				labelsKey: LabelExcludes,
 			},
 		},
 	},

--- a/golangci.yml
+++ b/golangci.yml
@@ -32,6 +32,7 @@ linters:
     - godot
     - godox
     - gomoddirectives
+    - gomodguard # deprecated alias since golangci-lint v2.12.0; gomodguard_v2 is enabled via `default: all`
     - inamedparam
     - interfacebloat
     - intrange


### PR DESCRIPTION
## Summary

Two small lint-config fixes that unblock the Renovate bump to `golangci-lint` v2.12.2 (#2687):

- **`bindings/go/descriptor/normalisation/json/v4alpha1/normalisation.go`** — extract the repeated `"labels"` map key into a `labelsKey` constant. v2.12.0 extended `goconst` detection so the existing 5 occurrences now trip the linter (`issues-exit-code: 2` → red CI).
- **`golangci.yml`** — disable the deprecated `gomodguard` linter. Since v2.12.0 it's been replaced by `gomodguard_v2`, which we get for free via `linters.default: all`. Without this, every lint run logs a deprecation warning.

After this lands, Renovate will rebase #2687 and it should go green on its own.

## Test plan

- [x] `golangci-lint run` (v2.12.2) on the previously-failing `bindings/go/descriptor/normalisation` module — `0 issues.`
- [x] Spot-checked `bindings/go/blob` and `bindings/go/configuration` — both clean, no `gomodguard` deprecation warning emitted.
- [ ] CI matrix lints all modules cleanly on this PR.