### PR TITLE
fix(controller): do not list components on single versions in `semver`

### DIFF
--- a/kubernetes/controller/internal/controller/component/component_controller.go
+++ b/kubernetes/controller/internal/controller/component/component_controller.go
@@ -391,6 +391,13 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, component *v1alpha1.Co
 func (r *Reconciler) DetermineEffectiveVersionFromRepo(ctx context.Context, component *v1alpha1.Component,
 	repo repository.ComponentVersionRepository,
 ) (string, error) {
+	// Fast path: if Spec.Semver is a single version (not a constraint),
+	// skip the ListComponentVersions call. Any not-found error will be
+	// surfaced by the subsequent GetComponentVersion call.
+	if pinned, err := semver.NewVersion(component.Spec.Semver); err == nil {
+		return ocm.ApplyDowngradePolicy(component, pinned)
+	}
+
 	versions, err := repo.ListComponentVersions(ctx, component.Spec.Component)
 	if err != nil {
 		return "", fmt.Errorf("failed to list versions: %w", err)
@@ -407,27 +414,5 @@ func (r *Reconciler) DetermineEffectiveVersionFromRepo(ctx context.Context, comp
 		return "", reconcile.TerminalError(fmt.Errorf("failed to get valid latest version: %w", err))
 	}
 
-	// we didn't yet reconcile anything, return whatever the retrieved version is.
-	if component.Status.Component.Version == "" {
-		return latestSemver.Original(), nil
-	}
-
-	currentSemver, err := semver.NewVersion(component.Status.Component.Version)
-	if err != nil {
-		return "", reconcile.TerminalError(fmt.Errorf("failed to check reconciled version: %w", err))
-	}
-
-	if latestSemver.GreaterThanEqual(currentSemver) {
-		return latestSemver.Original(), nil
-	}
-
-	switch component.Spec.DowngradePolicy {
-	case v1alpha1.DowngradePolicyDeny:
-		return "", reconcile.TerminalError(fmt.Errorf("component version cannot be downgraded from version %s "+
-			"to version %s", currentSemver.Original(), latestSemver.Original()))
-	case v1alpha1.DowngradePolicyAllow:
-		return latestSemver.Original(), nil
-	default:
-		return "", reconcile.TerminalError(errors.New("unknown downgrade policy: " + string(component.Spec.DowngradePolicy)))
-	}
+	return ocm.ApplyDowngradePolicy(component, latestSemver)
 }

--- a/kubernetes/controller/internal/controller/component/component_controller_test.go
+++ b/kubernetes/controller/internal/controller/component/component_controller_test.go
@@ -628,7 +628,7 @@ var _ = Describe("Component Controller", func() {
 			Expect(k8sClient.Create(ctx, component)).To(Succeed())
 
 			By("checking that the component has not been reconciled successfully")
-			test.WaitForNotReadyObject(ctx, k8sClient, component, v1alpha1.CheckVersionFailedReason)
+			test.WaitForNotReadyObject(ctx, k8sClient, component, v1alpha1.GetComponentVersionFailedReason)
 
 			By("delete resources manually")
 			test.DeleteObject(ctx, k8sClient, component)

--- a/kubernetes/controller/internal/controller/component/component_controller_test.go
+++ b/kubernetes/controller/internal/controller/component/component_controller_test.go
@@ -634,6 +634,127 @@ var _ = Describe("Component Controller", func() {
 			test.DeleteObject(ctx, k8sClient, component)
 		})
 
+		It("respects SemverFilter to exclude non-matching versions", func(ctx SpecContext) {
+			// SemverFilter is a regex applied to the version list before the
+			// Semver constraint picks a winner. Here the filter accepts only
+			// canonical MAJOR.MINOR.PATCH (no pre-release suffix), so the
+			// "1.1.0-rc.1" build must be excluded and the constraint
+			// ">=1.0.0-0" should resolve to the highest remaining release,
+			// "1.2.0".
+			By("creating component versions, mixing release and pre-release builds")
+			_, specData := test.SetupCTFComponentVersionRepository(ctx, ctfpath, []*descruntime.Descriptor{
+				{
+					Component: descruntime.Component{
+						ComponentMeta: descruntime.ComponentMeta{
+							ObjectMeta: descruntime.ObjectMeta{
+								Name:    componentName,
+								Version: "1.0.0",
+							},
+						},
+						Provider: descruntime.Provider{Name: "ocm.software"},
+					},
+				},
+				{
+					Component: descruntime.Component{
+						ComponentMeta: descruntime.ComponentMeta{
+							ObjectMeta: descruntime.ObjectMeta{
+								Name:    componentName,
+								Version: "1.1.0-rc.1",
+							},
+						},
+						Provider: descruntime.Provider{Name: "ocm.software"},
+					},
+				},
+				{
+					Component: descruntime.Component{
+						ComponentMeta: descruntime.ComponentMeta{
+							ObjectMeta: descruntime.ObjectMeta{
+								Name:    componentName,
+								Version: "1.2.0",
+							},
+						},
+						Provider: descruntime.Provider{Name: "ocm.software"},
+					},
+				},
+			})
+
+			By("mocking an ocm repository")
+			repositoryObj = test.SetupRepositoryWithSpecData(ctx, k8sClient, namespace.GetName(), repositoryName, specData)
+
+			By("creating a component constrained by a constraint and a release-only filter")
+			component := &v1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace.GetName(),
+					Name:      ComponentObj,
+				},
+				Spec: v1alpha1.ComponentSpec{
+					RepositoryRef: corev1.LocalObjectReference{
+						Name: repositoryObj.GetName(),
+					},
+					Component:    componentName,
+					Semver:       ">=1.0.0-0",
+					SemverFilter: `^[0-9]+\.[0-9]+\.[0-9]+$`,
+					Interval:     metav1.Duration{Duration: time.Minute * 10},
+				},
+			}
+			Expect(k8sClient.Create(ctx, component)).To(Succeed())
+
+			By("checking that the highest non-pre-release version was selected")
+			test.WaitForReadyObject(ctx, k8sClient, component, map[string]any{
+				"Status.Component.Version": "1.2.0",
+			})
+
+			By("delete resources manually")
+			test.DeleteObject(ctx, k8sClient, component)
+		})
+
+		It("fails reconciliation when SemverFilter is an invalid regex", func(ctx SpecContext) {
+			// An unparseable regex must surface as a CheckVersion failure
+			// rather than crashing the reconciler or silently disabling the
+			// filter.
+			By("creating a component version")
+			_, specData := test.SetupCTFComponentVersionRepository(ctx, ctfpath, []*descruntime.Descriptor{
+				{
+					Component: descruntime.Component{
+						ComponentMeta: descruntime.ComponentMeta{
+							ObjectMeta: descruntime.ObjectMeta{
+								Name:    componentName,
+								Version: Version1,
+							},
+						},
+						Provider: descruntime.Provider{Name: "ocm.software"},
+					},
+				},
+			})
+
+			By("mocking an ocm repository")
+			repositoryObj = test.SetupRepositoryWithSpecData(ctx, k8sClient, namespace.GetName(), repositoryName, specData)
+
+			By("creating a component with an invalid SemverFilter regex")
+			component := &v1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace.GetName(),
+					Name:      ComponentObj,
+				},
+				Spec: v1alpha1.ComponentSpec{
+					RepositoryRef: corev1.LocalObjectReference{
+						Name: repositoryObj.GetName(),
+					},
+					Component:    componentName,
+					Semver:       ">=1.0.0",
+					SemverFilter: "(",
+					Interval:     metav1.Duration{Duration: time.Minute * 10},
+				},
+			}
+			Expect(k8sClient.Create(ctx, component)).To(Succeed())
+
+			By("checking that the component has not been reconciled successfully")
+			test.WaitForNotReadyObject(ctx, k8sClient, component, v1alpha1.CheckVersionFailedReason)
+
+			By("delete resources manually")
+			test.DeleteObject(ctx, k8sClient, component)
+		})
+
 		It("verifies the signing of a component version", func(ctx SpecContext) {
 			By("creating a component version")
 			repo, specData := test.SetupCTFComponentVersionRepository(ctx, ctfpath, []*descruntime.Descriptor{

--- a/kubernetes/controller/internal/ocm/ocm.go
+++ b/kubernetes/controller/internal/ocm/ocm.go
@@ -2,6 +2,7 @@ package ocm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -10,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"ocm.software/open-component-model/kubernetes/controller/api/v1alpha1"
 )
@@ -137,4 +139,32 @@ func GetLatestValidVersion(ctx context.Context, versions []string, semvers strin
 	}
 
 	return matchedVersions[len(matchedVersions)-1], nil
+}
+
+// ApplyDowngradePolicy returns the candidate version unless it is older than
+// the previously reconciled version and Spec.DowngradePolicy denies it.
+func ApplyDowngradePolicy(component *v1alpha1.Component, candidate *semver.Version) (string, error) {
+	// we didn't yet reconcile anything, return whatever the retrieved version is.
+	if component.Status.Component.Version == "" {
+		return candidate.Original(), nil
+	}
+
+	currentSemver, err := semver.NewVersion(component.Status.Component.Version)
+	if err != nil {
+		return "", reconcile.TerminalError(fmt.Errorf("failed to check reconciled version: %w", err))
+	}
+
+	if candidate.GreaterThanEqual(currentSemver) {
+		return candidate.Original(), nil
+	}
+
+	switch component.Spec.DowngradePolicy {
+	case v1alpha1.DowngradePolicyDeny:
+		return "", reconcile.TerminalError(fmt.Errorf("component version cannot be downgraded from version %s "+
+			"to version %s", currentSemver.Original(), candidate.Original()))
+	case v1alpha1.DowngradePolicyAllow:
+		return candidate.Original(), nil
+	default:
+		return "", reconcile.TerminalError(errors.New("unknown downgrade policy: " + string(component.Spec.DowngradePolicy)))
+	}
 }

--- a/kubernetes/controller/internal/ocm/ocm_test.go
+++ b/kubernetes/controller/internal/ocm/ocm_test.go
@@ -621,4 +621,90 @@ var _ = Describe("ocm utility", func() {
 			Expect(versionLatest.Equal(version1))
 		})
 	})
