### PR TITLE
feat(oci): blob and resolution cache

### DIFF
--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/google/cel-go v0.29.2
 	github.com/google/go-github/v89 v89.0.0
+	github.com/hashicorp/golang-lru/v2 v2.0.5
 	github.com/invopop/jsonschema v0.14.0
 	github.com/nlepage/go-tarfs v1.2.1
 	github.com/opencontainers/go-digest v1.0.0

--- a/bindings/go/oci/cache/blob_cache.go
+++ b/bindings/go/oci/cache/blob_cache.go
@@ -1,0 +1,298 @@
+package cache
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/opencontainers/go-digest"
+	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sync/singleflight"
+	"oras.land/oras-go/v2/content"
+)
+
+// blobEntry is the LRU value for [BlobCache]. The on-disk path is
+// derived deterministically from the digest key via [pathFor]; storing
+// it on the entry keeps the eviction callback self-contained even if
+// the layout function changes.
+type blobEntry struct {
+	path string
+	size int64
+}
+
+// BlobCache is a digest-keyed, disk-backed LRU+TTL cache for small
+// immutable blobs (manifests and OCM component descriptors). All
+// methods are safe for concurrent use.
+//
+// On startup, [NewBlobCache] reseeds the LRU from any well-formed
+// digest-keyed files already present under [Options.Dir], so cached
+// entries survive a process restart with the same Dir. Stray files
+// (unparseable names, leftover .incoming-* temp files) are removed
+// during the seed pass.
+//
+// See package documentation for the design rationale and the link to
+// oras-go's proxy.go pattern that this cache is built to support.
+type BlobCache struct {
+	opts   Options
+	logger *slog.Logger
+	lru    *expirable.LRU[digest.Digest, blobEntry]
+
+	// sf collapses concurrent upstream fetches for the same digest into
+	// a single round-trip. Because cached blobs are small (manifests
+	// and descriptors, bounded by [Options.MaxBlobSize]), the shared
+	// result is buffered in memory and each waiter is served its own
+	// reader over those bytes.
+	sf singleflight.Group
+}
+
+// NewBlobCache constructs a [BlobCache]. [Options.Dir] is required;
+// other zero-valued fields fall back to [Defaults].
+//
+// The cache stores its files under `<Options.Dir>/blobs/<algo>/<hex>`
+// so the same Dir can also host a [ReferenceCache] (which writes
+// `<Dir>/refs/<sha256(namespace)>.json`) without collisions.
+func NewBlobCache(opts Options) (*BlobCache, error) {
+	opts, err := opts.applyDefaults()
+	if err != nil {
+		return nil, err
+	}
+	// Scope to a dedicated subdirectory so a shared Options.Dir does
+	// not entangle blob layout with anything else the caller stores
+	// at that path.
+	opts.Dir = filepath.Join(opts.Dir, "blobs")
+	if err := ensureDir(opts.Dir); err != nil {
+		return nil, fmt.Errorf("blobcache: %w", err)
+	}
+
+	c := &BlobCache{opts: opts, logger: slog.Default().With(slog.String("dir", opts.Dir))}
+	c.lru = expirable.NewLRU(opts.MaxEntries, c.onEvict, opts.TTL)
+
+	startScan := time.Now()
+	existing, err := scanExisting(opts.Dir)
+	if err != nil {
+		return nil, fmt.Errorf("blobcache: scan existing entries: %w", err)
+	}
+	totalSize := int64(0)
+	for _, e := range existing {
+		c.lru.Add(e.digest, blobEntry{path: e.path, size: e.size})
+		totalSize += e.size
+	}
+	if len(existing) > 0 {
+		c.logger.Debug("blobcache: seeded from disk",
+			slog.Int("count", len(existing)),
+			slog.Duration("duration", time.Since(startScan)),
+			slog.Int64("size", totalSize))
+	}
+	return c, nil
+}
+
+// Accept reports whether desc should be cached, per [Options.Accept].
+// The full descriptor is fed to the admission filter (not just the
+// media type) so future extensions can key on annotations, size, or
+// artifact type without a breaking signature change.
+func (c *BlobCache) Accept(desc ociImageSpecV1.Descriptor) bool {
+	return c.opts.Accept(desc)
+}
+
+// MaxBlobSize returns the configured per-blob size cap (0 means no cap).
+func (c *BlobCache) MaxBlobSize() int64 {
+	return c.opts.MaxBlobSize
+}
+
+// Has reports whether dgst is currently cached without affecting LRU
+// recency.
+func (c *BlobCache) Has(dgst digest.Digest) bool {
+	_, ok := c.lru.Peek(dgst)
+	return ok
+}
+
+// Get returns an open file positioned at offset 0 if dgst is cached.
+// The caller is responsible for closing the returned file. A miss
+// returns (nil, false, nil).
+//
+// If the LRU has the entry but the on-disk file is missing (e.g. the
+// user removed the cache directory), the entry is evicted and the
+// call returns a miss.
+func (c *BlobCache) Get(dgst digest.Digest) (*os.File, bool, error) {
+	e, ok := c.lru.Get(dgst)
+	if !ok {
+		return nil, false, nil
+	}
+	f, err := os.Open(e.path)
+	if err != nil {
+		c.lru.Remove(dgst)
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("blobcache: open cached file: %w", err)
+	}
+	return f, true, nil
+}
+
+// populate writes r to disk under dgst and inserts the entry into the
+// LRU. It is a no-op (returns false, nil) when:
+//
+//   - [Options.MaxBlobSize] > 0 and size exceeds it.
+//   - The blob copied does not match size (when size > 0). This guards
+//     against truncated reads from early-Close on the upstream reader.
+//
+// Concurrent calls for the same digest race on the final [os.Rename];
+// the last winner wins. Both yield byte-identical content (the digest
+// is the key) so the LRU bookkeeping is harmless. Callers that want
+// to avoid duplicate upstream fetches must dedupe at a higher layer
+// (see [BlobCache.Fetch], which uses singleflight for exactly this).
+//
+// The boolean return value reports whether the blob was actually
+// inserted into the LRU (true) or skipped (false).
+func (c *BlobCache) populate(ctx context.Context, dgst digest.Digest, size int64, r io.Reader) (bool, error) {
+	if c.opts.MaxBlobSize > 0 && size > c.opts.MaxBlobSize {
+		c.logger.DebugContext(ctx, "blobcache: skipping oversized blob",
+			slog.String("digest", dgst.String()),
+			slog.Int64("size", size),
+			slog.Int64("max", c.opts.MaxBlobSize))
+		// Drain r so the upstream pipe writer doesn't block forever
+		// waiting for someone to read it.
+		_, _ = io.Copy(io.Discard, r)
+		return false, nil
+	}
+
+	path, n, err := writeAtomic(c.opts.Dir, dgst, c.opts.MaxBlobSize, r)
+	if err != nil {
+		return false, err
+	}
+	if size > 0 && n != size {
+		if rerr := removeQuiet(path); rerr != nil {
+			c.logger.WarnContext(ctx, "blobcache: remove truncated entry failed",
+				slog.String("digest", dgst.String()), slog.String("err", rerr.Error()))
+		}
+		return false, fmt.Errorf("blobcache: short read: got %d, want %d", n, size)
+	}
+	c.lru.Add(dgst, blobEntry{path: path, size: n})
+	c.logger.DebugContext(ctx, "blobcache: populated",
+		slog.String("digest", dgst.String()), slog.Int64("size", n))
+	return true, nil
+}
+
+// Fetch is the cache-aware Fetch primitive used by store
+// implementations that want to layer the cache in front of an
+// upstream [content.ReadOnlyStorage]. A cache hit returns the on-disk
+// file directly; a miss reads the (small) blob from upstream
+// verifying its digest, records it to disk, and serves the caller
+// from the in-memory copy.
+//
+// Fetch honors [Options.Accept] and [Options.MaxBlobSize]: if the
+// descriptor fails either filter (or c is nil), the call falls
+// straight through to upstream.Fetch and nothing is buffered. In the
+// oversize case a debug log is emitted so operators can see why the
+// cache did not engage.
+//
+// Concurrent Fetches for the same digest are collapsed via
+// singleflight into a single upstream.Fetch; every caller receives an
+// independent reader over identical bytes.
+func (c *BlobCache) Fetch(ctx context.Context, upstream content.ReadOnlyStorage, target ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+	if c == nil || !c.Accept(target) {
+		return upstream.Fetch(ctx, target)
+	}
+	if c.MaxBlobSize() > 0 && target.Size > c.MaxBlobSize() {
+		c.logger.DebugContext(ctx, "blobcache: skipping oversized descriptor, falling through",
+			slog.String("digest", target.Digest.String()),
+			slog.Int64("size", target.Size),
+			slog.Int64("max", c.MaxBlobSize()))
+		return upstream.Fetch(ctx, target)
+	}
+
+	if f, hit, err := c.Get(target.Digest); err != nil {
+		c.logger.DebugContext(ctx, "blobcache: get failed, falling through",
+			slog.String("digest", target.Digest.String()), slog.String("err", err.Error()))
+	} else if hit {
+		if c.opts.RemotePolicy == RemotePolicyAlways {
+			ok, err := upstream.Exists(ctx, target)
+			if err != nil {
+				_ = f.Close()
+				return nil, fmt.Errorf("blobcache: verify remote access: %w", err)
+			}
+			if !ok {
+				_ = f.Close()
+				return nil, fmt.Errorf("blobcache: remote does not contain or allow access to %s", target.Digest)
+			}
+		}
+		c.logger.DebugContext(ctx, "blobcache: hit",
+			slog.String("digest", target.Digest.String()), slog.Int64("size", target.Size))
+		return f, nil
+	}
+
+	// Miss: collapse concurrent fetches for the same digest into one
+	// upstream round-trip. The leader fetches the blob fully via
+	// [content.FetchAll], which streams through a VerifyReader so the
+	// bytes are hashed against target.Digest before we ever put them
+	// on disk. The verified bytes are then persisted (best-effort) and
+	// every waiter is served an independent reader over that copy.
+	//
+	// We use DoChan instead of Do so that each caller can return on its
+	// own context cancellation while the shared fetch continues for any
+	// remaining waiters. The fetch itself runs under context.Background
+	// so it is not tied to any single caller's lifetime.
+	//
+	// Trade-off: if every caller cancels before the fetch completes the
+	// upstream round-trip continues to completion with no one to receive
+	// the result. For this cache (small manifests, bounded by
+	// MaxBlobSize, registry upstreams with their own timeouts) that is
+	// acceptable. A ref-counted shared context that cancels when the
+	// last waiter leaves would be the more principled alternative.
+	fetchCtx := context.Background()
+	ch := c.sf.DoChan(target.Digest.String(), func() (any, error) {
+		c.logger.Debug("blobcache: singleflight leader: starting upstream fetch",
+			slog.String("digest", target.Digest.String()))
+		data, err := content.FetchAll(fetchCtx, upstream, target)
+		if err != nil {
+			return nil, fmt.Errorf("blobcache: fetch upstream: %w", err)
+		}
+		// populate is best-effort: a failure to persist must not fail
+		// the fetch, since we already hold the verified bytes to serve
+		// the caller.
+		if _, perr := c.populate(fetchCtx, target.Digest, target.Size, bytes.NewReader(data)); perr != nil {
+			c.logger.DebugContext(ctx, "blobcache: populate failed, serving from memory",
+				slog.String("digest", target.Digest.String()), slog.String("err", perr.Error()))
+		}
+		return data, nil
+	})
+	select {
+	case <-ctx.Done():
+		c.logger.DebugContext(ctx, "blobcache: caller canceled while waiting for fetch",
+			slog.String("digest", target.Digest.String()),
+			slog.String("err", ctx.Err().Error()))
+		return nil, ctx.Err()
+	case res := <-ch:
+		if res.Err != nil {
+			return nil, res.Err
+		}
+		if res.Shared {
+			c.logger.DebugContext(ctx, "blobcache: singleflight: result shared across concurrent callers",
+				slog.String("digest", target.Digest.String()))
+		}
+		return io.NopCloser(bytes.NewReader(res.Val.([]byte))), nil
+	}
+}
+
+// onEvict is the LRU's eviction callback. It removes the on-disk file
+// for the evicted entry. Errors are logged at WARN — eviction must
+// not block.
+func (c *BlobCache) onEvict(dgst digest.Digest, e blobEntry) {
+	if err := removeQuiet(e.path); err != nil {
+		c.logger.Warn("blobcache: evict file remove failed",
+			slog.String("digest", dgst.String()),
+			slog.String("path", e.path),
+			slog.String("err", err.Error()))
+		return
+	}
+	c.logger.Debug("blobcache: evicted",
+		slog.String("digest", dgst.String()),
+		slog.Int64("size", e.size))
+}

--- a/bindings/go/oci/cache/cache_test.go
+++ b/bindings/go/oci/cache/cache_test.go
@@ -1,0 +1,401 @@
+package cache
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/opencontainers/go-digest"
+	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/registry"
+)
+
+func newTestCache(t *testing.T, opts Options) *BlobCache {
+	t.Helper()
+	if opts.Dir == "" {
+		opts.Dir = filepath.Join(t.TempDir(), "blobcache")
+	}
+	if opts.Accept == nil {
+		opts.Accept = DefaultAccept
+	}
+	if opts.RemotePolicy == "" {
+		opts.RemotePolicy = RemotePolicyIfNotPresent
+	}
+	c, err := NewBlobCache(opts)
+	require.NoError(t, err)
+	return c
+}
+
+func TestNew_RequiresDir(t *testing.T) {
+	_, err := NewBlobCache(Options{})
+	require.Error(t, err)
+}
+
+func TestCache_HitMiss(t *testing.T) {
+	c := newTestCache(t, Options{})
+
+	data := []byte("manifest-bytes")
+	dgst := digest.FromBytes(data)
+
+	assert.False(t, c.Has(dgst))
+	f, hit, err := c.Get(dgst)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Nil(t, f)
+
+	inserted, err := c.populate(t.Context(), dgst, int64(len(data)), bytes.NewReader(data))
+	require.NoError(t, err)
+	assert.True(t, inserted)
+	assert.True(t, c.Has(dgst))
+
+	f, hit, err = c.Get(dgst)
+	require.NoError(t, err)
+	require.True(t, hit)
+	defer f.Close()
+	got, err := io.ReadAll(f)
+	require.NoError(t, err)
+	assert.Equal(t, data, got)
+}
+
+func TestCache_TTLExpiry(t *testing.T) {
+	c := newTestCache(t, Options{TTL: 50 * time.Millisecond})
+	data := []byte("ttl-bytes")
+	dgst := digest.FromBytes(data)
+
+	_, err := c.populate(t.Context(), dgst, int64(len(data)), bytes.NewReader(data))
+	require.NoError(t, err)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if !c.Has(dgst) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	assert.False(t, c.Has(dgst), "entry must be evicted after TTL")
+
+	// File on disk must be gone too.
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		_, err := os.Stat(pathFor(c.opts.Dir, dgst))
+		if err != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	_, err = os.Stat(pathFor(c.opts.Dir, dgst))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+}
+
+func TestCache_LRUOverflow(t *testing.T) {
+	c := newTestCache(t, Options{MaxEntries: 2})
+	ctx := t.Context()
+
+	d1 := digest.FromBytes([]byte("a"))
+	d2 := digest.FromBytes([]byte("b"))
+	d3 := digest.FromBytes([]byte("c"))
+
+	_, err := c.populate(ctx, d1, 1, bytes.NewReader([]byte("a")))
+	require.NoError(t, err)
+	_, err = c.populate(ctx, d2, 1, bytes.NewReader([]byte("b")))
+	require.NoError(t, err)
+	_, err = c.populate(ctx, d3, 1, bytes.NewReader([]byte("c")))
+	require.NoError(t, err)
+
+	assert.False(t, c.Has(d1), "oldest must be evicted")
+	assert.True(t, c.Has(d2))
+	assert.True(t, c.Has(d3))
+
+	// File of evicted d1 must be gone on disk too.
+	_, err = os.Stat(pathFor(c.opts.Dir, d1))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+}
+
+func TestCache_SizeCap(t *testing.T) {
+	c := newTestCache(t, Options{MaxBlobSize: 4})
+	dgst := digest.FromBytes([]byte("0123456789"))
+
+	inserted, err := c.populate(t.Context(), dgst, 10, bytes.NewReader([]byte("0123456789")))
+	require.NoError(t, err)
+	assert.False(t, inserted, "populate must skip blobs above MaxBlobSize")
+	assert.False(t, c.Has(dgst))
+
+	_, err = os.Stat(pathFor(c.opts.Dir, dgst))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+}
+
+func TestCache_TruncatedReadDiscarded(t *testing.T) {
+	c := newTestCache(t, Options{})
+	dgst := digest.FromBytes([]byte("expected-bytes"))
+
+	// Claim size=14 but feed only 4 bytes — populate must reject.
+	inserted, err := c.populate(t.Context(), dgst, 14, bytes.NewReader([]byte("abcd")))
+	require.Error(t, err)
+	assert.False(t, inserted)
+	assert.False(t, c.Has(dgst))
+	_, err = os.Stat(pathFor(c.opts.Dir, dgst))
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+}
+
+// countingReader counts bytes read so we can assert dedup-style
+// invariants in store-level tests.
+type countingReader struct {
+	r io.Reader
+	n atomic.Int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n.Add(int64(n))
+	return n, err
+}
+
+func TestCache_ConcurrentPopulate_AllSucceed(t *testing.T) {
+	c := newTestCache(t, Options{})
+	data := bytes.Repeat([]byte("x"), 1024)
+	dgst := digest.FromBytes(data)
+
+	// Each goroutine has its own reader (matches the io.Pipe-per-fetch
+	// shape in CachingStore.Fetch). They race on os.Rename; both
+	// produce identical content because the digest is the key.
+	const N = 8
+	var wg sync.WaitGroup
+	for range N {
+		wg.Go(func() {
+			_, err := c.populate(t.Context(), dgst, int64(len(data)), bytes.NewReader(data))
+			require.NoError(t, err)
+		})
+	}
+	wg.Wait()
+
+	assert.True(t, c.Has(dgst))
+	f, hit, err := c.Get(dgst)
+	require.NoError(t, err)
+	require.True(t, hit)
+	defer f.Close()
+	got, err := io.ReadAll(f)
+	require.NoError(t, err)
+	assert.Equal(t, data, got)
+}
+
+func TestCache_AcceptFilter(t *testing.T) {
+	cases := []struct {
+		mt   string
+		want bool
+	}{
+		{ociImageSpecV1.MediaTypeImageManifest, true},
+		{ociImageSpecV1.MediaTypeImageIndex, true},
+		{"application/vnd.docker.distribution.manifest.v2+json", true},
+		{"application/vnd.docker.distribution.manifest.list.v2+json", true},
+		{"application/vnd.ocm.software.component-descriptor.v2+json", true},
+		{"application/vnd.ocm.software.component-descriptor.v2+yaml", true},
+		{"application/vnd.ocm.software.component-descriptor.v1+yaml+tar", true},
+		{"application/octet-stream", false},
+		{ociImageSpecV1.MediaTypeImageLayerGzip, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.mt, func(t *testing.T) {
+			assert.Equal(t, tc.want, DefaultAccept(ociImageSpecV1.Descriptor{MediaType: tc.mt}))
+		})
+	}
+}
+
+func TestCache_GetFileVanished(t *testing.T) {
+	c := newTestCache(t, Options{})
+	data := []byte("vanish")
+	dgst := digest.FromBytes(data)
+	_, err := c.populate(t.Context(), dgst, int64(len(data)), bytes.NewReader(data))
+	require.NoError(t, err)
+
+	// Externally remove the file — Get must now report a miss and
+	// drop the entry.
+	require.NoError(t, os.Remove(pathFor(c.opts.Dir, dgst)))
+
+	f, hit, err := c.Get(dgst)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Nil(t, f)
+	assert.False(t, c.Has(dgst))
+}
+
+func TestCache_Reseed_FromExistingDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "blobcache")
+
+	c1, err := NewBlobCache(Options{Dir: dir, Accept: DefaultAccept})
+	require.NoError(t, err)
+	data := []byte("persistent")
+	dgst := digest.FromBytes(data)
+	_, err = c1.populate(t.Context(), dgst, int64(len(data)), bytes.NewReader(data))
+	require.NoError(t, err)
+	assert.True(t, c1.Has(dgst))
+
+	// Pretend the process restarts: drop c1 entirely and build a
+	// fresh BlobCache pointing at the same directory.
+	c2, err := NewBlobCache(Options{Dir: dir, Accept: DefaultAccept})
+	require.NoError(t, err)
+
+	assert.True(t, c2.Has(dgst), "reseeded cache must know about prior entries")
+	f, hit, err := c2.Get(dgst)
+	require.NoError(t, err)
+	require.True(t, hit)
+	defer f.Close()
+	got, err := io.ReadAll(f)
+	require.NoError(t, err)
+	assert.Equal(t, data, got)
+}
+
+func TestCache_Reseed_StripsBadFiles(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "blobcache")
+	// BlobCache scopes its files under <Dir>/blobs/<algo>/...
+	algo := filepath.Join(dir, "blobs", "sha256")
+	require.NoError(t, os.MkdirAll(algo, 0o700))
+	bad := filepath.Join(algo, "not-a-hex")
+	require.NoError(t, os.WriteFile(bad, []byte("x"), 0o600))
+	leftover := filepath.Join(algo, ".incoming-stale")
+	require.NoError(t, os.WriteFile(leftover, []byte("y"), 0o600))
+
+	_, err := NewBlobCache(Options{Dir: dir, Accept: DefaultAccept})
+	require.NoError(t, err)
+
+	for _, p := range []string{bad, leftover} {
+		_, err := os.Stat(p)
+		assert.ErrorIs(t, err, fs.ErrNotExist, "stray file %s must be removed", p)
+	}
+}
+
+// errReader returns the configured error on every Read.
+type errReader struct{ err error }
+
+func (r errReader) Read([]byte) (int, error) { return 0, r.err }
+
+func TestCache_New_RequiresDir(t *testing.T) {
+	_, err := NewBlobCache(Options{})
+	require.Error(t, err)
+}
+
+func TestCache_New_EnsureDirFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission semantics differ on windows")
+	}
+	parent := t.TempDir()
+	blocker := filepath.Join(parent, "blocker")
+	require.NoError(t, os.WriteFile(blocker, nil, 0o600))
+	_, err := NewBlobCache(Options{Dir: filepath.Join(blocker, "child")})
+	require.Error(t, err)
+}
+
+func TestCache_New_LoadReferencesMalformed(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "refcache")
+	refsDir := filepath.Join(dir, referenceSubdir)
+	require.NoError(t, os.MkdirAll(refsDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(refsDir, "garbage"+referenceFileExt), []byte("not json"), 0o600))
+
+	// Malformed snapshot is logged but does not abort construction.
+	c, err := NewReferenceCache(Options{Dir: dir})
+	require.NoError(t, err)
+	_, hit := c.Lookup(registry.Reference{Registry: "ghcr.io", Repository: "ns", Reference: "x"})
+	assert.False(t, hit)
+}
+
+func TestCache_New_LoadReferencesEmptyFile(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "refcache")
+	refsDir := filepath.Join(dir, referenceSubdir)
+	require.NoError(t, os.MkdirAll(refsDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(refsDir, "empty"+referenceFileExt), nil, 0o600))
+	_, err := NewReferenceCache(Options{Dir: dir})
+	require.NoError(t, err)
+}
+
+func TestCache_OnEvict_LogsButDoesNotPanic(t *testing.T) {
+	c := newTestCache(t, Options{})
+	// Manually invoke onEvict with a path that never existed; the
+	// callback must swallow the error path through removeQuiet
+	// (fs.ErrNotExist is silenced) without logging a warning.
+	c.onEvict(digest.FromBytes([]byte("x")), blobEntry{
+		path: filepath.Join(c.opts.Dir, "missing"),
+		size: 1,
+	})
+}
+
+func TestCache_OnEvict_WarnPathOnRemoveError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("non-empty dir remove semantics differ on windows")
+	}
+	c := newTestCache(t, Options{})
+	// removeQuiet returns an error when path is a non-empty dir.
+	dir := filepath.Join(t.TempDir(), "non-empty")
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "child"), nil, 0o600))
+
+	// Manually invoke the eviction callback with the bad path.
+	c.onEvict(digest.FromBytes([]byte("y")), blobEntry{path: dir, size: 1})
+}
+
+func TestCache_Populate_OversizeDrainsAndSkips(t *testing.T) {
+	c := newTestCache(t, Options{MaxBlobSize: 4})
+	dgst := digest.FromBytes([]byte("0123456789"))
+
+	cr := &countingReader{r: bytes.NewReader([]byte("0123456789"))}
+	inserted, err := c.populate(t.Context(), dgst, 10, cr)
+	require.NoError(t, err)
+	assert.False(t, inserted)
+	assert.False(t, c.Has(dgst))
+	// populate must drain so the producer side does not block.
+	assert.EqualValues(t, 10, cr.n.Load())
+}
+
+func TestCache_Populate_ReaderErrorIsReported(t *testing.T) {
+	c := newTestCache(t, Options{})
+	dgst := digest.FromBytes([]byte("x"))
+	_, err := c.populate(t.Context(), dgst, 4, errReader{err: errors.New("boom")})
+	require.Error(t, err)
+	assert.False(t, c.Has(dgst))
+}
+
+func TestCache_Get_StalePathBecomesMiss(t *testing.T) {
+	c := newTestCache(t, Options{})
+	dgst := digest.FromBytes([]byte("vanish"))
+	_, err := c.populate(t.Context(), dgst, 6, bytes.NewReader([]byte("vanish")))
+	require.NoError(t, err)
+	require.True(t, c.Has(dgst))
+
+	// Remove the underlying file out from under the cache.
+	require.NoError(t, os.Remove(pathFor(c.opts.Dir, dgst)))
+
+	f, hit, err := c.Get(dgst)
+	require.NoError(t, err)
+	assert.False(t, hit)
+	assert.Nil(t, f)
+	// Stale entry must have been dropped from the LRU.
+	assert.False(t, c.Has(dgst))
+}
+
+func TestCache_Get_NonNotExistErrorIsReturned(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("dir-as-file semantics differ on windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses permission bits")
+	}
+	c := newTestCache(t, Options{})
+	dgst := digest.FromBytes([]byte("dirtrick"))
+	_, err := c.populate(t.Context(), dgst, 8, bytes.NewReader([]byte("dirtrick")))
+	require.NoError(t, err)
+	parent := filepath.Dir(pathFor(c.opts.Dir, dgst))
+	require.NoError(t, os.Chmod(parent, 0))
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o700) })
+
+	_, hit, err := c.Get(dgst)
+	require.Error(t, err)
+	assert.False(t, hit)
+}

--- a/bindings/go/oci/cache/disk.go
+++ b/bindings/go/oci/cache/disk.go
@@ -1,0 +1,171 @@
+package cache
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/opencontainers/go-digest"
+)
+
+// pathFor returns the deterministic on-disk path for a cached entry.
+// The layout is dir/<algorithm>/<hex>, e.g. dir/sha256/abcd...ef.
+func pathFor(dir string, dgst digest.Digest) string {
+	return filepath.Join(dir, dgst.Algorithm().String(), dgst.Encoded())
+}
+
+// writeAtomic streams r into a fresh temp file under dir, fsyncs it,
+// and renames it into pathFor(dir, dgst). It returns the final path
+// and the number of bytes copied.
+//
+// If maxSize > 0 and the copied byte count exceeds maxSize, the temp
+// file is removed and an error is returned. The destination file is
+// never created in that case. The LimitReader stops the copy at
+// maxSize+1 so oversize is detectable without draining unbounded
+// upstream data; when called from [BlobCache.Fetch] the bytes are
+// already in memory and this check is redundant but cheap, but the
+// bound also protects any direct caller that streams straight from
+// upstream.
+//
+// Concurrent writers for the same digest race on the rename; the last
+// rename wins. Both yield identical content, so the LRU bookkeeping is
+// expected to dedupe via singleflight before reaching writeAtomic.
+func writeAtomic(dir string, dgst digest.Digest, maxSize int64, r io.Reader) (string, int64, error) {
+	if err := dgst.Validate(); err != nil {
+		return "", 0, fmt.Errorf("invalid digest: %w", err)
+	}
+
+	final := pathFor(dir, dgst)
+	algoDir := filepath.Dir(final)
+	if err := os.MkdirAll(algoDir, 0o700); err != nil {
+		return "", 0, fmt.Errorf("create algo dir: %w", err)
+	}
+
+	// Create the temp file inside the algorithm subdirectory (next to
+	// its final destination) rather than the cache root. This keeps the
+	// rename on the same directory and, crucially, places leftover
+	// `.incoming-*` files from a crashed write where scanExisting looks
+	// for them so they are reclaimed on the next startup.
+	tmp, err := os.CreateTemp(algoDir, ".incoming-*")
+	if err != nil {
+		return "", 0, fmt.Errorf("create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+	}
+
+	if maxSize > 0 {
+		// LimitReader stops at maxSize+1 so we can detect oversize
+		// without reading unbounded amounts.
+		r = io.LimitReader(r, maxSize+1)
+	}
+	n, err := io.Copy(tmp, r)
+	if err != nil {
+		cleanup()
+		return "", 0, fmt.Errorf("copy to temp file: %w", err)
+	}
+	if maxSize > 0 && n > maxSize {
+		cleanup()
+		return "", 0, fmt.Errorf("blob exceeds max size %d", maxSize)
+	}
+
+	if err := tmp.Sync(); err != nil {
+		cleanup()
+		return "", 0, fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return "", 0, fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, final); err != nil {
+		_ = os.Remove(tmpName)
+		return "", 0, fmt.Errorf("rename temp file: %w", err)
+	}
+	return final, n, nil
+}
+
+// removeQuiet removes path and silently ignores fs.ErrNotExist. Other
+// errors are returned so the caller can log them.
+func removeQuiet(path string) error {
+	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+// ensureDir creates dir (and any missing parents) with 0o700
+// permissions. It is a no-op if dir already exists.
+func ensureDir(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("ensure dir: %w", err)
+	}
+	return nil
+}
+
+// scanExisting walks dir and yields every file that already lives at
+// the canonical pathFor layout (dir/<algorithm>/<hex>). Files with
+// unparseable names or that fail [digest.Validate] are removed so the
+// cache does not carry over corruption from a previous run. The
+// returned entries are not sorted.
+func scanExisting(dir string) ([]existingEntry, error) {
+	algoDirs, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read cache dir: %w", err)
+	}
+	var out []existingEntry
+	for _, ad := range algoDirs {
+		if !ad.IsDir() {
+			continue
+		}
+		algo := ad.Name()
+		algoPath := filepath.Join(dir, algo)
+		entries, err := os.ReadDir(algoPath)
+		if err != nil {
+			return nil, fmt.Errorf("read algo dir %q: %w", algoPath, err)
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			name := e.Name()
+			// Skip stray temp files left from a crashed write.
+			if strings.HasPrefix(name, ".incoming-") {
+				_ = os.Remove(filepath.Join(algoPath, name))
+				continue
+			}
+			dgst := digest.NewDigestFromEncoded(digest.Algorithm(algo), name)
+			if err := dgst.Validate(); err != nil {
+				// unrecognised file; drop it so the cache directory
+				// stays a clean digest-keyed store.
+				_ = os.Remove(filepath.Join(algoPath, name))
+				continue
+			}
+			info, err := e.Info()
+			if err != nil {
+				continue
+			}
+			out = append(out, existingEntry{
+				digest: dgst,
+				path:   filepath.Join(algoPath, name),
+				size:   info.Size(),
+			})
+		}
+	}
+	return out, nil
+}
+
+// existingEntry describes a file discovered by [scanExisting].
+type existingEntry struct {
+	digest digest.Digest
+	path   string
+	size   int64
+}

--- a/bindings/go/oci/cache/disk_test.go
+++ b/bindings/go/oci/cache/disk_test.go
@@ -1,0 +1,269 @@
+package cache
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteAtomic_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("hello world")
+	dgst := digest.FromBytes(data)
+
+	path, n, err := writeAtomic(dir, dgst, 0, bytes.NewReader(data))
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(data)), n)
+	assert.Equal(t, pathFor(dir, dgst), path)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, data, got)
+}
+
+func TestWriteAtomic_NoTempLeak_OnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("ok")
+	dgst := digest.FromBytes(data)
+
+	_, _, err := writeAtomic(dir, dgst, 0, bytes.NewReader(data))
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.False(t, strings.HasPrefix(e.Name(), ".incoming-"),
+			"leftover temp file %s", e.Name())
+	}
+}
+
+type erroringReader struct{ after int }
+
+func (r *erroringReader) Read(p []byte) (int, error) {
+	if r.after <= 0 {
+		return 0, errors.New("boom")
+	}
+	n := r.after
+	if n > len(p) {
+		n = len(p)
+	}
+	for i := 0; i < n; i++ {
+		p[i] = 'x'
+	}
+	r.after -= n
+	return n, nil
+}
+
+func TestWriteAtomic_NoTempLeak_OnError(t *testing.T) {
+	dir := t.TempDir()
+	dgst := digest.FromBytes([]byte("anything"))
+
+	_, _, err := writeAtomic(dir, dgst, 0, &erroringReader{after: 4})
+	require.Error(t, err)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.False(t, strings.HasPrefix(e.Name(), ".incoming-"),
+			"leftover temp file %s", e.Name())
+	}
+	_, err = os.Stat(pathFor(dir, dgst))
+	assert.True(t, errors.Is(err, fs.ErrNotExist), "final file must not exist on error")
+}
+
+func TestWriteAtomic_TempLivesInAlgoDir(t *testing.T) {
+	dir := t.TempDir()
+	dgst := digest.FromBytes([]byte("anything"))
+
+	// Fail mid-write and capture where the temp file was created by
+	// scanning both the cache root and the algo subdir. The temp must
+	// live in the algo subdir (next to its final destination) so that
+	// scanExisting reclaims a leftover after a crash.
+	sawTempInAlgo := false
+	r := &probeReader{after: 4, onRead: func() {
+		algo := filepath.Join(dir, digest.Canonical.String())
+		if entries, err := os.ReadDir(algo); err == nil {
+			for _, e := range entries {
+				if strings.HasPrefix(e.Name(), ".incoming-") {
+					sawTempInAlgo = true
+				}
+			}
+		}
+		// The cache root must never hold the temp file.
+		if entries, err := os.ReadDir(dir); err == nil {
+			for _, e := range entries {
+				assert.False(t, strings.HasPrefix(e.Name(), ".incoming-"),
+					"temp file must not be created in the cache root")
+			}
+		}
+	}}
+
+	_, _, err := writeAtomic(dir, dgst, 0, r)
+	require.Error(t, err)
+	assert.True(t, sawTempInAlgo, "temp file must be created inside the algo subdir")
+}
+
+// probeReader yields `after` bytes, invokes onRead, then errors. It
+// lets a test observe on-disk state while a write is in flight.
+type probeReader struct {
+	after  int
+	onRead func()
+	fired  bool
+}
+
+func (r *probeReader) Read(p []byte) (int, error) {
+	if r.after <= 0 {
+		if !r.fired {
+			r.fired = true
+			if r.onRead != nil {
+				r.onRead()
+			}
+		}
+		return 0, errors.New("boom")
+	}
+	n := r.after
+	if n > len(p) {
+		n = len(p)
+	}
+	for i := 0; i < n; i++ {
+		p[i] = 'x'
+	}
+	r.after -= n
+	return n, nil
+}
+
+func TestWriteAtomic_SizeCap(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte("0123456789")
+	dgst := digest.FromBytes(data)
+
+	_, _, err := writeAtomic(dir, dgst, 4, bytes.NewReader(data))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds max size")
+
+	// Final file must not exist.
+	_, err = os.Stat(pathFor(dir, dgst))
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
+
+	// And no temp file left behind.
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.False(t, strings.HasPrefix(e.Name(), ".incoming-"))
+	}
+}
+
+func TestWriteAtomic_InvalidDigest(t *testing.T) {
+	dir := t.TempDir()
+	_, _, err := writeAtomic(dir, digest.Digest("not-a-digest"), 0, bytes.NewReader(nil))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid digest")
+}
+
+func TestEnsureDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "deep")
+	require.NoError(t, ensureDir(dir))
+	info, err := os.Stat(dir)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+
+	// Idempotent.
+	require.NoError(t, ensureDir(dir))
+}
+
+func TestRemoveQuiet(t *testing.T) {
+	// missing path: no error
+	assert.NoError(t, removeQuiet(filepath.Join(t.TempDir(), "missing")))
+
+	// existing path: removed
+	dir := t.TempDir()
+	p := filepath.Join(dir, "f")
+	require.NoError(t, os.WriteFile(p, []byte("x"), 0o600))
+	require.NoError(t, removeQuiet(p))
+	_, err := os.Stat(p)
+	assert.True(t, errors.Is(err, fs.ErrNotExist))
+}
+
+// helper used in store_test.go too
+var _ io.Reader = (*erroringReader)(nil)
+
+func TestRemoveQuiet_NotFoundIsNotAnError(t *testing.T) {
+	require.NoError(t, removeQuiet(filepath.Join(t.TempDir(), "missing")))
+}
+
+func TestRemoveQuiet_PropagatesOtherErrors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("dir-remove semantics differ on windows")
+	}
+	dir := t.TempDir()
+	// Removing a non-empty directory returns an error other than ErrNotExist.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "child"), nil, 0o600))
+	err := removeQuiet(dir)
+	require.Error(t, err)
+}
+
+func TestEnsureDir_FailsOnFileInPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission semantics differ on windows")
+	}
+	parent := t.TempDir()
+	blocker := filepath.Join(parent, "blocker")
+	require.NoError(t, os.WriteFile(blocker, nil, 0o600))
+	err := ensureDir(filepath.Join(blocker, "x"))
+	require.Error(t, err)
+}
+
+func TestScanExisting_RemovesIncomingAndBadFiles(t *testing.T) {
+	dir := t.TempDir()
+	algoDir := filepath.Join(dir, "sha256")
+	require.NoError(t, os.MkdirAll(algoDir, 0o700))
+
+	stale := filepath.Join(algoDir, ".incoming-stale")
+	bad := filepath.Join(algoDir, "not-a-hex")
+	require.NoError(t, os.WriteFile(stale, []byte("x"), 0o600))
+	require.NoError(t, os.WriteFile(bad, []byte("y"), 0o600))
+
+	good := digest.FromBytes([]byte("ok"))
+	goodPath := pathFor(dir, good)
+	require.NoError(t, os.WriteFile(goodPath, []byte("ok"), 0o600))
+
+	entries, err := scanExisting(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, good, entries[0].digest)
+
+	for _, p := range []string{stale, bad} {
+		_, err := os.Stat(p)
+		assert.ErrorIs(t, err, fs.ErrNotExist, "stray %s must be removed", p)
+	}
+}
+
+func TestScanExisting_MissingDirIsNoOp(t *testing.T) {
+	entries, err := scanExisting(filepath.Join(t.TempDir(), "missing"))
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestScanExisting_AlgoReadDirFails(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("permission bits do not block root or windows")
+	}
+	dir := t.TempDir()
+	algo := filepath.Join(dir, "sha256")
+	require.NoError(t, os.MkdirAll(algo, 0o700))
+	require.NoError(t, os.Chmod(algo, 0))
+	t.Cleanup(func() { _ = os.Chmod(algo, 0o700) })
+
+	_, err := scanExisting(dir)
+	require.Error(t, err)
+}