+
+	Context("apply downgrade policy", func() {
+		// componentWith builds a Component with the given previously-reconciled
+		// version and downgrade policy. An empty currentVersion models the
+		// first-reconcile case.
+		componentWith := func(currentVersion string, policy v1alpha1.DowngradePolicy) *v1alpha1.Component {
+			return &v1alpha1.Component{
+				Spec: v1alpha1.ComponentSpec{DowngradePolicy: policy},
+				Status: v1alpha1.ComponentStatus{
+					Component: v1alpha1.ComponentInfo{Version: currentVersion},
+				},
+			}
+		}
+
+		It("returns the candidate on first reconcile regardless of policy", func() {
+			candidate, err := semver.NewVersion("1.0.0")
+			Expect(err).ToNot(HaveOccurred())
+
+			got, err := ApplyDowngradePolicy(componentWith("", v1alpha1.DowngradePolicyDeny), candidate)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got).To(Equal("1.0.0"))
+		})
+
+		It("preserves the candidate's original string including build metadata", func() {
+			candidate, err := semver.NewVersion("1.2.3-rc.1+build.5")
+			Expect(err).ToNot(HaveOccurred())
+
+			got, err := ApplyDowngradePolicy(componentWith("", ""), candidate)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got).To(Equal("1.2.3-rc.1+build.5"))
+		})
+
+		It("accepts an equal candidate", func() {
+			candidate, err := semver.NewVersion("1.0.0")
+			Expect(err).ToNot(HaveOccurred())
+
+			got, err := ApplyDowngradePolicy(componentWith("1.0.0", v1alpha1.DowngradePolicyDeny), candidate)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got).To(Equal("1.0.0"))
+		})
+
+		It("accepts a greater candidate", func() {
+			candidate, err := semver.NewVersion("2.0.0")
+			Expect(err).ToNot(HaveOccurred())
+
+			got, err := ApplyDowngradePolicy(componentWith("1.0.0", v1alpha1.DowngradePolicyDeny), candidate)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got).To(Equal("2.0.0"))
+		})
+
+		It("denies a downgrade with policy Deny", func() {
+			candidate, err := semver.NewVersion("0.9.0")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = ApplyDowngradePolicy(componentWith("1.0.0", v1alpha1.DowngradePolicyDeny), candidate)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot be downgraded from version 1.0.0 to version 0.9.0"))
+		})
+
+		It("allows a downgrade with policy Allow", func() {
+			candidate, err := semver.NewVersion("0.9.0")
+			Expect(err).ToNot(HaveOccurred())
+
+			got, err := ApplyDowngradePolicy(componentWith("1.0.0", v1alpha1.DowngradePolicyAllow), candidate)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got).To(Equal("0.9.0"))
+		})
+
+		It("rejects an unknown downgrade policy", func() {
+			candidate, err := semver.NewVersion("0.9.0")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = ApplyDowngradePolicy(componentWith("1.0.0", v1alpha1.DowngradePolicy("bogus")), candidate)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unknown downgrade policy: bogus"))
+		})
+
+		It("returns a terminal error if the previously-reconciled version is malformed", func() {
+			candidate, err := semver.NewVersion("1.0.0")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = ApplyDowngradePolicy(componentWith("not-a-version", v1alpha1.DowngradePolicyDeny), candidate)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to check reconciled version"))
+		})
+	})
 })


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

[ `Component.Semver`](https://github.com/open-component-model/open-component-model/blob/main/kubernetes/controller/api/v1alpha1/component_types.go#L41) takes a single version, e.g. `1.0.0`, as well as semver constraints, e.g. `=>1.0.0`. Currently, in both cases, we would do a List-Component-Version call that downloads all available versions, validate if they are a component version, and then filter it out.

This is not only very inefficient it also leads to unexpected behaviours for users having a lot of versions for the same component.

This PR changes this. If the passed version can be considered a semantic version without constraints, we will immediately return the version instead of listing and filtering.

#### Which issue(s) this PR fixes

Fixes #2826 

- [x] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [x] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [x] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