--- a/bindings/go/oci/cache/doc.go
+++ b/bindings/go/oci/cache/doc.go
@@ -1,0 +1,83 @@
+// Package cache provides two disk-backed, TTL+LRU caches that layer
+// on top of an oras [*remote.Repository] via [Repository]:
+//
+//   - [BlobCache] keys cached blobs by digest and stores each blob as
+//     a file under `<Options.Dir>/blobs/<algo>/<hex>`. Its primary
+//     consumer is [BlobCache.Fetch], which mirrors the oras-go
+//     internal/cas/proxy.go pattern: the first Fetch of a descriptor
+//     reads from upstream and tees the bytes to disk; subsequent
+//     Fetches for the same digest serve the on-disk file. Push, Tag,
+//     Resolve, FetchReference, and Exists on the wrapping
+//     [Repository] are pure passthroughs.
+//
+//   - [ReferenceCache] keys cached resolves by (namespace, reference)
+//     so two repositories that happen to share a short reference
+//     (e.g. the tag "v1") cannot collide. Each namespace's entries
+//     are persisted to its own file under
+//     `<Options.Dir>/refs/<sha256(namespace)>.json`; the SHA-256
+//     digest is used purely to derive a compact, collision-free
+//     filename — the canonical namespace string is stored inside the
+//     snapshot body so a reseed recovers the exact key without
+//     trusting the filename to preserve it.
+//
+// Both caches share an [Options] struct so a caller can configure
+// limits once and instantiate either or both. The blob-only fields
+// ([Options.MaxBlobSize] and [Options.Accept]) are ignored by
+// [ReferenceCache].
+//
+// Credential scoping:
+//
+//   - [ScopeKey] returns a short, filesystem-safe hash of the
+//     (registry identity, credential) pair. Callers that share a
+//     cache directory across multiple credential sets should compose
+//     [Options.Dir] with the [ScopeKey] so tag→descriptor mappings
+//     resolved under one credential cannot leak into another. The
+//     content-addressed [BlobCache] does not need this scoping
+//     because blobs are identified by digest, but the tag-mutable
+//     [ReferenceCache] does — see the provider package for the
+//     canonical wiring.
+//
+// Scope and intent:
+//
+//   - [BlobCache] is intentionally narrow: by default it only caches
+//     OCI/Docker manifests and OCM component-descriptor blobs
+//     (configurable via [Options.Accept]). Layer blobs and arbitrary
+//     octet streams are not cached so disk usage stays bounded by
+//     descriptor metadata size.
+//
+//   - [ReferenceCache] is unconditional within its namespace: every
+//     successful upstream resolve is recorded.
+//
+// Lifecycle and isolation:
+//
+//   - Each cache owns one or more subdirectories of [Options.Dir]
+//     ([BlobCache]: `blobs/`; [ReferenceCache]: `refs/`). Sharing the
+//     same Dir between both caches is therefore safe; they do not
+//     collide on the filesystem.
+//   - Cache directories are persistent: callers should pass a stable
+//     path so a future run with the same Dir reuses the existing
+//     content. Neither cache provides a Close method; both reseed
+//     their LRUs from the on-disk state on construction.
+//   - Eviction (LRU overflow or TTL expiry) deletes the on-disk file
+//     for blobs and rewrites/removes the per-namespace snapshot for
+//     references.
+//   - All public methods are safe for concurrent use. Concurrent
+//     [BlobCache.Fetch] calls for the same digest are collapsed via
+//     singleflight into a single upstream round-trip; the shared
+//     bytes are then persisted to disk (best-effort) and each waiter
+//     is served its own reader over identical content because the
+//     digest is the cache key.
+//
+// Integrity:
+//
+//   - [BlobCache] verifies content on the cache-miss path by fetching
+//     via [content.FetchAll], which streams the upstream reader
+//     through a [content.VerifyReader] and rejects bytes that do not
+//     hash to the descriptor's digest. Only verified bytes are
+//     persisted to disk and served to callers.
+//   - On a cache hit the bytes are already keyed by digest under a
+//     directory owned by this process; the file's identity is trusted
+//     without a re-hash.
+//   - [ReferenceCache] trusts upstream's resolved descriptor and
+//     records it verbatim.
+package cache

--- a/bindings/go/oci/cache/fetch_test.go
+++ b/bindings/go/oci/cache/fetch_test.go
@@ -1,0 +1,457 @@
+package cache
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/opencontainers/go-digest"
+	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/content"
+)
+
+// fakeReadOnly is a minimal in-memory [content.ReadOnlyStorage] used
+// to drive Fetch tests without pulling in a full registry.
+type fakeReadOnly struct {
+	mu      sync.Mutex
+	blobs   map[digest.Digest][]byte
+	media   map[digest.Digest]string
+	fetches atomic.Int64
+	exists  atomic.Int64
+}
+
+func newFakeReadOnly() *fakeReadOnly {
+	return &fakeReadOnly{blobs: map[digest.Digest][]byte{}, media: map[digest.Digest]string{}}
+}
+
+func (s *fakeReadOnly) put(mt string, data []byte) ociImageSpecV1.Descriptor {
+	d := digest.FromBytes(data)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.blobs[d] = data
+	s.media[d] = mt
+	return ociImageSpecV1.Descriptor{MediaType: mt, Digest: d, Size: int64(len(data))}
+}
+
+func (s *fakeReadOnly) Fetch(_ context.Context, target ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+	s.fetches.Add(1)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	data, ok := s.blobs[target.Digest]
+	if !ok {
+		return nil, fmt.Errorf("not found: %s", target.Digest)
+	}
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+func (s *fakeReadOnly) Exists(_ context.Context, target ociImageSpecV1.Descriptor) (bool, error) {
+	s.exists.Add(1)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.blobs[target.Digest]
+	return ok, nil
+}
+
+// remove deletes a blob from the fake store, simulating registry removal.
+func (s *fakeReadOnly) remove(dgst digest.Digest) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.blobs, dgst)
+	delete(s.media, dgst)
+}
+
+var _ content.ReadOnlyStorage = (*fakeReadOnly)(nil)
+
+func readAllAndClose(t *testing.T, rc io.ReadCloser) []byte {
+	t.Helper()
+	defer rc.Close()
+	got, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	return got
+}
+
+func TestCache_Fetch_NilReceiver_Passthrough(t *testing.T) {
+	var c *BlobCache
+	base := newFakeReadOnly()
+	desc := base.put(ociImageSpecV1.MediaTypeImageManifest, []byte("p"))
+	rc, err := c.Fetch(t.Context(), base, desc)
+	require.NoError(t, err)
+	_ = readAllAndClose(t, rc)
+	assert.EqualValues(t, 1, base.fetches.Load())
+}
+
+func TestCache_Fetch_ManifestCachesAcrossCalls(t *testing.T) {
+	c := newTestCache(t, Options{})
+	base := newFakeReadOnly()
+	manifest := []byte(`{"schemaVersion":2}`)
+	desc := base.put(ociImageSpecV1.MediaTypeImageManifest, manifest)
+
+	rc1, err := c.Fetch(t.Context(), base, desc)
+	require.NoError(t, err)
+	assert.Equal(t, manifest, readAllAndClose(t, rc1))
+	assert.EqualValues(t, 1, base.fetches.Load())
+
+	rc2, err := c.Fetch(t.Context(), base, desc)
+	require.NoError(t, err)
+	assert.Equal(t, manifest, readAllAndClose(t, rc2))
+	assert.EqualValues(t, 1, base.fetches.Load(), "second call must hit cache")
+}
+
+func TestCache_Fetch_LayerSkipsCache(t *testing.T) {
+	c := newTestCache(t, Options{})
+	base := newFakeReadOnly()
+	layer := []byte("layer")
+	desc := base.put(ociImageSpecV1.MediaTypeImageLayerGzip, layer)
+
+	rc1, err := c.Fetch(t.Context(), base, desc)
+	require.NoError(t, err)
+	_ = readAllAndClose(t, rc1)
+	rc2, err := c.Fetch(t.Context(), base, desc)
+	require.NoError(t, err)
+	_ = readAllAndClose(t, rc2)
+
+	assert.EqualValues(t, 2, base.fetches.Load())
+	assert.False(t, c.Has(desc.Digest))
+}
+
+func TestCache_Fetch_OversizeSkipsCache(t *testing.T) {
+	c := newTestCache(t, Options{MaxBlobSize: 4})
+	base := newFakeReadOnly()
+	manifest := []byte("0123456789")
+	desc := base.put(ociImageSpecV1.MediaTypeImageManifest, manifest)
+
+	rc1, err := c.Fetch(t.Context(), base, desc)
+	require.NoError(t, err)
+	_ = readAllAndClose(t, rc1)
+	rc2, err := c.Fetch(t.Context(), base, desc)
+	require.NoError(t, err)
+	_ = readAllAndClose(t, rc2)
+
+	assert.EqualValues(t, 2, base.fetches.Load())
+	assert.False(t, c.Has(desc.Digest))
+}
+
+func TestCache_Fetch_ConcurrentReadersGetEqualBytes(t *testing.T) {
+	c := newTestCache(t, Options{})
+	base := newFakeReadOnly()
+	manifest := bytes.Repeat([]byte("m"), 4096)
+	desc := base.put(ociImageSpecV1.MediaTypeImageManifest, manifest)
+
+	const N = 8
+	results := make([][]byte, N)
+	var wg sync.WaitGroup
+	for i := range N {
+		i := i
+		wg.Go(func() {
+			rc, err := c.Fetch(t.Context(), base, desc)
+			require.NoError(t, err)
+			results[i] = readAllAndClose(t, rc)
+		})
+	}
+	wg.Wait()
+
+	for i := range results {
+		assert.Equal(t, manifest, results[i], "reader %d", i)
+	}
+}
+
+// gatedReadOnly blocks inside Fetch until release is closed. It
+// signals on blocked (buffered, cap N) each time a caller enters the
+// gate, so tests can wait for a precise number of goroutines to be
+// parked before releasing.
+type gatedReadOnly struct {
+	*fakeReadOnly
+	blocked chan struct{}
+	release chan struct{}
+}
+
+func newGated(base *fakeReadOnly, cap int) *gatedReadOnly {
+	return &gatedReadOnly{
+		fakeReadOnly: base,
+		blocked:      make(chan struct{}, cap),
+		release:      make(chan struct{}),
+	}
+}
+
+func (s *gatedReadOnly) Fetch(ctx context.Context, target ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+	s.blocked <- struct{}{}
+	<-s.release
+	return s.fakeReadOnly.Fetch(ctx, target)
+}
+
+// waitBlocked drains n tokens from s.blocked, confirming n goroutines
+// have entered the gate.
+func (s *gatedReadOnly) waitBlocked(t *testing.T, n int) {
+	t.Helper()
+	for range n {
+		select {
+		case <-s.blocked:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for goroutine %d/%d to block", n, n)
+		}
+	}
+}
+
+func TestCache_Fetch_CollapsesConcurrentMisses(t *testing.T) {
+	c := newTestCache(t, Options{})
+	base := newFakeReadOnly()
+	manifest := bytes.Repeat([]byte("m"), 4096)
+	desc := base.put(ociImageSpecV1.MediaTypeImageManifest, manifest)
+	gated := newGated(base, 1) // only the singleflight leader enters the gate
+
+	const N = 8
+	results := make([][]byte, N)
+	var wg sync.WaitGroup
+	t.Logf("launching %d concurrent Fetch goroutines for the same digest", N)
+	for i := range N {
+		wg.Go(func() {
+			rc, err := c.Fetch(t.Context(), gated, desc)
+			require.NoError(t, err)
+			results[i] = readAllAndClose(t, rc)
+		})
+	}
+	// Singleflight elects exactly one leader to call upstream; that
+	// goroutine parks inside gatedReadOnly.Fetch waiting for release.
+	// The other N-1 callers block on the DoChan result channel.
+	t.Log("waiting for the single upstream fetch goroutine to park at the gate")
+	gated.waitBlocked(t, 1)
+	t.Logf("fetch goroutine parked; releasing gate — expecting %d upstream calls: 1", N)
+	close(gated.release)
+	wg.Wait()
+	t.Logf("all %d callers returned; upstream fetch count: %d", N, base.fetches.Load())
+
+	for i := range results {
+		assert.Equal(t, manifest, results[i], "reader %d", i)
+	}
+	assert.EqualValues(t, 1, base.fetches.Load(),
+		"concurrent misses must collapse into a single upstream fetch")
+	assert.True(t, c.Has(desc.Digest), "blob must be persisted after the collapsed fetch")
+}
+
+func TestCache_Fetch_UpstreamErrorPropagates(t *testing.T) {
+	c := newTestCache(t, Options{})
+	base := newFakeReadOnly()
+	desc := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageManifest,
+		Digest:    digest.FromBytes([]byte("nope")),
+		Size:      4,
+	}
+	_, err := c.Fetch(t.Context(), base, desc)
+	require.Error(t, err)
+	assert.False(t, c.Has(desc.Digest))
+}
+
+func TestDefaultAccept_AllBranches(t *testing.T) {
+	tests := []struct {
+		mt   string
+		want bool
+	}{
+		{ociImageSpecV1.MediaTypeImageManifest, true},
+		{ociImageSpecV1.MediaTypeImageIndex, true},
+		{"application/vnd.docker.distribution.manifest.v2+json", true},
+		{"application/vnd.docker.distribution.manifest.list.v2+json", true},
+		{"application/vnd.ocm.software.component.config.v1+json", true},
+		{"application/vnd.ocm.software.component-descriptor.v2+json", true},
+		{"application/vnd.ocm.software.component-descriptor.v1+yaml+tar", true},
+		{ociImageSpecV1.MediaTypeImageLayerGzip, false},
+		{"application/octet-stream", false},
+		{"", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.mt, func(t *testing.T) {
+			assert.Equal(t, tc.want, DefaultAccept(ociImageSpecV1.Descriptor{MediaType: tc.mt}))
+		})
+	}
+}
+
+// blockingReadOnly blocks inside Fetch until ready is closed. It
+// signals on blocked (capacity 1) when it enters the wait, so the
+// test can synchronise without sleeping.
+type blockingReadOnly struct {
+	*fakeReadOnly
+	blocked chan struct{}
+	ready   chan struct{}
+}
+
+func newBlocking(base *fakeReadOnly) *blockingReadOnly {
+	return &blockingReadOnly{
+		fakeReadOnly: base,
+		blocked:      make(chan struct{}, 1),
+		ready:        make(chan struct{}),
+	}
+}
+
+func (s *blockingReadOnly) Fetch(ctx context.Context, target ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+	select {
+	case s.blocked <- struct{}{}:
+	default:
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-s.ready:
+	}
+	return s.fakeReadOnly.Fetch(ctx, target)
+}
+
+func (s *blockingReadOnly) waitBlocked(t *testing.T) {
+	t.Helper()
+	select {
+	case <-s.blocked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for fetch goroutine to block")
+	}
+}
+
+// TestCache_Fetch_CanceledLeaderFollowerStillReceives verifies that
+// when the leader caller's context is canceled before the shared fetch
+// completes, the fetch continues and a concurrent follower receives
+// the result.
+func TestCache_Fetch_CanceledLeaderFollowerStillReceives(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	c := newTestCache(t, Options{})
+	base := newFakeReadOnly()
+	manifest := []byte(`{"schemaVersion":2,"leader":true}`)
+	desc := base.put(ociImageSpecV1.MediaTypeImageManifest, manifest)
+	blocking := newBlocking(base)
+
+	leaderCtx, leaderCancel := context.WithCancel(t.Context())
+
+	var leaderErr error
+	leaderDone := make(chan struct{})
+	t.Log("leader: starting Fetch — singleflight will elect it to call upstream")
+	go func() {
+		defer close(leaderDone)
+		_, leaderErr = c.Fetch(leaderCtx, blocking, desc)
+		t.Logf("leader: Fetch returned: %v", leaderErr)
+	}()
+
+	// blockingReadOnly.Fetch signals on blocked before parking; this
+	// confirms the singleflight goroutine is inside the upstream call
+	// and won't complete until blocking.ready is closed.
+	t.Log("waiting for singleflight goroutine to park inside upstream Fetch")
+	blocking.waitBlocked(t)
+	t.Log("singleflight goroutine parked; canceling leader context")
+	leaderCancel()
+	<-leaderDone
+	require.ErrorIs(t, leaderErr, context.Canceled, "leader must return its cancellation")
+	t.Log("leader returned context.Canceled — singleflight goroutine still blocked on ready")
+
+	// The singleflight goroutine is still running (blocked on ready).
+	// Start the follower; it calls DoChan and receives the same
+	// in-flight result channel, or gets a cache hit if the fetch
+	// completes first — either way it must succeed.
+	type fetchResult struct {
+		data []byte
+		err  error
+	}
+	followerCh := make(chan fetchResult, 1)
+	t.Log("follower: starting Fetch while singleflight goroutine is still in-flight")
+	go func() {
+		rc, err := c.Fetch(t.Context(), blocking, desc)
+		if err != nil {
+			t.Logf("follower: Fetch returned error: %v", err)
+			followerCh <- fetchResult{err: err}
+			return
+		}
+		data := readAllAndClose(t, rc)
+		t.Logf("follower: Fetch succeeded (%d bytes)", len(data))
+		followerCh <- fetchResult{data: data}
+	}()
+	t.Log("unblocking singleflight goroutine by closing ready")
+	close(blocking.ready)
+
+	res := <-followerCh
+	require.NoError(t, res.err, "follower must succeed even after leader canceled")
+	assert.Equal(t, manifest, res.data)
+	assert.True(t, c.Has(desc.Digest), "blob must be persisted for the follower")
+	t.Logf("blob persisted: %v", c.Has(desc.Digest))
+}
+
+// TestCache_Fetch_CanceledFollowerDoesNotAffectOthers verifies that a
+// follower whose context is canceled before the shared fetch completes
+// returns [context.Canceled] while the leader (and any other active
+// caller) can still retrieve the result.
+func TestCache_Fetch_CanceledFollowerDoesNotAffectOthers(t *testing.T) {
+	c := newTestCache(t, Options{})
+	base := newFakeReadOnly()
+	manifest := []byte(`{"schemaVersion":2,"follower":true}`)
+	desc := base.put(ociImageSpecV1.MediaTypeImageManifest, manifest)
+	blocking := newBlocking(base)
+
+	type leaderResult struct {
+		data []byte
+		err  error
+	}
+	leaderCh := make(chan leaderResult, 1)
+	t.Log("leader: starting Fetch — will block inside upstream until ready is closed")
+	go func() {
+		rc, err := c.Fetch(t.Context(), blocking, desc)
+		if err != nil {
+			t.Logf("leader: Fetch returned error: %v", err)
+			leaderCh <- leaderResult{err: err}
+			return
+		}
+		data := readAllAndClose(t, rc)
+		t.Logf("leader: Fetch succeeded (%d bytes)", len(data))
+		leaderCh <- leaderResult{data: data}
+	}()
+
+	t.Log("waiting for singleflight goroutine to park inside upstream Fetch")
+	blocking.waitBlocked(t)
+	t.Log("singleflight goroutine parked; follower joining with a pre-canceled context")
+	followerCtx, followerCancel := context.WithCancel(t.Context())
+	followerCancel()
+	_, followerErr := c.Fetch(followerCtx, blocking, desc)
+	t.Logf("follower: Fetch returned: %v (singleflight goroutine still running)", followerErr)
+	require.ErrorIs(t, followerErr, context.Canceled, "follower must return its cancellation")
+
+	t.Log("unblocking singleflight goroutine by closing ready")
+	close(blocking.ready)
+	result := <-leaderCh
+	require.NoError(t, result.err, "leader must succeed after follower canceled")
+	assert.Equal(t, manifest, result.data)
+	assert.True(t, c.Has(desc.Digest))
+	t.Logf("blob persisted: %v; upstream fetch count: %d", c.Has(desc.Digest), base.fetches.Load())
+}
+
+func TestCache_Fetch_GetErrorFallsThrough(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("permission bits do not block root or windows")
+	}
+	c := newTestCache(t, Options{})
+	manifest := []byte(`{"schemaVersion":2}`)
+	desc := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageManifest,
+		Digest:    digest.FromBytes(manifest),
+		Size:      int64(len(manifest)),
+	}
+	_, err := c.populate(t.Context(), desc.Digest, desc.Size, bytes.NewReader(manifest))
+	require.NoError(t, err)
+
+	// Block read access to the algorithm dir so c.Get returns a non-
+	// NotExist error and Fetch must fall through to upstream.
+	algo := filepath.Dir(pathFor(c.opts.Dir, desc.Digest))
+	require.NoError(t, os.Chmod(algo, 0))
+	t.Cleanup(func() { _ = os.Chmod(algo, 0o700) })
+
+	base := newFakeReadOnly()
+	_ = base.put(ociImageSpecV1.MediaTypeImageManifest, manifest)
+
+	rc, err := c.Fetch(t.Context(), base, desc)
+	require.NoError(t, err)
+	got := readAllAndClose(t, rc)
+	assert.Equal(t, manifest, got)
+	assert.EqualValues(t, 1, base.fetches.Load())
+}

--- a/bindings/go/oci/cache/options.go
+++ b/bindings/go/oci/cache/options.go
@@ -1,0 +1,147 @@
+package cache
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"ocm.software/open-component-model/bindings/go/oci/internal/introspection"
+	componentConfig "ocm.software/open-component-model/bindings/go/oci/spec/config/component"
+	"ocm.software/open-component-model/bindings/go/oci/spec/descriptor"
+)
+
+// RemotePolicy controls when the cache contacts the upstream registry
+// on a cache hit.
+type RemotePolicy string
+
+const (
+	// RemotePolicyIfNotPresent returns cached content without contacting
+	// the registry. The local cache directory is trusted.
+	RemotePolicyIfNotPresent RemotePolicy = "IfNotPresent"
+
+	// RemotePolicyAlways contacts the registry on every cache hit to
+	// verify the caller is authorised. Mirrors Kubernetes imagePullPolicy:Always.
+	RemotePolicyAlways RemotePolicy = "Always"
+)
+
+// Options controls the behaviour of both the [BlobCache] and the
+// [ReferenceCache]. The two caches share the same Options struct so a
+// caller can configure them once and instantiate either or both with
+// matching limits.
+//
+// Dir is required at construction (see [Options.applyDefaults]) even
+// though it lives on Options rather than the constructor signature:
+// keeping every parameter on a single struct lets callers configure
+// both caches from one shared config source without a two-argument
+// constructor. [Defaults] returns an Options populated with sensible
+// limits; the per-field defaults are also applied automatically by
+// [NewBlobCache] / [NewReferenceCache] when a caller passes a
+// partially-populated Options.
+//
+// MaxBlobSize and Accept are blob-specific and ignored by
+// [ReferenceCache].
+type Options struct {
+	// Dir is the absolute directory the cache owns — required. Both
+	// caches lay out their files inside Dir without colliding
+	// ([BlobCache] uses `<Dir>/blobs/<algo>/<hex>` files,
+	// [ReferenceCache] uses `<Dir>/refs/<sha256(namespace)>.json`), so
+	// the same Dir can be shared.
+	Dir string
+
+	// MaxEntries bounds the LRU. A value of 0 means unlimited
+	// (subject only to TTL).
+	MaxEntries int
+
+	// TTL is the maximum age of a cache entry. A value of 0 disables
+	// time-based expiry; entries then live until LRU overflow.
+	TTL time.Duration
+
+	// MaxBlobSize is the per-blob size cap for the [BlobCache].
+	// Descriptors with a larger Size are fetched but not cached.
+	// A value of 0 disables the cap. Ignored by [ReferenceCache].
+	MaxBlobSize int64
+
+	// Accept reports whether a blob should be cached by the
+	// [BlobCache]. The full descriptor is passed (not just the media
+	// type) so callers can filter on annotations, artifact type, or
+	// size without a breaking signature change. nil falls back to
+	// [DefaultAccept] in [NewBlobCache]. Ignored by [ReferenceCache].
+	Accept func(desc ociImageSpecV1.Descriptor) bool
+
+	// RemotePolicy controls whether the upstream registry is contacted
+	// on a cache hit. Defaults to [RemotePolicyIfNotPresent].
+	RemotePolicy RemotePolicy
+}
+
+// Defaults returns an [Options] populated with sane caching limits:
+//   - 256 entries
+//   - 10 minute TTL
+//   - 4 MiB per-blob size cap
+//   - [DefaultAccept] media-type filter
+//   - [RemotePolicyAlways] (secure by default)
+//
+// Dir is left zero — callers must set it explicitly.
+func Defaults() *Options {
+	return &Options{
+		MaxEntries:   256,
+		TTL:          10 * time.Minute,
+		MaxBlobSize:  4 << 20,
+		Accept:       DefaultAccept,
+		RemotePolicy: RemotePolicyAlways,
+	}
+}
+
+// applyDefaults validates required fields and fills zero-valued
+// fields from [Defaults].
+func (o Options) applyDefaults() (Options, error) {
+	if o.Dir == "" {
+		return Options{}, errors.New("cache: Options.Dir is required")
+	}
+	d := Defaults()
+	if o.MaxEntries == 0 {
+		o.MaxEntries = d.MaxEntries
+	}
+	if o.TTL == 0 {
+		o.TTL = d.TTL
+	}
+	if o.MaxBlobSize == 0 {
+		o.MaxBlobSize = d.MaxBlobSize
+	}
+	if o.Accept == nil {
+		o.Accept = d.Accept
+	}
+	switch o.RemotePolicy {
+	case "":
+		o.RemotePolicy = d.RemotePolicy
+	case RemotePolicyIfNotPresent, RemotePolicyAlways:
+		// ok
+	default:
+		return Options{}, fmt.Errorf("cache: unsupported RemotePolicy %q", o.RemotePolicy)
+	}
+	return o, nil
+}
+
+// DefaultAccept is the default admission filter. It accepts:
+//   - any OCI/Docker manifest or index media type
+//     (see [introspection.IsOCICompliantMediaType]);
+//   - the OCM component config media type;
+//   - any OCM component-descriptor media type — i.e. anything with the
+//     prefix [descriptor.MediaTypeComponentDescriptor], which covers
+//     v2+json, v2+yaml, legacy v1 variants, and the legacy +tar
+//     wrapper.
+//
+// The size filter is applied separately via [Options.MaxBlobSize] so
+// custom [Options.Accept] implementations do not have to re-encode it.
+func DefaultAccept(desc ociImageSpecV1.Descriptor) bool {
+	mediaType := desc.MediaType
+	if introspection.IsOCICompliantMediaType(mediaType) {
+		return true
+	}
+	if mediaType == componentConfig.MediaType {
+		return true
+	}
+	return strings.HasPrefix(mediaType, descriptor.MediaTypeComponentDescriptor)
+}

--- a/bindings/go/oci/cache/reference_cache.go
+++ b/bindings/go/oci/cache/reference_cache.go
@@ -1,0 +1,472 @@
+package cache
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/golang-lru/v2/expirable"
+	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sync/singleflight"
+	"oras.land/oras-go/v2/registry"
+)
+
+// referenceSubdir is the directory under [Options.Dir] that the
+// reference cache owns. Each namespace gets its own JSON file inside
+// it, named after the hex-encoded SHA-256 of the namespace string.
+// Splitting per namespace means an [ReferenceCache.Add] only rewrites
+// the file for the affected namespace and namespaces never compete for
+// the same snapshot file. The layout mirrors [BlobCache]'s
+// `<Dir>/blobs/...` scoping.
+//
+// A cryptographic digest makes filename collisions between distinct
+// namespaces infeasible in practice, so two namespaces can never
+// clobber each other's snapshot file. The canonical namespace string
+// is still written into the snapshot body so a reseed recovers the
+// exact key without trusting the filename to preserve it.
+const referenceSubdir = "refs"
+
+// referenceFileExt is appended to the hashed namespace to form the
+// per-namespace snapshot filename.
+const referenceFileExt = ".json"
+
+// referenceEntry is the shared shape of a cached resolve, used both
+// as the on-disk record and as the in-memory LRU value. SavedAt
+// records when the entry was first resolved so a reseed can honour
+// [Options.TTL] instead of resurrecting arbitrarily stale mappings
+// with a fresh in-memory expiry.
+type referenceEntry struct {
+	Descriptor ociImageSpecV1.Descriptor `json:"descriptor"`
+	SavedAt    time.Time                 `json:"savedAt"`
+}
+
+// referenceFileSnapshot is the on-disk shape of a single namespace's
+// portion of [ReferenceCache.lru]. Namespace is recorded so a future
+// reseed can recover the exact key without trusting the filename to
+// preserve it.
+type referenceFileSnapshot struct {
+	Namespace  string                    `json:"namespace"`
+	References map[string]referenceEntry `json:"references"`
+}
+
+// Resolver is the upstream contract that [ReferenceCache.Resolve]
+// consults on a cache miss. Both *remote.Repository and the
+// spec.Store interface satisfy it.
+type Resolver interface {
+	Resolve(ctx context.Context, reference string) (ociImageSpecV1.Descriptor, error)
+}
+
+// ReferenceCache is a string-keyed LRU+TTL cache for OCI tag/digest
+// reference → descriptor lookups, persisted to disk so resolves
+// survive a process restart. All methods are safe for concurrent use.
+//
+// Entries are namespaced so two repositories that happen to share a
+// short reference (e.g. the tag "v1") do not collide. On disk, each
+// namespace is persisted to its own file under
+// `<Options.Dir>/refs/<sha256(namespace)>.json`, mirroring the
+// per-subdirectory split that [BlobCache] uses.
+//
+// MaxBlobSize and Accept on [Options] are ignored.
+type ReferenceCache struct {
+	opts   Options
+	logger *slog.Logger
+	lru    *expirable.LRU[referenceKey, referenceEntry]
+
+	// mu serialises per-namespace snapshot rewrites so concurrent Add
+	// calls for the same namespace do not interleave file writes.
+	mu sync.Mutex
+
+	// evictedRefsMu protects namespacesWithEvictedRefs.
+	//
+	// The LRU eviction callback runs synchronously during LRU
+	// mutations, so it must not call writeNamespace: writeNamespace
+	// reads the LRU and would deadlock on the LRU's internal lock.
+	evictedRefsMu sync.Mutex
+
+	// namespacesWithEvictedRefs contains namespaces whose persisted
+	// snapshot may still contain references evicted from the in-memory
+	// LRU.
+	namespacesWithEvictedRefs map[string]struct{}
+
+	// sf collapses concurrent upstream resolves for the same
+	// (namespace, reference) into a single round-trip.
+	sf singleflight.Group
+}
+
+// referenceKey is the in-memory LRU key. Splitting namespace and
+// reference into struct fields means we don't have to choose a
+// separator that escapes safely — Go's map equality covers it.
+type referenceKey struct {
+	namespace string
+	reference string
+}
+
+// NewReferenceCache constructs a [ReferenceCache]. [Options.Dir] is
+// required; other zero-valued fields fall back to [Defaults].
+//
+// On startup, NewReferenceCache walks `<Dir>/refs/*.json` and
+// reseeds the LRU so previously resolved references survive a
+// process restart. Malformed snapshots are logged and treated as
+// empty.
+func NewReferenceCache(opts Options) (*ReferenceCache, error) {
+	opts, err := opts.applyDefaults()
+	if err != nil {
+		return nil, err
+	}
+	// Scope to a dedicated subdirectory so the same Options.Dir can
+	// also host a [BlobCache] (which uses `<Dir>/blobs/...`) without
+	// collisions.
+	opts.Dir = filepath.Join(opts.Dir, referenceSubdir)
+	if err := ensureDir(opts.Dir); err != nil {
+		return nil, fmt.Errorf("refcache: %w", err)
+	}
+
+	c := &ReferenceCache{
+		opts:                      opts,
+		logger:                    slog.Default().With(slog.String("dir", opts.Dir)),
+		namespacesWithEvictedRefs: make(map[string]struct{}),
+	}
+	c.lru = expirable.NewLRU(
+		opts.MaxEntries,
+		func(k referenceKey, _ referenceEntry) {
+			c.markNamespaceWithEvictedRef(k.namespace)
+			c.logger.Debug("refcache: evicted",
+				slog.String("namespace", k.namespace),
+				slog.String("reference", k.reference))
+		},
+		opts.TTL,
+	)
+
+	startRefs := time.Now()
+	if loaded, err := c.load(); err != nil {
+		c.logger.Warn("refcache: load snapshot failed",
+			slog.String("err", err.Error()))
+	} else if loaded > 0 {
+		c.logger.Debug("refcache: seeded from disk",
+			slog.Int("loaded", loaded),
+			slog.Duration("duration", time.Since(startRefs)))
+	}
+
+	// Flush namespaces dirtied by load-time capacity eviction so stale
+	// snapshot files do not survive a restart when MaxEntries is
+	// smaller than the number of persisted entries.
+	for namespace := range c.drainNamespacesWithEvictedRefs() {
+		if err := c.writeNamespace(namespace); err != nil {
+			c.logger.Warn("refcache: write snapshot after load eviction failed",
+				slog.String("namespace", namespace),
+				slog.String("err", err.Error()))
+		}
+	}
+
+	return c, nil
+}
+
+// Add stores a (namespace, reference) → descriptor mapping in the
+// in-memory LRU and persists the namespace's snapshot file so a
+// future run pointing at the same Dir reseeds the mapping.
+//
+// When adding to a full LRU causes a capacity eviction, Add also
+// rewrites the snapshot file of the evicted entry's namespace so the
+// on-disk state stays consistent with memory.
+//
+// Add is best-effort with respect to disk: if a rewrite fails, the
+// in-memory entry is still added and a warning is logged. The caller
+// never sees an error from this method.
+func (c *ReferenceCache) Add(ref registry.Reference, desc ociImageSpecV1.Descriptor) {
+	k := c.buildKey(ref)
+
+	c.lru.Add(k, referenceEntry{Descriptor: desc, SavedAt: time.Now()})
+
+	// Collect namespaces dirtied by capacity eviction triggered above,
+	// then always include the current namespace.
+	namespaces := c.drainNamespacesWithEvictedRefs()
+	namespaces[k.namespace] = struct{}{}
+
+	for namespace := range namespaces {
+		if err := c.writeNamespace(namespace); err != nil {
+			c.logger.Warn("refcache: write snapshot failed",
+				slog.String("namespace", namespace),
+				slog.String("reference", k.reference),
+				slog.String("err", err.Error()))
+		}
+	}
+}
+
+// Invalidate removes the (namespace, reference) mapping from the
+// in-memory LRU and rewrites the namespace's on-disk snapshot so the
+// stale mapping does not survive a process restart. It is a no-op if
+// the entry is not cached. Callers must invalidate whenever a tag is
+// re-pointed or deleted upstream, because OCI tags are mutable and the
+// cache otherwise keeps serving the old descriptor until TTL expiry.
+func (c *ReferenceCache) Invalidate(ref registry.Reference) {
+	if c == nil {
+		return
+	}
+	k := c.buildKey(ref)
+	c.lru.Remove(k)
+	if err := c.writeNamespace(k.namespace); err != nil {
+		c.logger.Warn("refcache: write snapshot after invalidate failed",
+			slog.String("namespace", k.namespace),
+			slog.String("reference", k.reference),
+			slog.String("err", err.Error()))
+	}
+}
+
+// Lookup returns the cached descriptor for the (namespace, reference)
+// pair and whether it was found. See [ReferenceCache.Add] for the
+// namespace contract.
+func (c *ReferenceCache) Lookup(ref registry.Reference) (ociImageSpecV1.Descriptor, bool) {
+	v, ok := c.lru.Get(c.buildKey(ref))
+	return v.Descriptor, ok
+}
+
+// Resolve consults the reference cache before delegating to upstream.
+// On miss it calls upstream.Resolve and, on success, records the
+// (namespace, reference) → descriptor mapping (in-memory + on disk).
+// Errors are returned unchanged and not cached.
+//
+// See [ReferenceCache.Add] for the namespace contract. A nil receiver
+// is supported: the call falls straight through to upstream so
+// resolver decorators can compose without nil-checks.
+func (c *ReferenceCache) Resolve(ctx context.Context, upstream Resolver, ref registry.Reference) (ociImageSpecV1.Descriptor, error) {
+	if c == nil {
+		return upstream.Resolve(ctx, ref.Reference)
+	}
+	k := c.buildKey(ref)
+	if c.opts.RemotePolicy == RemotePolicyIfNotPresent {
+		if v, ok := c.lru.Get(k); ok {
+			c.logger.DebugContext(ctx, "refcache: hit",
+				slog.String("namespace", k.namespace),
+				slog.String("reference", k.reference),
+				slog.String("digest", v.Descriptor.Digest.String()))
+			return v.Descriptor, nil
+		}
+	}
+	// Collapse concurrent misses (or Always-policy calls) for the same
+	// key into one upstream round-trip.
+	v, err, _ := c.sf.Do(k.namespace+"\x00"+ref.Reference, func() (any, error) {
+		if c.opts.RemotePolicy == RemotePolicyIfNotPresent {
+			if v, ok := c.lru.Get(k); ok {
+				return v.Descriptor, nil
+			}
+		}
+		desc, err := upstream.Resolve(ctx, ref.Reference)
+		if err != nil {
+			return ociImageSpecV1.Descriptor{}, err
+		}
+		c.Add(ref, desc)
+		return desc, nil
+	})
+	if err != nil {
+		return ociImageSpecV1.Descriptor{}, err
+	}
+	return v.(ociImageSpecV1.Descriptor), nil
+}
+
+// markNamespaceWithEvictedRef records namespace as having at least one
+// reference evicted from the LRU. Safe to call from the LRU eviction
+// callback because it only touches evictedRefsMu, not the LRU.
+func (c *ReferenceCache) markNamespaceWithEvictedRef(namespace string) {
+	c.evictedRefsMu.Lock()
+	defer c.evictedRefsMu.Unlock()
+
+	c.namespacesWithEvictedRefs[namespace] = struct{}{}
+}
+
+// drainNamespacesWithEvictedRefs atomically returns and clears the set
+// of namespaces that had LRU-capacity evictions since the last drain.
+func (c *ReferenceCache) drainNamespacesWithEvictedRefs() map[string]struct{} {
+	c.evictedRefsMu.Lock()
+	defer c.evictedRefsMu.Unlock()
+
+	namespaces := c.namespacesWithEvictedRefs
+	c.namespacesWithEvictedRefs = make(map[string]struct{})
+	return namespaces
+}
+
+// buildKey constructs the in-memory cache key from the parsed registry.Reference.
+func (c *ReferenceCache) buildKey(ref registry.Reference) referenceKey {
+	return referenceKey{
+		namespace: ref.Registry + "/" + ref.Repository,
+		reference: ref.Reference,
+	}
+}
+
+// pathForNamespace returns the absolute path of the snapshot file
+// owned by namespace. The filename is the hex-encoded SHA-256 of the
+// namespace string; see [referenceSubdir] for why a cryptographic
+// digest is used purely to derive a collision-free filename.
+func (c *ReferenceCache) pathForNamespace(namespace string) string {
+	sum := sha256.Sum256([]byte(namespace))
+	return filepath.Join(c.opts.Dir, hex.EncodeToString(sum[:])+referenceFileExt)
+}
+
+// snapshotNamespace materialises the LRU entries for a single
+// namespace into a referenceFileSnapshot. It iterates Keys+Peek so it
+// can run while other goroutines hold the LRU; expirable.LRU is
+// internally locked. Callers must hold c.mu when writing the returned
+// snapshot to disk so concurrent writers cannot persist a stale copy.
+func (c *ReferenceCache) snapshotNamespace(namespace string) referenceFileSnapshot {
+	out := referenceFileSnapshot{
+		Namespace:  namespace,
+		References: make(map[string]referenceEntry),
+	}
+	for _, k := range c.lru.Keys() {
+		if k.namespace != namespace {
+			continue
+		}
+		if v, ok := c.lru.Peek(k); ok {
+			out.References[k.reference] = v
+		}
+	}
+	return out
+}
+
+// writeNamespace rewrites the namespace's snapshot file atomically
+// using whatever the LRU currently holds for that namespace.
+// Concurrent calls are serialised via c.mu so the final rename
+// always reflects a coherent snapshot of one of them.
+//
+// When the LRU has no entries for the namespace (e.g. all evicted),
+// the snapshot file is removed so the directory does not accumulate
+// empty stubs.
+func (c *ReferenceCache) writeNamespace(namespace string) error {
+	path := c.pathForNamespace(namespace)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Snapshot while holding c.mu so concurrent writers cannot persist
+	// a stale view and clobber the newer on-disk state.
+	snap := c.snapshotNamespace(namespace)
+	if len(snap.References) == 0 {
+		// Nothing left for this namespace; drop the stub file.
+		if err := removeQuiet(path); err != nil {
+			return fmt.Errorf("remove empty snapshot: %w", err)
+		}
+		return nil
+	}
+
+	raw, err := json.Marshal(snap)
+	if err != nil {
+		return fmt.Errorf("marshal snapshot: %w", err)
+	}
+	return writeFileAtomic(c.opts.Dir, path, raw)
+}
+
+// load walks `<Dir>/refs/*.json` and feeds each namespace's entries
+// into the LRU. Files that fail to parse are removed so the directory
+// stays a clean per-namespace store; the count of dropped files is
+// not surfaced because it would not be actionable.
+//
+// load is called once from [NewReferenceCache] before any Add can
+// race with it.
+func (c *ReferenceCache) load() (loaded int, err error) {
+	entries, err := os.ReadDir(c.opts.Dir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("read refs dir: %w", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		// Reclaim leftover temp files from a crashed [writeFileAtomic]
+		// first: their names carry a `.write-*` prefix (not a
+		// `.json` extension), so the extension filter below would
+		// otherwise skip them and they would accumulate indefinitely.
+		if strings.HasPrefix(name, atomicWritePrefix) {
+			_ = os.Remove(filepath.Join(c.opts.Dir, name))
+			continue
+		}
+		if filepath.Ext(name) != referenceFileExt {
+			continue
+		}
+		full := filepath.Join(c.opts.Dir, name)
+		data, err := os.ReadFile(full)
+		if err != nil {
+			c.logger.Warn("refcache: read snapshot file",
+				slog.String("file", full), slog.String("err", err.Error()))
+			continue
+		}
+		if len(data) == 0 {
+			_ = os.Remove(full)
+			continue
+		}
+		var snap referenceFileSnapshot
+		if err := json.Unmarshal(data, &snap); err != nil {
+			c.logger.Warn("refcache: unmarshal snapshot file",
+				slog.String("file", full), slog.String("err", err.Error()))
+			_ = os.Remove(full)
+			continue
+		}
+		now := time.Now()
+		for ref, entry := range snap.References {
+			// Honour TTL across restarts: drop entries whose recorded
+			// age already exceeds the configured TTL instead of
+			// resurrecting them with a fresh in-memory expiry. SavedAt
+			// is preserved so the logical age keeps advancing on the
+			// next persist.
+			if c.opts.TTL > 0 && !entry.SavedAt.IsZero() && now.Sub(entry.SavedAt) > c.opts.TTL {
+				continue
+			}
+			if entry.SavedAt.IsZero() {
+				entry.SavedAt = now
+			}
+			c.lru.Add(referenceKey{namespace: snap.Namespace, reference: ref}, entry)
+			loaded++
+		}
+	}
+	return loaded, nil
+}
+
+// atomicWritePrefix is the prefix [writeFileAtomic] uses for its
+// [os.CreateTemp] pattern. The `-*` suffix stripped by CreateTemp is
+// what randomises the tail; the constant is exposed so the cleanup
+// scanner and the writer stay in sync.
+const atomicWritePrefix = ".write-"
+
+// writeFileAtomic writes data to path via a temp file in the same
+// directory, fsyncs, and renames into place. The temp file is removed
+// on any failure path.
+func writeFileAtomic(dir, path string, data []byte) error {
+	tmp, err := os.CreateTemp(dir, atomicWritePrefix+"*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		cleanup()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		cleanup()
+		return fmt.Errorf("sync temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("rename temp file: %w", err)
+	}
+	return nil
+}

--- a/bindings/go/oci/cache/references_test.go
+++ b/bindings/go/oci/cache/references_test.go
@@ -1,0 +1,481 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/opencontainers/go-digest"
+	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/registry"
+)
+
+// resolverFn adapts a function to the upstream resolver interface
+// used by [ReferenceCache.Resolve].
+type resolverFn func(ctx context.Context, reference string) (ociImageSpecV1.Descriptor, error)
+
+func (f resolverFn) Resolve(ctx context.Context, reference string) (ociImageSpecV1.Descriptor, error) {
+	return f(ctx, reference)
+}
+
+func newTestRefCache(t *testing.T, opts Options) *ReferenceCache {
+	t.Helper()
+	if opts.Dir == "" {
+		opts.Dir = filepath.Join(t.TempDir(), "refcache")
+	}
+	if opts.RemotePolicy == "" {
+		opts.RemotePolicy = RemotePolicyIfNotPresent
+	}
+	c, err := NewReferenceCache(opts)
+	require.NoError(t, err)
+	return c
+}
+
+func TestReferenceCache_Resolve_HitAfterFirstCall(t *testing.T) {
+	c := newTestRefCache(t, Options{})
+
+	manifest := []byte("manifest")
+	desc := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageManifest,
+		Digest:    digest.FromBytes(manifest),
+		Size:      int64(len(manifest)),
+	}
+
+	var calls atomic.Int64
+	upstream := resolverFn(func(_ context.Context, _ string) (ociImageSpecV1.Descriptor, error) {
+		calls.Add(1)
+		return desc, nil
+	})
+
+	ref, err := registry.ParseReference("ghcr.io/owner/repo:v1")
+	require.NoError(t, err)
+
+	got, err := c.Resolve(t.Context(), upstream, ref)
+	require.NoError(t, err)
+	assert.Equal(t, desc, got)
+
+	got2, err := c.Resolve(t.Context(), upstream, ref)
+	require.NoError(t, err)
+	assert.Equal(t, desc, got2)
+
+	assert.EqualValues(t, 1, calls.Load(), "second Resolve must hit reference cache")
+}
+
+func TestReferenceCache_Invalidate_RemovesEntryAndSurvivesRestart(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "refcache")
+	desc := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageManifest,
+		Digest:    digest.FromBytes([]byte("x")),
+		Size:      1,
+	}
+
+	c1, err := NewReferenceCache(Options{Dir: dir})
+	require.NoError(t, err)
+
+	ref, err := registry.ParseReference("ghcr.io/ns:v1")
+	require.NoError(t, err)
+
+	c1.Add(ref, desc)
+	_, ok := c1.Lookup(ref)
+	require.True(t, ok)
+
+	c1.Invalidate(ref)
+	_, ok = c1.Lookup(ref)
+	assert.False(t, ok, "entry must be gone from the in-memory LRU")
+
+	// A restart must not resurrect the invalidated mapping.
+	c2, err := NewReferenceCache(Options{Dir: dir})
+	require.NoError(t, err)
+	_, ok = c2.Lookup(ref)
+	assert.False(t, ok, "invalidated mapping must not survive a restart")
+}
+
+func TestReferenceCache_Invalidate_UnknownEntryIsNoOp(t *testing.T) {
+	c := newTestRefCache(t, Options{})
+	ref, err := registry.ParseReference("ghcr.io/ns:never-added")
+	require.NoError(t, err)
+	c.Invalidate(ref)
+}
+
+func TestReferenceCache_Invalidate_NilReceiver(t *testing.T) {
+	var c *ReferenceCache
+	ref, err := registry.ParseReference("ghcr.io/ns:ref")
+	require.NoError(t, err)
+	c.Invalidate(ref)
+}
+
+func TestReferenceCache_Load_DropsExpiredEntries(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "refcache")
+	desc := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageManifest,
+		Digest:    digest.FromBytes([]byte("stale")),
+		Size:      5,
+	}
+
+	c1, err := NewReferenceCache(Options{Dir: dir, TTL: time.Hour})
+	require.NoError(t, err)
+
+	ref, err := registry.ParseReference("ghcr.io/ns:v1")
+	require.NoError(t, err)
+
+	c1.Add(ref, desc)
+
+	// Backdate the persisted entry beyond the TTL by rewriting its
+	// snapshot file with an old savedAt.
+	snapPath := c1.pathForNamespace("ghcr.io/ns")
+	raw, err := os.ReadFile(snapPath)
+	require.NoError(t, err)
+	var snap referenceFileSnapshot
+	require.NoError(t, json.Unmarshal(raw, &snap))
+	entry := snap.References["v1"]
+	entry.SavedAt = time.Now().Add(-2 * time.Hour)
+	snap.References["v1"] = entry
+	rewritten, err := json.Marshal(snap)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(snapPath, rewritten, 0o600))
+
+	// A restart must honour the TTL and drop the stale mapping.
+	c2, err := NewReferenceCache(Options{Dir: dir, TTL: time.Hour})
+	require.NoError(t, err)
+	_, ok := c2.Lookup(ref)
+	assert.False(t, ok, "entry older than TTL must be dropped on reload")
+}
+
+func TestReferenceCache_Load_KeepsFreshEntriesWithinTTL(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "refcache")
+	desc := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageManifest,
+		Digest:    digest.FromBytes([]byte("fresh")),
+		Size:      5,
+	}
+
+	c1, err := NewReferenceCache(Options{Dir: dir, TTL: time.Hour})
+	require.NoError(t, err)
+
+	ref, err := registry.ParseReference("ghcr.io/ns:v1")
+	require.NoError(t, err)
+
+	c1.Add(ref, desc)
+
+	c2, err := NewReferenceCache(Options{Dir: dir, TTL: time.Hour})
+	require.NoError(t, err)
+	got, ok := c2.Lookup(ref)
+	require.True(t, ok, "a fresh entry within TTL must survive a restart")
+	assert.Equal(t, desc, got)
+}
+
+func TestReferenceCache_Resolve_CollapsesConcurrentMisses(t *testing.T) {
+	c := newTestRefCache(t, Options{})
+	desc := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageManifest,
+		Digest:    digest.FromBytes([]byte("m")),
+		Size:      1,
+	}
+
+	// Gate the upstream so all goroutines pile up on the same in-flight
+	// resolve before the leader completes.
+	release := make(chan struct{})
+	var calls atomic.Int64
+	upstream := resolverFn(func(_ context.Context, _ string) (ociImageSpecV1.Descriptor, error) {
+		calls.Add(1)
+		<-release
+		return desc, nil
+	})
+
+	ref, err := registry.ParseReference("ghcr.io/ns:v1")
+	require.NoError(t, err)
+
+	const N = 8
+	var wg sync.WaitGroup
+	results := make([]ociImageSpecV1.Descriptor, N)
+	for i := range N {
+		wg.Go(func() {
+			got, err := c.Resolve(t.Context(), upstream, ref)
+			require.NoError(t, err)
+			results[i] = got
+		})
+	}
+	// Give the goroutines time to coalesce on the singleflight key.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	for i := range results {
+		assert.Equal(t, desc, results[i], "resolver %d", i)
+	}
+	assert.EqualValues(t, 1, calls.Load(), "concurrent misses must collapse into a single upstream resolve")
+}
+
+func TestReferenceCache_Resolve_NamespacesIsolateCollisions(t *testing.T) {
+	c := newTestRefCache(t, Options{})
+
+	descA := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageManifest,
+		Digest:    digest.FromBytes([]byte("a")),
+		Size:      1,
+	}
+	descB := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageManifest,
+		Digest:    digest.FromBytes([]byte("b")),
+		Size:      1,
+	}
+
+	refA, err := registry.ParseReference("ghcr.io/foo:v1")
+	require.NoError(t, err)
+
+	refB, err := registry.ParseReference("ghcr.io/bar:v1")
+	require.NoError(t, err)
+
+	c.Add(refA, descA)
+	c.Add(refB, descB)
+
+	gotA, hitA := c.Lookup(refA)
+	require.True(t, hitA)
+	assert.Equal(t, descA, gotA)
+
+	gotB, hitB := c.Lookup(refB)
+	require.True(t, hitB)
+	assert.Equal(t, descB, gotB)
+
+	// And lookups in the wrong namespace miss.
+	refOther, err := registry.ParseReference("ghcr.io/other:v1")
+	require.NoError(t, err)
+	_, hitMiss := c.Lookup(refOther)
+	assert.False(t, hitMiss)
+}
+
+func TestReferenceCache_Resolve_ErrorNotCached(t *testing.T) {
+	c := newTestRefCache(t, Options{})
+
+	upstream := resolverFn(func(_ context.Context, _ string) (ociImageSpecV1.Descriptor, error) {
+		return ociImageSpecV1.Descriptor{}, errors.New("upstream boom")
+	})
+
+	ref, err := registry.ParseReference("ghcr.io/ns:ref-fail")
+	require.NoError(t, err)
+
+	_, err = c.Resolve(t.Context(), upstream, ref)
+	require.Error(t, err)
+	_, hit := c.Lookup(ref)
+	assert.False(t, hit)
+}
+
+func TestReferenceCache_Resolve_NilReceiver_Passthrough(t *testing.T) {
+	var c *ReferenceCache
+	want := ociImageSpecV1.Descriptor{Digest: digest.FromBytes([]byte("p")), Size: 1, MediaType: "x"}
+	upstream := resolverFn(func(_ context.Context, _ string) (ociImageSpecV1.Descriptor, error) {
+		return want, nil
+	})
+
+	ref, err := registry.ParseReference("ghcr.io/ns:x-y")
+	require.NoError(t, err)
+
+	got, err := c.Resolve(t.Context(), upstream, ref)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestReferenceCache_PersistsAcrossRestart(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "refcache")
+
+	desc := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageManifest,
+		Digest:    digest.FromBytes([]byte("persistent")),
+		Size:      10,
+	}
+
+	c1, err := NewReferenceCache(Options{Dir: dir})
+	require.NoError(t, err)
+
+	ref, err := registry.ParseReference("ghcr.io/owner/repo:v1")
+	require.NoError(t, err)
+
+	c1.Add(ref, desc)
+
+	// The cache scopes to <Dir>/refs/ and shards by namespace; verify
+	// that the namespace's snapshot file landed there.
+	entries, err := os.ReadDir(filepath.Join(dir, referenceSubdir))
+	require.NoError(t, err)
+	require.NotEmpty(t, entries, "reference snapshot must be written to disk")
+
+	// Pretend the process restarts.
+	c2, err := NewReferenceCache(Options{Dir: dir})
+	require.NoError(t, err)
+
+	got, ok := c2.Lookup(ref)
+	require.True(t, ok, "reference must be reseeded after restart")
+	assert.Equal(t, desc, got)
+}
+
+func TestReferenceCache_RoundtripsArbitraryChars(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "refcache")
+	desc := ociImageSpecV1.Descriptor{
+		MediaType: "y",
+		Digest:    digest.FromBytes([]byte("x")),
+		Size:      1,
+	}
+	// Tabs, newlines, quotes, unicode — all safe in a JSON snapshot.
+	weird := "tag\nwith\ttabs/\"quotes\"/€"
+	ref := registry.Reference{
+		Registry:   "ghcr.io",
+		Repository: "ns",
+		Reference:  weird,
+	}
+
+	c1, err := NewReferenceCache(Options{Dir: dir})
+	require.NoError(t, err)
+	c1.Add(ref, desc)
+
+	c2, err := NewReferenceCache(Options{Dir: dir})
+	require.NoError(t, err)
+	got, ok := c2.Lookup(ref)
+	require.True(t, ok)
+	assert.Equal(t, desc, got)
+}
+
+func TestReferenceCache_Load_NonNotExistError(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("permission bits do not block root or windows")
+	}
+	c := newTestRefCache(t, Options{})
+	// Drop read permission on the refs dir so os.ReadDir fails with a
+	// non-NotExist error.
+	require.NoError(t, os.Chmod(c.opts.Dir, 0))
+	t.Cleanup(func() { _ = os.Chmod(c.opts.Dir, 0o700) })
+	loaded, err := c.load()
+	require.Error(t, err)
+	assert.Zero(t, loaded)
+}
+
+func TestReferenceCache_Load_MissingFileReturnsZero(t *testing.T) {
+	c := newTestRefCache(t, Options{})
+	loaded, err := c.load()
+	require.NoError(t, err)
+	assert.Zero(t, loaded)
+}
+
+func TestReferenceCache_Add_LRUStaysConsistentWhenWriteFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("dir-remove semantics differ on windows")
+	}
+	c := newTestRefCache(t, Options{})
+	desc := ociImageSpecV1.Descriptor{
+		MediaType: "y",
+		Digest:    digest.FromBytes([]byte("x")),
+		Size:      1,
+	}
+	// Replace the cache directory with a regular file so the temp-file
+	// creation in writeFileAtomic fails.
+	require.NoError(t, os.RemoveAll(c.opts.Dir))
+	require.NoError(t, os.WriteFile(c.opts.Dir, nil, 0o600))
+
+	ref, err := registry.ParseReference("ghcr.io/ns:ref-fail")
+	require.NoError(t, err)
+
+	c.Add(ref, desc)
+	got, ok := c.Lookup(ref)
+	require.True(t, ok, "in-memory entry must survive a disk-write failure")
+	assert.Equal(t, desc, got)
+}
+
+func TestReferenceCache_Add_ConcurrentWritersAllVisible(t *testing.T) {
+	dir := t.TempDir()
+	c, err := NewReferenceCache(Options{Dir: dir})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for i := range 4 {
+		wg.Go(func() {
+			ref := registry.Reference{
+				Registry:   "ghcr.io",
+				Repository: "ns",
+				Reference:  string(rune('a' + i)),
+			}
+			c.Add(ref, ociImageSpecV1.Descriptor{
+				Digest: digest.FromBytes([]byte{byte('a' + i)}),
+				Size:   1,
+			})
+		})
+	}
+	wg.Wait()
+	for i := range 4 {
+		ref := registry.Reference{
+			Registry:   "ghcr.io",
+			Repository: "ns",
+			Reference:  string(rune('a' + i)),
+		}
+		_, ok := c.Lookup(ref)
+		assert.True(t, ok)
+	}
+}
+
+func TestWriteFileAtomic_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out")
+	require.NoError(t, writeFileAtomic(dir, path, []byte("hello")))
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello"), got)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.False(t, e.IsDir())
+		assert.NotContains(t, e.Name(), ".write-")
+	}
+}
+
+func TestWriteFileAtomic_TempDirMissing(t *testing.T) {
+	err := writeFileAtomic(filepath.Join(t.TempDir(), "missing"), "irrelevant", []byte("x"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create temp file")
+}
+
+func TestReferenceCache_Add_RewritesEvictedNamespaceSnapshot(t *testing.T) {
+	r := require.New(t)
+	dir := filepath.Join(t.TempDir(), "refcache")
+
+	refA, err := registry.ParseReference("ghcr.io/a/repo:v1")
+	r.NoError(err)
+	refB, err := registry.ParseReference("ghcr.io/b/repo:v1")
+	r.NoError(err)
+
+	descA := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageManifest,
+		Digest:    digest.FromBytes([]byte("a")),
+		Size:      1,
+	}
+	descB := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageManifest,
+		Digest:    digest.FromBytes([]byte("b")),
+		Size:      1,
+	}
+
+	c1, err := NewReferenceCache(Options{Dir: dir, MaxEntries: 1})
+	r.NoError(err)
+
+	c1.Add(refA, descA)
+	c1.Add(refB, descB) // triggers capacity eviction of A
+
+	_, ok := c1.Lookup(refA)
+	r.False(ok, "A must be evicted from memory")
+
+	c2, err := NewReferenceCache(Options{Dir: dir, MaxEntries: 2})
+	r.NoError(err)
+
+	_, ok = c2.Lookup(refA)
+	assert.False(t, ok, "snapshot-evicted reference must not survive restart")
+
+	gotB, ok := c2.Lookup(refB)
+	r.True(ok)
+	assert.Equal(t, descB, gotB)
+}

--- a/bindings/go/oci/cache/remote_policy_test.go
+++ b/bindings/go/oci/cache/remote_policy_test.go
@@ -1,0 +1,154 @@
+package cache
+
+import (
+	"context"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/registry"
+
+	identityv1 "ocm.software/open-component-model/bindings/go/oci/spec/identity/v1"
+)
+
+// ---- Options validation ----
+
+func TestOptions_DefaultPolicyIsAlways(t *testing.T) {
+	assert.Equal(t, RemotePolicyAlways, Defaults().RemotePolicy)
+}
+
+func TestOptions_ExplicitAlwaysAccepted(t *testing.T) {
+	opts, err := Options{Dir: t.TempDir(), RemotePolicy: RemotePolicyAlways}.applyDefaults()
+	require.NoError(t, err)
+	assert.Equal(t, RemotePolicyAlways, opts.RemotePolicy)
+}
+
+func TestOptions_InvalidPolicyRejected(t *testing.T) {
+	_, err := Options{Dir: t.TempDir(), RemotePolicy: "Never"}.applyDefaults()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported RemotePolicy")
+}
+
+// ---- BlobCache remote policy ----
+
+func TestBlobCache_IfNotPresent_NoExistsOnHit(t *testing.T) {
+	c := newTestCache(t, Options{RemotePolicy: RemotePolicyIfNotPresent})
+	base := newFakeReadOnly()
+	desc := base.put(ociImageSpecV1.MediaTypeImageManifest, []byte(`{"schemaVersion":2}`))
+
+	rc1, err := c.Fetch(t.Context(), base, desc)
+	require.NoError(t, err)
+	_ = readAllAndClose(t, rc1)
+
+	rc2, err := c.Fetch(t.Context(), base, desc)
+	require.NoError(t, err)
+	_ = readAllAndClose(t, rc2)
+
+	assert.EqualValues(t, 1, base.fetches.Load(), "fetches")
+	assert.EqualValues(t, 0, base.exists.Load(), "exists must not be called with IfNotPresent")
+}
+
+func TestBlobCache_Always_ExistsCalledOnHit(t *testing.T) {
+	c := newTestCache(t, Options{RemotePolicy: RemotePolicyAlways})
+	base := newFakeReadOnly()
+	manifest := []byte(`{"schemaVersion":2}`)
+	desc := base.put(ociImageSpecV1.MediaTypeImageManifest, manifest)
+
+	rc1, err := c.Fetch(t.Context(), base, desc)
+	require.NoError(t, err)
+	assert.Equal(t, manifest, readAllAndClose(t, rc1))
+
+	rc2, err := c.Fetch(t.Context(), base, desc)
+	require.NoError(t, err)
+	assert.Equal(t, manifest, readAllAndClose(t, rc2))
+
+	assert.EqualValues(t, 1, base.fetches.Load(), "fetches")
+	assert.EqualValues(t, 1, base.exists.Load(), "exists must be called on cache hit with Always")
+}
+
+func TestBlobCache_Always_ExistsDeniedReturnsError(t *testing.T) {
+	c := newTestCache(t, Options{RemotePolicy: RemotePolicyAlways})
+	base := newFakeReadOnly()
+	manifest := []byte(`{"schemaVersion":2}`)
+	desc := base.put(ociImageSpecV1.MediaTypeImageManifest, manifest)
+
+	rc1, err := c.Fetch(t.Context(), base, desc)
+	require.NoError(t, err)
+	_ = readAllAndClose(t, rc1)
+
+	base.remove(desc.Digest)
+
+	_, err = c.Fetch(t.Context(), base, desc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "remote does not contain")
+	assert.EqualValues(t, 1, base.exists.Load())
+}
+
+// ---- ReferenceCache remote policy ----
+
+func TestReferenceCache_IfNotPresent_HitAvoidsUpstream(t *testing.T) {
+	c := newTestRefCache(t, Options{RemotePolicy: RemotePolicyIfNotPresent})
+
+	desc := ociImageSpecV1.Descriptor{MediaType: ociImageSpecV1.MediaTypeImageManifest, Size: 1}
+	ref, err := registry.ParseReference("ghcr.io/owner/repo:v1")
+	require.NoError(t, err)
+
+	var resolves atomic.Int64
+	up := resolverFn(func(_ context.Context, _ string) (ociImageSpecV1.Descriptor, error) {
+		resolves.Add(1)
+		return desc, nil
+	})
+
+	_, err = c.Resolve(t.Context(), up, ref)
+	require.NoError(t, err)
+
+	_, err = c.Resolve(t.Context(), up, ref)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, 1, resolves.Load(), "IfNotPresent must not call upstream on hit")
+}
+
+func TestReferenceCache_Always_AlwaysCallsUpstream(t *testing.T) {
+	c := newTestRefCache(t, Options{RemotePolicy: RemotePolicyAlways})
+
+	desc := ociImageSpecV1.Descriptor{MediaType: ociImageSpecV1.MediaTypeImageManifest, Size: 1}
+	ref, err := registry.ParseReference("ghcr.io/owner/repo:v1")
+	require.NoError(t, err)
+
+	var resolves atomic.Int64
+	up := resolverFn(func(_ context.Context, _ string) (ociImageSpecV1.Descriptor, error) {
+		resolves.Add(1)
+		return desc, nil
+	})
+
+	_, err = c.Resolve(t.Context(), up, ref)
+	require.NoError(t, err)
+
+	_, err = c.Resolve(t.Context(), up, ref)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, 2, resolves.Load(), "Always must call upstream on every resolve")
+}
+
+// ---- Provider scope ----
+
+func TestProviderScope_SameIdentityProducesSameKey(t *testing.T) {
+	id := &identityv1.OCIRegistryIdentity{Hostname: "ghcr.io", Path: "owner/repo"}
+	assert.Equal(t, RepositoryKey(id), RepositoryKey(id))
+}
+
+func TestProviderScope_DifferentRepositoryPathDifferentKey(t *testing.T) {
+	id1 := &identityv1.OCIRegistryIdentity{Hostname: "ghcr.io", Path: "owner/repo"}
+	id2 := &identityv1.OCIRegistryIdentity{Hostname: "ghcr.io", Path: "owner/other"}
+	assert.NotEqual(t, RepositoryKey(id1), RepositoryKey(id2))
+}
+
+func TestProviderScope_ReferenceCacheDirDeterministic(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "refcache")
+	id := &identityv1.OCIRegistryIdentity{Hostname: "ghcr.io", Path: "owner/repo"}
+	scope := RepositoryKey(id)
+	assert.Equal(t, filepath.Join(base, scope), filepath.Join(base, RepositoryKey(id)))
+}

--- a/bindings/go/oci/cache/repository.go
+++ b/bindings/go/oci/cache/repository.go
@@ -1,0 +1,117 @@
+package cache
+
+import (
+	"context"
+	"io"
+
+	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/registry/remote"
+
+	"ocm.software/open-component-model/bindings/go/oci/internal/remotestore"
+	"ocm.software/open-component-model/bindings/go/oci/spec"
+)
+
+// Repository decorates an oras [*remote.Repository] with optional
+// [BlobCache] and [ReferenceCache] layers. The embedded
+// [*remote.Repository] is exposed via Go field promotion so type
+// assertions used elsewhere in the codebase
+// ([registry.TagLister], [registry.ReferrerLister],
+// `interface{ Blobs() registry.BlobStore }`) keep working unchanged.
+//
+// Either cache may be nil; the corresponding override degrades to a
+// pure passthrough to the embedded *remote.Repository.
+type Repository struct {
+	*remote.Repository
+	BlobCache      *BlobCache
+	ReferenceCache *ReferenceCache
+}
+
+// Fetch consults [Repository.BlobCache] before delegating to the
+// embedded [*remote.Repository]. See [BlobCache.Fetch] for the exact
+// semantics: cache hit returns the on-disk file directly; miss
+// performs the upstream fetch and tees into the cache. Layer blobs
+// and other non-manifest media types pass through transparently.
+//
+// When BlobCache is nil, this is a direct passthrough.
+func (r *Repository) Fetch(ctx context.Context, target ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+	return r.BlobCache.Fetch(ctx, r.Repository, target)
+}
+
+// Resolve consults [Repository.ReferenceCache] before delegating to
+// the embedded [*remote.Repository]. See [ReferenceCache.Resolve] for
+// the exact semantics. Successful resolves are appended to the
+// snapshot so they survive a process restart against the same Dir.
+//
+// The cache key is namespaced by the embedded *remote.Repository's
+// registry/repository so two repositories that happen to share a
+// short reference (e.g. the tag "v1") cannot collide.
+//
+// When ReferenceCache is nil, this is a direct passthrough.
+func (r *Repository) Resolve(ctx context.Context, reference string) (ociImageSpecV1.Descriptor, error) {
+	if r.ReferenceCache == nil {
+		return r.Repository.Resolve(ctx, reference)
+	}
+	ref, err := r.ParseReference(reference)
+	if err != nil {
+		return ociImageSpecV1.Descriptor{}, err
+	}
+	return r.ReferenceCache.Resolve(ctx, r.Repository, ref)
+}
+
+// Unwrap returns the embedded [*remote.Repository] so consumers that
+// type-assert on the underlying store (e.g. global-store detection in
+// internal/pack) can see through the cache decorator.
+func (r *Repository) Unwrap() content.Storage {
+	return r.Repository
+}
+
+// Untag implements [content.Untagger] by delegating to the underlying
+// remote repository so alias deletion keeps working when the cache
+// decorator is in the store chain. On success it invalidates the
+// reference cache entry so a restart does not resurrect the stale
+// tag→descriptor mapping.
+func (r *Repository) Untag(ctx context.Context, reference string) error {
+	if err := (&remotestore.RemoteStore{Repository: r.Repository}).Untag(ctx, reference); err != nil {
+		return err
+	}
+	if r.ReferenceCache != nil {
+		ref, err := r.ParseReference(reference)
+		if err != nil {
+			return err
+		}
+		r.ReferenceCache.Invalidate(ref)
+	}
+	return nil
+}
+
+// Tag associates reference with desc on the underlying remote
+// repository and, on success, refreshes the reference cache so the
+// mutable tag now resolves to the newly tagged descriptor. Without
+// this the cache would keep serving a previously resolved digest for
+// the tag until TTL expiry (OCI tags are mutable). A nil
+// ReferenceCache degrades to a pure passthrough.
+func (r *Repository) Tag(ctx context.Context, desc ociImageSpecV1.Descriptor, reference string) error {
+	if err := r.Repository.Tag(ctx, desc, reference); err != nil {
+		return err
+	}
+	if r.ReferenceCache != nil {
+		ref, err := r.ParseReference(reference)
+		if err != nil {
+			return err
+		}
+		r.ReferenceCache.Add(ref, desc)
+	}
+	return nil
+}
+
+// ProxyRepository proxies the given repo with the configured caches
+// when at least one is non-nil; otherwise it returns repo unchanged
+// so the cache decorator only appears in the type chain when there
+// is something to cache.
+func ProxyRepository(repo *remote.Repository, blob *BlobCache, refs *ReferenceCache) spec.Store {
+	if blob == nil && refs == nil {
+		return repo
+	}
+	return &Repository{Repository: repo, BlobCache: blob, ReferenceCache: refs}
+}

--- a/bindings/go/oci/cache/repository_test.go
+++ b/bindings/go/oci/cache/repository_test.go
@@ -1,0 +1,266 @@
+package cache
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/registry"
+	"oras.land/oras-go/v2/registry/remote"
+)
+
+func TestRepository_Fetch_DelegatesToBlobCache(t *testing.T) {
+	c := newTestCache(t, Options{})
+	manifest := []byte(`{"schemaVersion":2}`)
+	desc := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageManifest,
+		Digest:    digest.FromBytes(manifest),
+		Size:      int64(len(manifest)),
+	}
+	_, err := c.populate(t.Context(), desc.Digest, desc.Size, bytes.NewReader(manifest))
+	require.NoError(t, err)
+
+	// Cache hit serves the file; the embedded *remote.Repository is
+	// never reached, so an empty value is fine.
+	repo := &Repository{Repository: &remote.Repository{}, BlobCache: c}
+	rc, err := repo.Fetch(t.Context(), desc)
+	require.NoError(t, err)
+	defer rc.Close()
+	got, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, manifest, got)
+}
+
+func TestRepository_Resolve_DelegatesToReferenceCache(t *testing.T) {
+	rc := newTestRefCache(t, Options{})
+	desc := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageManifest,
+		Digest:    digest.FromBytes([]byte("x")),
+		Size:      1,
+	}
+	// Use a fully-qualified Reference so the wrapper computes a stable
+	// per-repository namespace; the cache pre-populate must use the
+	// same namespace ("registry/repository") to be considered a hit.
+	inner := &remote.Repository{
+		Reference: registry.Reference{Registry: "ghcr.io", Repository: "owner/repo"},
+	}
+	rc.Add(registry.Reference{Registry: "ghcr.io", Repository: "owner/repo", Reference: "ref-1"}, desc)
+
+	repo := &Repository{Repository: inner, ReferenceCache: rc}
+	got, err := repo.Resolve(t.Context(), "ref-1")
+	require.NoError(t, err)
+	assert.Equal(t, desc, got)
+}
+
+func TestRepository_Resolve_WithFullReferenceAndNormalization(t *testing.T) {
+	rc := newTestRefCache(t, Options{})
+	desc := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageManifest,
+		Digest:    digest.FromBytes([]byte("normalized-test")),
+		Size:      15,
+	}
+	inner := &remote.Repository{
+		Reference: registry.Reference{Registry: "ghcr.io", Repository: "owner/repo"},
+	}
+	repo := &Repository{Repository: inner, ReferenceCache: rc}
+
+	// 1. Add as normalized tag to cache
+	rc.Add(registry.Reference{
+		Registry:   "ghcr.io",
+		Repository: "owner/repo",
+		Reference:  "v1",
+	}, desc)
+
+	// 2. Resolve using fully-qualified reference (should hit, since ParseReference normalizes it to "v1")
+	gotFull, err := repo.Resolve(t.Context(), "ghcr.io/owner/repo:v1")
+	require.NoError(t, err)
+	assert.Equal(t, desc, gotFull)
+}
+
+func TestRepository_Unwrap_ReturnsEmbedded(t *testing.T) {
+	inner := &remote.Repository{}
+	repo := &Repository{Repository: inner, BlobCache: newTestCache(t, Options{})}
+	assert.Same(t, inner, repo.Unwrap())
+}
+
+func TestProxyRepository_NilCachesReturnBase(t *testing.T) {
+	inner := &remote.Repository{}
+	got := ProxyRepository(inner, nil, nil)
+	assert.Same(t, inner, got)
+}
+
+func TestProxyRepository_BlobCacheOnlyWraps(t *testing.T) {
+	inner := &remote.Repository{}
+	c := newTestCache(t, Options{})
+	got := ProxyRepository(inner, c, nil)
+	wrapped, ok := got.(*Repository)
+	require.True(t, ok)
+	assert.Same(t, inner, wrapped.Repository)
+	assert.Same(t, c, wrapped.BlobCache)
+	assert.Nil(t, wrapped.ReferenceCache)
+}
+
+func TestProxyRepository_ReferenceCacheOnlyWraps(t *testing.T) {
+	inner := &remote.Repository{}
+	rc := newTestRefCache(t, Options{})
+	got := ProxyRepository(inner, nil, rc)
+	wrapped, ok := got.(*Repository)
+	require.True(t, ok)
+	assert.Same(t, inner, wrapped.Repository)
+	assert.Nil(t, wrapped.BlobCache)
+	assert.Same(t, rc, wrapped.ReferenceCache)
+}
+
+func TestProxyRepository_BothCachesWrap(t *testing.T) {
+	inner := &remote.Repository{}
+	c := newTestCache(t, Options{})
+	rc := newTestRefCache(t, Options{})
+	got := ProxyRepository(inner, c, rc)
+	wrapped, ok := got.(*Repository)
+	require.True(t, ok)
+	assert.Same(t, inner, wrapped.Repository)
+	assert.Same(t, c, wrapped.BlobCache)
+	assert.Same(t, rc, wrapped.ReferenceCache)
+}
+
+// plainHTTPRepo builds a *remote.Repository pointed at srv over plain
+// HTTP with the standard "<addr>/test-repo" reference.
+func plainHTTPRepo(t *testing.T, srv *httptest.Server) *remote.Repository {
+	t.Helper()
+	repo, err := remote.NewRepository(srv.Listener.Addr().String() + "/test-repo")
+	require.NoError(t, err)
+	repo.PlainHTTP = true
+	repo.Client = &http.Client{}
+	return repo
+}
+
+func TestRepository_Untag_SuccessInvalidatesCache(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(srv.Close)
+
+	inner := plainHTTPRepo(t, srv)
+	rc := newTestRefCache(t, Options{})
+	repo := &Repository{Repository: inner, ReferenceCache: rc}
+
+	ref := registry.Reference{
+		Registry:   inner.Reference.Registry,
+		Repository: inner.Reference.Repository,
+		Reference:  "latest",
+	}
+
+	desc := ociImageSpecV1.Descriptor{Digest: digest.FromBytes([]byte("x")), Size: 1}
+	rc.Add(ref, desc)
+	_, ok := rc.Lookup(ref)
+	require.True(t, ok)
+
+	require.NoError(t, repo.Untag(t.Context(), "latest"))
+	_, ok = rc.Lookup(ref)
+	assert.False(t, ok, "successful Untag must invalidate the cached mapping")
+}
+
+func TestRepository_Untag_FailureKeepsCache(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	t.Cleanup(srv.Close)
+
+	inner := plainHTTPRepo(t, srv)
+	rc := newTestRefCache(t, Options{})
+	repo := &Repository{Repository: inner, ReferenceCache: rc}
+
+	ref := registry.Reference{
+		Registry:   inner.Reference.Registry,
+		Repository: inner.Reference.Repository,
+		Reference:  "latest",
+	}
+
+	desc := ociImageSpecV1.Descriptor{Digest: digest.FromBytes([]byte("x")), Size: 1}
+	rc.Add(ref, desc)
+
+	require.Error(t, repo.Untag(t.Context(), "latest"))
+	_, ok := rc.Lookup(ref)
+	assert.True(t, ok, "a failed Untag must not invalidate the cached mapping")
+}
+
+func TestRepository_Untag_NilReferenceCache(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(srv.Close)
+
+	repo := &Repository{Repository: plainHTTPRepo(t, srv)}
+	require.NoError(t, repo.Untag(t.Context(), "latest"))
+}
+
+func TestRepository_Tag_SuccessRefreshesCache(t *testing.T) {
+	manifest := []byte(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json"}`)
+	desc := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageManifest,
+		Digest:    digest.FromBytes(manifest),
+		Size:      int64(len(manifest)),
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v2/test-repo/manifests/"+desc.Digest.String():
+			w.Header().Set("Content-Type", desc.MediaType)
+			w.Header().Set("Docker-Content-Digest", desc.Digest.String())
+			_, _ = w.Write(manifest)
+		case r.Method == http.MethodPut && r.URL.Path == "/v2/test-repo/manifests/latest":
+			w.Header().Set("Docker-Content-Digest", desc.Digest.String())
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	inner := plainHTTPRepo(t, srv)
+	rc := newTestRefCache(t, Options{})
+	repo := &Repository{Repository: inner, ReferenceCache: rc}
+
+	ref := registry.Reference{
+		Registry:   inner.Reference.Registry,
+		Repository: inner.Reference.Repository,
+		Reference:  "latest",
+	}
+
+	require.NoError(t, repo.Tag(t.Context(), desc, "latest"))
+	got, ok := rc.Lookup(ref)
+	require.True(t, ok, "successful Tag must populate the reference cache")
+	assert.Equal(t, desc, got)
+}
+
+func TestRepository_Tag_FailureLeavesCacheEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	inner := plainHTTPRepo(t, srv)
+	rc := newTestRefCache(t, Options{})
+	repo := &Repository{Repository: inner, ReferenceCache: rc}
+
+	ref := registry.Reference{
+		Registry:   inner.Reference.Registry,
+		Repository: inner.Reference.Repository,
+		Reference:  "latest",
+	}
+
+	desc := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageManifest,
+		Digest:    digest.FromBytes([]byte("x")),
+		Size:      1,
+	}
+	require.Error(t, repo.Tag(t.Context(), desc, "latest"))
+	_, ok := rc.Lookup(ref)
+	assert.False(t, ok, "a failed Tag must not populate the reference cache")
+}

--- a/bindings/go/oci/cache/scope.go
+++ b/bindings/go/oci/cache/scope.go
@@ -1,0 +1,37 @@
+package cache
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	identityv1 "ocm.software/open-component-model/bindings/go/oci/spec/identity/v1"
+)
+
+// RepositoryKey returns a stable, filesystem-safe string that uniquely
+// identifies a registry repository by its location only, without any
+// credential material. It is used to derive an isolated cache
+// subdirectory per repository so blobs and manifests from different
+// repositories do not collide.
+//
+// The key is a 16-hex-character SHA-256 prefix of:
+//
+//	"<hostname>[:<port>]<path>"
+//
+// Credential material is deliberately excluded: short-lived tokens
+// would create new scope keys and kill cache reuse. Use
+// [RemotePolicyAlways] instead when remote authorisation must be
+// verified on every cache hit.
+func RepositoryKey(identity *identityv1.OCIRegistryIdentity) string {
+	var b strings.Builder
+	if identity != nil {
+		b.WriteString(identity.Hostname)
+		if identity.Port != "" {
+			b.WriteByte(':')
+			b.WriteString(identity.Port)
+		}
+		b.WriteString(identity.Path)
+	}
+	sum := sha256.Sum256([]byte(b.String()))
+	return hex.EncodeToString(sum[:8])
+}

--- a/bindings/go/oci/cache/scope_test.go
+++ b/bindings/go/oci/cache/scope_test.go
@@ -1,0 +1,50 @@
+package cache
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	identityv1 "ocm.software/open-component-model/bindings/go/oci/spec/identity/v1"
+)
+
+func TestRepositoryKey_Deterministic(t *testing.T) {
+	id := &identityv1.OCIRegistryIdentity{Hostname: "ghcr.io", Path: "owner/repo"}
+	assert.Equal(t, RepositoryKey(id), RepositoryKey(id))
+}
+
+func TestRepositoryKey_FormatIs16Hex(t *testing.T) {
+	got := RepositoryKey(&identityv1.OCIRegistryIdentity{Hostname: "ghcr.io"})
+	assert.Len(t, got, 16)
+	assert.NotContains(t, got, "/")
+	for _, r := range got {
+		assert.True(t, strings.ContainsRune("0123456789abcdef", r), "non-hex char %q", r)
+	}
+}
+
+func TestRepositoryKey_NilIdentity(t *testing.T) {
+	got := RepositoryKey(nil)
+	assert.Len(t, got, 16)
+}
+
+func TestRepositoryKey_DifferentPathsDistinct(t *testing.T) {
+	base := RepositoryKey(&identityv1.OCIRegistryIdentity{Hostname: "ghcr.io", Path: "owner/repo"})
+	other := RepositoryKey(&identityv1.OCIRegistryIdentity{Hostname: "ghcr.io", Path: "owner/other"})
+	assert.NotEqual(t, base, other)
+}
+
+func TestRepositoryKey_PortAffectsKey(t *testing.T) {
+	base := RepositoryKey(&identityv1.OCIRegistryIdentity{Hostname: "ghcr.io", Path: "owner/repo"})
+	withPort := RepositoryKey(&identityv1.OCIRegistryIdentity{Hostname: "ghcr.io", Port: "5000", Path: "owner/repo"})
+	assert.NotEqual(t, base, withPort)
+}
+
+func TestRepositoryKey_CredentialsDoNotAffectKey(t *testing.T) {
+	id := &identityv1.OCIRegistryIdentity{Hostname: "ghcr.io", Path: "owner/repo"}
+	k1 := RepositoryKey(id)
+	// Calling with the same identity but conceptually different "users" must
+	// produce the same key — credentials are not part of RepositoryKey.
+	k2 := RepositoryKey(id)
+	assert.Equal(t, k1, k2)
+}

--- a/bindings/go/oci/internal/pack/pack.go
+++ b/bindings/go/oci/internal/pack/pack.go
@@ -300,15 +300,23 @@ func setGlobalAccess(baseReference string, desc ociImageSpecV1.Descriptor, local
 	}
 }
 
-// backedByGlobalStore checks if the given storage is backed by a globally reachable store
+// backedByGlobalStore checks if the given storage is backed by a globally reachable store.
+//
+// Decorators that wrap a global store (e.g. the manifest blob cache
+// in resolver/url) may implement an Unwrap method returning the
+// underlying store; this function unwraps recursively so the test
+// looks through the decorator chain.
 //
 // TODO(jakobmoellerdev): Eventually we should find a smarter solution to determine if a store is global.
 func backedByGlobalStore(storage content.Storage) bool {
-	switch storage.(type) {
+	switch s := storage.(type) {
+	// for ORAS repositories, we know they are global if they are remote repositories.
 	case *remote.Repository:
 		return true
 	case *remotestore.RemoteStore:
 		return true
+	case interface{ Unwrap() content.Storage }:
+		return backedByGlobalStore(s.Unwrap())
 	default:
 		return false
 	}

--- a/bindings/go/oci/repository.go
+++ b/bindings/go/oci/repository.go
@@ -900,6 +900,7 @@ func getDescriptorOCIImageManifest(ctx context.Context, store spec.Store, refere
 		if descriptorManifest.MediaType != ociImageSpecV1.MediaTypeImageManifest {
 			return ociImageSpecV1.Manifest{}, nil, fmt.Errorf("index manifest is not an OCI image manifest")
 		}
+		slogcontext.Log(ctx, slog.LevelDebug, "fetching first manifest from index", log.DescriptorLogAttr(descriptorManifest))
 		indexManifestRaw, err := store.Fetch(ctx, descriptorManifest)
 		defer func() {
 			err = errors.Join(err, indexManifestRaw.Close())

--- a/bindings/go/oci/repository/provider/options.go
+++ b/bindings/go/oci/repository/provider/options.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	httpv1alpha1 "ocm.software/open-component-model/bindings/go/http/spec/config/v1alpha1"
+	"ocm.software/open-component-model/bindings/go/oci/cache"
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
@@ -30,6 +31,20 @@ type Options struct {
 	// Accepts the serialisable config type so that external plugins can
 	// round-trip it over the wire and reconstruct an equivalent client.
 	HTTPConfig *httpv1alpha1.Config
+
+	// BlobCacheOptions, when non-nil, configures the manifest blob cache
+	// the provider builds and shares across every OCI repository it hands
+	// out. The zero value [cache.Options]{} is sufficient for sane
+	// defaults — only Dir is auto-derived from TempDir when left empty.
+	// Leave nil to disable blob caching entirely.
+	BlobCacheOptions *cache.Options
+
+	// ReferenceCacheOptions, when non-nil, configures the reference
+	// cache the provider builds and shares across every OCI repository
+	// it hands out. The zero value [cache.Options]{} is sufficient for
+	// sane defaults — only Dir is auto-derived from TempDir when left
+	// empty. Leave nil to disable reference caching entirely.
+	ReferenceCacheOptions *cache.Options
 }
 
 type Option func(*Options)
@@ -65,5 +80,29 @@ func WithScheme(scheme *runtime.Scheme) Option {
 func WithHTTPConfig(cfg *httpv1alpha1.Config) Option {
 	return func(o *Options) {
 		o.HTTPConfig = cfg
+	}
+}
+
+// WithBlobCacheOptions enables a shared manifest blob cache across every
+// OCI repository the provider hands out. Pass [cache.Options]{} for
+// sane defaults; pass nil (the default) to disable caching. The cache
+// directory defaults to <TempDir>/ocm-oci-blobcache and is deterministic
+// so consecutive provider instances over the same TempDir reuse the
+// existing on-disk entries.
+func WithBlobCacheOptions(opts *cache.Options) Option {
+	return func(o *Options) {
+		o.BlobCacheOptions = opts
+	}
+}
+
+// WithReferenceCacheOptions enables a shared reference cache across
+// every OCI repository the provider hands out. Pass [cache.Options]{}
+// for sane defaults; pass nil (the default) to disable. The cache
+// directory defaults to <TempDir>/ocm-oci-refcache and is
+// deterministic so consecutive provider instances over the same
+// TempDir reuse the existing on-disk snapshot.
+func WithReferenceCacheOptions(opts *cache.Options) Option {
+	return func(o *Options) {
+		o.ReferenceCacheOptions = opts
 	}
 }

--- a/bindings/go/oci/repository/provider/provider.go
+++ b/bindings/go/oci/repository/provider/provider.go
@@ -4,15 +4,22 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
 
+	"golang.org/x/sync/singleflight"
 	"oras.land/oras-go/v2/registry/remote/auth"
 
 	ocmhttp "ocm.software/open-component-model/bindings/go/http"
 	"ocm.software/open-component-model/bindings/go/oci"
+	"ocm.software/open-component-model/bindings/go/oci/cache"
 	"ocm.software/open-component-model/bindings/go/oci/credentials"
 	ocictf "ocm.software/open-component-model/bindings/go/oci/ctf"
 	ocirepository "ocm.software/open-component-model/bindings/go/oci/repository"
+	urlresolver "ocm.software/open-component-model/bindings/go/oci/resolver/url"
 	v2 "ocm.software/open-component-model/bindings/go/oci/spec/credentials/v1"
 	"ocm.software/open-component-model/bindings/go/oci/spec/identity/v1"
 	repoSpec "ocm.software/open-component-model/bindings/go/oci/spec/repository"
@@ -59,6 +66,45 @@ type CachingComponentVersionRepositoryProvider struct {
 	// (such as the extracted directory representation of a tar
 	// or tar.gz ctf archive).
 	tempDir string
+
+	// blobCacheOpts, when non-nil, enables a shared content-addressable blob
+	// cache. All credential scopes share one BlobCache because blobs are
+	// immutable and identified by digest — a digest unambiguously identifies
+	// content regardless of who fetched it. Only tag→digest resolution is
+	// access-controlled; once you hold a digest you are authorised.
+	//
+	// Note: while an attacker who *guesses* a digest could observe its
+	// existence in the cache, they must first obtain the digest via a
+	// [cache.ReferenceCache.Resolve] under credentials that entitle them
+	// to see the tag — which IS credential-scoped. When we grow the
+	// blob cache to cover resource layers, callers with weaker
+	// credentials must not be able to learn digests from a stronger
+	// scope, so revisit this decision if the cache starts holding
+	// layer blobs (see open-component-model#2833 discussion).
+	blobCacheOpts *cache.Options
+
+	// referenceCacheOpts, when non-nil, enables per-scope reference caches.
+	// Tag resolution IS access-controlled (a private registry won't return a
+	// descriptor for a tag you can't read), so each credential scope gets its
+	// own ReferenceCache to prevent one scope from reading tag mappings
+	// resolved under a different credential set.
+	referenceCacheOpts *cache.Options
+
+	// sharedBlobCache is the single process-wide BlobCache shared across all
+	// credential scopes. Initialised lazily on first use via [sync.OnceValue].
+	sharedBlobCache func() *cache.BlobCache
+
+	// referenceCaches stores one *cache.ReferenceCache per credential scope key.
+	referenceCaches sync.Map // string → *cache.ReferenceCache
+
+	// referenceCacheInit serialises the constructor calls per scope
+	// key so a burst of first-use callers for the same scope does not
+	// each build (and discard) their own [cache.ReferenceCache]. The
+	// winner is published into referenceCaches; every other caller
+	// finds it there via Load without re-running the (expensive)
+	// on-disk reseed. Mirrors the pattern used by storeCache.loadOrStore
+	// (see open-component-model/ocm-project#694).
+	referenceCacheInit singleflight.Group
 }
 
 var _ repository.ComponentVersionRepositoryProvider = (*CachingComponentVersionRepositoryProvider)(nil)
@@ -79,7 +125,7 @@ func NewComponentVersionRepositoryProvider(opts ...Option) *CachingComponentVers
 		options.Scheme = repoSpec.Scheme
 	}
 
-	provider := &CachingComponentVersionRepositoryProvider{
+	prov := &CachingComponentVersionRepositoryProvider{
 		creator:    options.UserAgent,
 		scheme:     options.Scheme,
 		storeCache: &storeCache{store: make(map[string]*ocictf.Store)},
@@ -87,10 +133,15 @@ func NewComponentVersionRepositoryProvider(opts ...Option) *CachingComponentVers
 			ocmhttp.WithConfig(options.HTTPConfig),
 			ocmhttp.WithUserAgent(options.UserAgent),
 		),
-		tempDir: options.TempDir,
+		tempDir:            options.TempDir,
+		blobCacheOpts:      options.BlobCacheOptions,
+		referenceCacheOpts: options.ReferenceCacheOptions,
 	}
-
-	return provider
+	// Wire the shared blob cache constructor now that prov exists so the
+	// closure can read its final field values. sync.OnceValue guarantees
+	// the constructor runs at most once across all callers.
+	prov.sharedBlobCache = sync.OnceValue(prov.newSharedBlobCache)
+	return prov
 }
 
 func (b *CachingComponentVersionRepositoryProvider) GetComponentVersionRepositoryScheme() *runtime.Scheme {
@@ -159,14 +210,32 @@ func (b *CachingComponentVersionRepositoryProvider) GetComponentVersionRepositor
 			}
 		}
 
-		return ocirepository.NewFromOCIRepoV1(ctx, obj, &auth.Client{
+		var resolverOpts []urlresolver.Option
+		if b.blobCacheOpts != nil {
+			if bc := b.getOrCreateBlobCache(); bc != nil {
+				resolverOpts = append(resolverOpts, urlresolver.WithBlobCache(bc))
+			}
+		}
+		if b.referenceCacheOpts != nil {
+			if rc := b.getOrCreateReferenceCache(identity); rc != nil {
+				resolverOpts = append(resolverOpts, urlresolver.WithReferenceCache(rc))
+			}
+		}
+
+		resolver, err := ocirepository.NewResolver(ctx, &auth.Client{
 			Client:     b.httpClient,
 			Cache:      auth.NewCache(),
 			Credential: credentials.CredentialFunc(identity, ociCredentials),
 			Header: map[string][]string{
 				"User-Agent": {b.creator},
 			},
-		}, opts...)
+		}, obj, resolverOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("error creating oci repository resolver: %w", err)
+		}
+		opts = append(opts, oci.WithResolver(resolver))
+
+		return oci.NewRepository(opts...)
 	case *ctfrepospecv1.Repository:
 		loadFunc := func(path string) (*ocictf.Store, error) {
 			return ocirepository.NewStoreFromCTFRepoV1(ctx, obj, opts...)
@@ -189,6 +258,90 @@ func (b *CachingComponentVersionRepositoryProvider) GetComponentVersionRepositor
 	default:
 		return nil, fmt.Errorf("unsupported repository specification type %T", obj)
 	}
+}
+
+// getOrCreateBlobCache returns the process-wide shared BlobCache, initialising
+// it on first use. All credential scopes share one BlobCache because blobs are
+// content-addressed by digest — a digest uniquely and immutably identifies
+// content, so sharing across scopes cannot serve unexpected data. Deduplication
+// is therefore safe and avoids redundant disk storage when the same blob is
+// fetched by different callers.
+func (b *CachingComponentVersionRepositoryProvider) getOrCreateBlobCache() *cache.BlobCache {
+	return b.sharedBlobCache()
+}
+
+// newSharedBlobCache is the once-only constructor for the process-wide
+// blob cache; wired through [sync.OnceValue] in
+// [NewComponentVersionRepositoryProvider].
+func (b *CachingComponentVersionRepositoryProvider) newSharedBlobCache() *cache.BlobCache {
+	opts := *b.blobCacheOpts
+	if opts.Dir == "" {
+		base := b.tempDir
+		if base == "" {
+			base = os.TempDir()
+		}
+		opts.Dir = filepath.Join(base, "ocm-oci-cas")
+	}
+	c, err := cache.NewBlobCache(opts)
+	if err != nil {
+		slog.Warn("provider: failed to initialise shared blob cache, continuing without caching",
+			slog.String("err", err.Error()))
+		return nil
+	}
+	return c
+}
+
+// getOrCreateReferenceCache returns the ReferenceCache for the given repository
+// scope, creating and persisting it on first use. The scope is based solely on
+// repository identity (host[:port]/path); credentials are excluded because
+// short-lived tokens would create new scopes and kill cache reuse. Use
+// [RemotePolicyAlways] to require remote authorisation on every cache hit.
+//
+// Concurrent first-use callers for the same scope are collapsed via
+// [singleflight.Group] so exactly one [cache.NewReferenceCache] runs.
+func (b *CachingComponentVersionRepositoryProvider) getOrCreateReferenceCache(
+	identity *v1.OCIRegistryIdentity,
+) *cache.ReferenceCache {
+	scope := cache.RepositoryKey(identity)
+	if v, ok := b.referenceCaches.Load(scope); ok {
+		return v.(*cache.ReferenceCache)
+	}
+
+	v, err, _ := b.referenceCacheInit.Do(scope, func() (any, error) {
+		// Re-check under the singleflight so the leader picks up any
+		// concurrently-published cache instead of building another.
+		if existing, ok := b.referenceCaches.Load(scope); ok {
+			return existing, nil
+		}
+
+		opts := *b.referenceCacheOpts
+		if opts.Dir == "" {
+			base := b.tempDir
+			if base == "" {
+				base = os.TempDir()
+			}
+			opts.Dir = filepath.Join(base, "ocm-oci-refcache", scope)
+		} else {
+			opts.Dir = filepath.Join(opts.Dir, scope)
+		}
+
+		c, err := cache.NewReferenceCache(opts)
+		if err != nil {
+			return nil, err
+		}
+		b.referenceCaches.Store(scope, c)
+		return c, nil
+	})
+	if err != nil {
+		slog.Warn("provider: failed to initialise reference cache for scope, continuing without caching",
+			slog.String("scope", scope),
+			slog.String("err", err.Error()))
+		return nil
+	}
+	if v == nil {
+		return nil
+	}
+	return v.(*cache.ReferenceCache)
 }
 
 // getConvertedTypedSpec is a helper function that converts any runtime.Typed specification

--- a/bindings/go/oci/repository/repository.go
+++ b/bindings/go/oci/repository/repository.go
@@ -69,7 +69,12 @@ func NewStoreFromCTFRepoV1(ctx context.Context, repository *ctfrepospecv1.Reposi
 	return ocictf.NewFromCTF(archive), nil
 }
 
-// NewFromOCIRepoV1 creates a new [*oci.Repository] instance from an OCI repository v1 specification.
+// NewResolver creates a new [*urlresolver.CachingResolver] that can be used to create [*oci.Repository] instances from an OCI repository v1 specification.
+//
+// Extra resolver options (resolverOptions) are appended after the provider's
+// own resolver configuration, so callers can layer in cross-repository
+// concerns such as a manifest blob cache via [urlresolver.WithBlobCache]
+// without each repo having to construct its own.
 //
 // # Path Handling vs Old OCM
 //
@@ -82,18 +87,7 @@ func NewStoreFromCTFRepoV1(ctx context.Context, repository *ctfrepospecv1.Reposi
 //     https://github.com/open-component-model/ocm/blob/2b819e6/api/oci/extensions/repositories/ocireg/type.go#L104
 //   - Validate() uses HostInfo() to extract host, discarding any path
 //     https://github.com/open-component-model/ocm/blob/2b819e6/api/oci/extensions/repositories/ocireg/type.go#L138
-//
-// New OCM: Explicit BaseUrl + SubPath fields, consistent parsing, auto-extraction support
-func NewFromOCIRepoV1(_ context.Context, repository *ocirepospecv1.Repository, client remote.Client, options ...oci.RepositoryOption) (*oci.Repository, error) {
-	resolver, err := buildResolver(client, repository)
-	if err != nil {
-		return nil, fmt.Errorf("could not create OCI resolver for OCI repository %q: %w", repository.BaseUrl, err)
-	}
-
-	return oci.NewRepository(append(options, oci.WithResolver(resolver))...)
-}
-
-func buildResolver(client remote.Client, repository *ocirepospecv1.Repository) (*urlresolver.CachingResolver, error) {
+func NewResolver(_ context.Context, client remote.Client, repository *ocirepospecv1.Repository, extra ...urlresolver.Option) (*urlresolver.CachingResolver, error) {
 	if repository.BaseUrl == "" {
 		return nil, fmt.Errorf("a base url is required")
 	}
@@ -128,6 +122,7 @@ func buildResolver(client remote.Client, repository *ocirepospecv1.Repository) (
 	}
 
 	opts = append(opts, urlresolver.WithBaseClient(client))
+	opts = append(opts, extra...)
 
 	resolver, err := urlresolver.New(opts...)
 	if err != nil {
@@ -135,4 +130,24 @@ func buildResolver(client remote.Client, repository *ocirepospecv1.Repository) (
 	}
 
 	return resolver, nil
+}
+
+// NewFromOCIRepoV1 creates a new [*oci.Repository] instance from an OCI
+// repository v1 specification.
+//
+// Deprecated: Build the resolver explicitly with [NewResolver] (which
+// accepts [urlresolver.Option]s such as [urlresolver.WithBlobCache])
+// and pass it to [oci.NewRepository] directly:
+//
+//	resolver, err := NewResolver(client, repo)
+//	if err != nil { return nil, err }
+//	return oci.NewRepository(append(opts, oci.WithResolver(resolver))...)
+//
+// This wrapper is kept only for backwards compatibility.
+func NewFromOCIRepoV1(ctx context.Context, repository *ocirepospecv1.Repository, client remote.Client, options ...oci.RepositoryOption) (*oci.Repository, error) {
+	resolver, err := NewResolver(ctx, client, repository)
+	if err != nil {
+		return nil, fmt.Errorf("could not create OCI resolver for OCI repository %q: %w", repository.BaseUrl, err)
+	}
+	return oci.NewRepository(append(options, oci.WithResolver(resolver))...)
 }

--- a/bindings/go/oci/repository/repository_test.go
+++ b/bindings/go/oci/repository/repository_test.go
@@ -5,8 +5,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"ocm.software/open-component-model/bindings/go/oci/looseref"
 
+	"ocm.software/open-component-model/bindings/go/oci"
+	"ocm.software/open-component-model/bindings/go/oci/looseref"
 	ctfrepospecv1 "ocm.software/open-component-model/bindings/go/oci/spec/repository/v1/ctf"
 	ocirepospecv1 "ocm.software/open-component-model/bindings/go/oci/spec/repository/v1/oci"
 )
@@ -126,7 +127,11 @@ func TestNewFromOCIRepoV1(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			repo, err := NewFromOCIRepoV1(t.Context(), tt.repository, nil)
+			resolver, err := NewResolver(t.Context(), nil, tt.repository)
+			var repo *oci.Repository
+			if err == nil {
+				repo, err = oci.NewRepository(oci.WithResolver(resolver))
+			}
 			if tt.wantErr {
 				assert.Error(t, err)
 				if tt.errContains != "" {
@@ -253,7 +258,7 @@ func TestBuildResolver_SubPathExtraction(t *testing.T) {
 				SubPath: tt.subPath,
 			}
 
-			resolver, err := buildResolver(nil, repository)
+			resolver, err := NewResolver(t.Context(), nil, repository)
 			require.NoError(t, err)
 			require.NotNil(t, resolver)
 

--- a/bindings/go/oci/resolver/url/options.go
+++ b/bindings/go/oci/resolver/url/options.go
@@ -2,6 +2,8 @@ package url
 
 import (
 	"oras.land/oras-go/v2/registry/remote"
+
+	"ocm.software/open-component-model/bindings/go/oci/cache"
 )
 
 // Option is an interface for configuring the CachingResolver.
@@ -44,5 +46,29 @@ func WithPlainHTTP(plainHTTP bool) Option {
 func WithSubPath(subPath string) Option {
 	return OptionFunc(func(resolver *CachingResolver) {
 		resolver.subPath = subPath
+	})
+}
+
+// WithBlobCache wires a manifest blob cache into the resolver. Stores
+// returned by [CachingResolver.StoreForReference] are wrapped with
+// [cache.Repository] so their Fetch consults the cache; layer blobs
+// and other non-manifest media types pass through unchanged.
+//
+// Pass nil to disable blob caching (the default).
+func WithBlobCache(blob *cache.BlobCache) Option {
+	return OptionFunc(func(resolver *CachingResolver) {
+		resolver.SetBlobCache(blob)
+	})
+}
+
+// WithReferenceCache wires a reference cache into the resolver.
+// Stores returned by [CachingResolver.StoreForReference] are wrapped
+// with [cache.Repository] so their Resolve consults the reference
+// cache before performing a remote round-trip.
+//
+// Pass nil to disable reference caching (the default).
+func WithReferenceCache(refs *cache.ReferenceCache) Option {
+	return OptionFunc(func(resolver *CachingResolver) {
+		resolver.SetReferenceCache(refs)
 	})
 }

--- a/bindings/go/oci/resolver/url/resolver.go
+++ b/bindings/go/oci/resolver/url/resolver.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"sync/atomic"
 
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/errcode"
 
 	"ocm.software/open-component-model/bindings/go/oci"
+	"ocm.software/open-component-model/bindings/go/oci/cache"
 	"ocm.software/open-component-model/bindings/go/oci/internal/remotestore"
 	"ocm.software/open-component-model/bindings/go/oci/looseref"
 	"ocm.software/open-component-model/bindings/go/oci/spec"
@@ -43,7 +45,41 @@ type CachingResolver struct {
 	DisableCacheProxy bool
 
 	cacheMu sync.RWMutex
-	cache   map[string]spec.Store
+	cache   map[string]*remotestore.RemoteStore
+
+	// blobCache, when non-nil, is layered in front of every
+	// [*remote.Repository] this resolver hands out via
+	// [cache.Repository]. Configure via [WithBlobCache].
+	//
+	// Stored in an atomic.Pointer so [CachingResolver.SetBlobCache] can
+	// race with concurrent [CachingResolver.StoreForReference] calls
+	// without a data race — the doc contract of SetBlobCache says only
+	// stores handed out after the call must observe the new cache, so
+	// tearing is not tolerable.
+	blobCache atomic.Pointer[cache.BlobCache]
+
+	// referenceCache, when non-nil, short-circuits Resolve calls on
+	// every [*remote.Repository] this resolver hands out via
+	// [cache.Repository]. Configure via [WithReferenceCache]. Same
+	// concurrency contract as [CachingResolver.blobCache].
+	referenceCache atomic.Pointer[cache.ReferenceCache]
+}
+
+// SetBlobCache wires a manifest blob cache into the resolver. Stores
+// returned after this call (including those served from the resolver's
+// internal store cache) are wrapped with [cache.Repository] so their
+// Fetch consults the cache. Use [WithBlobCache] for the option-based
+// equivalent.
+func (resolver *CachingResolver) SetBlobCache(c *cache.BlobCache) {
+	resolver.blobCache.Store(c)
+}
+
+// SetReferenceCache wires a reference cache into the resolver. Stores
+// returned after this call are wrapped with [cache.Repository] so
+// their Resolve consults the cache. Use [WithReferenceCache] for the
+// option-based equivalent.
+func (resolver *CachingResolver) SetReferenceCache(c *cache.ReferenceCache) {
+	resolver.referenceCache.Store(c)
 }
 
 func (resolver *CachingResolver) SetClient(client remote.Client) {
@@ -112,8 +148,13 @@ func (resolver *CachingResolver) StoreForReference(_ context.Context, reference 
 		key = fmt.Sprintf("%s://%s", ref.Scheme, key)
 	}
 
-	if store, ok := resolver.getFromCache(key); ok {
-		return store, nil
+	if remoteStore, ok := resolver.getFromCache(key); ok {
+		blobCache := resolver.blobCache.Load()
+		refCache := resolver.referenceCache.Load()
+		if blobCache != nil || refCache != nil {
+			return cache.ProxyRepository(remoteStore.Repository, blobCache, refCache), nil
+		}
+		return remoteStore, nil
 	}
 
 	repo := &remote.Repository{
@@ -139,19 +180,24 @@ func (resolver *CachingResolver) StoreForReference(_ context.Context, reference 
 	store := &remotestore.RemoteStore{Repository: repo}
 	resolver.addToCache(key, store)
 
+	blobCache := resolver.blobCache.Load()
+	refCache := resolver.referenceCache.Load()
+	if blobCache != nil || refCache != nil {
+		return cache.ProxyRepository(repo, blobCache, refCache), nil
+	}
 	return store, nil
 }
 
-func (resolver *CachingResolver) addToCache(reference string, store spec.Store) {
+func (resolver *CachingResolver) addToCache(reference string, store *remotestore.RemoteStore) {
 	resolver.cacheMu.Lock()
 	defer resolver.cacheMu.Unlock()
 	if resolver.cache == nil {
-		resolver.cache = make(map[string]spec.Store)
+		resolver.cache = make(map[string]*remotestore.RemoteStore)
 	}
 	resolver.cache[reference] = store
 }
 
-func (resolver *CachingResolver) getFromCache(reference string) (spec.Store, bool) {
+func (resolver *CachingResolver) getFromCache(reference string) (*remotestore.RemoteStore, bool) {
 	resolver.cacheMu.RLock()
 	defer resolver.cacheMu.RUnlock()
 	store, ok := resolver.cache[reference]

--- a/bindings/go/oci/resolver/url/resolver_test.go
+++ b/bindings/go/oci/resolver/url/resolver_test.go
@@ -12,6 +12,8 @@ import (
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 
+	"ocm.software/open-component-model/bindings/go/oci/cache"
+	"ocm.software/open-component-model/bindings/go/oci/internal/remotestore"
 	"ocm.software/open-component-model/bindings/go/oci/resolver/url"
 )
 
@@ -476,4 +478,47 @@ func TestURLPathResolver_Ping(t *testing.T) {
 		assert.True(t, tokenFetched, "Expected token to be fetched from auth server")
 		assert.True(t, authUsed, "Expected bearer token to be used in request")
 	})
+}
+
+func TestURLPathResolver_DynamicCacheSwapping(t *testing.T) {
+	ctx := context.Background()
+	resolver, err := url.New(url.WithBaseURL("http://example.com"))
+	require.NoError(t, err)
+
+	ref := "example.com/test-component:v1.0.0"
+
+	// 1. Initially, no caches are set. StoreForReference should return the base *remotestore.RemoteStore.
+	store, err := resolver.StoreForReference(ctx, ref)
+	require.NoError(t, err)
+	assert.IsType(t, &remotestore.RemoteStore{}, store)
+
+	// 2. Set blob cache. StoreForReference for the same ref should return a wrapped *cache.Repository.
+	dummyBlobCache := &cache.BlobCache{}
+	resolver.SetBlobCache(dummyBlobCache)
+
+	store, err = resolver.StoreForReference(ctx, ref)
+	require.NoError(t, err)
+	require.IsType(t, &cache.Repository{}, store)
+	wrapped := store.(*cache.Repository)
+	assert.Equal(t, dummyBlobCache, wrapped.BlobCache)
+	assert.Nil(t, wrapped.ReferenceCache)
+
+	// 3. Set reference cache too.
+	dummyRefCache := &cache.ReferenceCache{}
+	resolver.SetReferenceCache(dummyRefCache)
+
+	store, err = resolver.StoreForReference(ctx, ref)
+	require.NoError(t, err)
+	require.IsType(t, &cache.Repository{}, store)
+	wrapped = store.(*cache.Repository)
+	assert.Equal(t, dummyBlobCache, wrapped.BlobCache)
+	assert.Equal(t, dummyRefCache, wrapped.ReferenceCache)
+
+	// 4. Set both back to nil. StoreForReference should return the base *remotestore.RemoteStore again.
+	resolver.SetBlobCache(nil)
+	resolver.SetReferenceCache(nil)
+
+	store, err = resolver.StoreForReference(ctx, ref)
+	require.NoError(t, err)
+	assert.IsType(t, &remotestore.RemoteStore{}, store)
 }

--- a/bindings/go/oci/store_descriptor.go
+++ b/bindings/go/oci/store_descriptor.go
@@ -203,6 +203,7 @@ func getDescriptorFromStore(ctx context.Context, store spec.Store, reference str
 		return nil, nil, nil, fmt.Errorf("failed to get manifest: %w", err)
 	}
 
+	slogcontext.Log(ctx, slog.LevelDebug, "fetching descriptor manifest config", log.DescriptorLogAttr(manifest.Config))
 	componentConfigRaw, err := store.Fetch(ctx, manifest.Config)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to get component config: %w", err)
@@ -217,7 +218,9 @@ func getDescriptorFromStore(ctx context.Context, store spec.Store, reference str
 	}
 
 	// Read component descriptor
-	descriptorRaw, err := store.Fetch(ctx, *cfg.ComponentDescriptorLayer)
+	descriptorLayer := *cfg.ComponentDescriptorLayer
+	slogcontext.Log(ctx, slog.LevelDebug, "fetching component descriptor layer", log.DescriptorLogAttr(descriptorLayer))
+	descriptorRaw, err := store.Fetch(ctx, descriptorLayer)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to fetch descriptor layer: %w", err)
 	}
@@ -225,7 +228,7 @@ func getDescriptorFromStore(ctx context.Context, store spec.Store, reference str
 		err = errors.Join(err, descriptorRaw.Close())
 	}()
 
-	desc, err = ocidescriptor.SingleFileDecodeDescriptor(descriptorRaw, cfg.ComponentDescriptorLayer.MediaType, unmarshal)
+	desc, err = ocidescriptor.SingleFileDecodeDescriptor(descriptorRaw, descriptorLayer.MediaType, unmarshal)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to decode descriptor: %w", err)
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

```go
// Package cache provides two disk-backed, TTL+LRU caches that layer
// on top of an oras [*remote.Repository] via [Repository]:
//
//   - [BlobCache] keys cached blobs by digest and stores each blob as
//     a file under `<Options.Dir>/blobs/<algo>/<hex>`. Its primary
//     consumer is [BlobCache.Fetch], which mirrors the oras-go
//     internal/cas/proxy.go pattern: the first Fetch of a descriptor
//     reads from upstream and tees the bytes to disk; subsequent
//     Fetches for the same digest serve the on-disk file. Push, Tag,
//     Resolve, FetchReference, and Exists on the wrapping
//     [Repository] are pure passthroughs.
//
//   - [ReferenceCache] keys cached resolves by (namespace, reference)
//     so two repositories that happen to share a short reference
//     (e.g. the tag "v1") cannot collide. Each namespace's entries
//     are persisted to its own file under
//     `<Options.Dir>/refs/<fnv1a(namespace)>.json`; the FNV-1a hash
//     is used purely to derive a compact filename — the canonical
//     namespace string is stored inside the snapshot body, so any
//     unlikely hash collision is recoverable.
```

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

This fixes various performance issues around recurring fetching of component versions, listing component versions and latency around fetching those.

#### Testing

I ran this against remote repositories with my local cli build

##### How to test the changes

Required files to test the changes:

cli/internal/plugin/builtin/oci/register.go
```go
cacheOpts := cache.Defaults()
	CachingComponentVersionRepositoryProvider := provider.NewComponentVersionRepositoryProvider(
		provider.WithTempDir(filesystemConfig.TempFolder),
		provider.WithUserAgent(creator),
		provider.WithHTTPConfig(httpConfig),
		provider.WithBlobCacheOptions(cacheOpts),
		provider.WithReferenceCacheOptions(cacheOpts),
	)
```


Commands that test the change:

```bash
ocm get cv xxx

ocm transfer xxx
```
-->

##### Verification

- [x] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [x] Tests pass locally (`task test` and `task test/integration` if applicable)
- [x] If touching multiple modules, `go work` is enabled (see `go.work`)
- [x] My changes do not decrease test coverage
- [x] I have tested the changes locally by running `ocm`
