### PR TITLE
chore: use 'main' tag instead of pinned sha for own workflow

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -174,6 +174,14 @@
       ],
       minimumReleaseAge: null,
     },
+    {
+      // The internal org workflows repo is tracked on @main intentionally
+      // (see .github/workflows/stale.yaml). Disable Renovate so it does not
+      // re-pin the ref to a SHA and then bump it on every upstream commit.
+      matchManagers: ['github-actions'],
+      matchDepNames: ['open-component-model/.github'],
+      enabled: false,
+    },
   ],
   customDatasources: {
     envtest: {

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -13,4 +13,4 @@ jobs:
       issues: write
       pull-requests: write
       contents: read
-    uses: open-component-model/.github/.github/workflows/stale.yml@6bd35dc7288d47e80637bc994f7212be4543258a # main
+    uses: open-component-model/.github/.github/workflows/stale.yml@main # zizmor: ignore[unpinned-uses] intentional: trusted internal org workflow, tracked on main to avoid per-commit digest bumps


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

renovate tries to bump every commit for the `stale` workflow which is a reusable workflow from our own `.github` repository. This PR changes that by pinning it to `main` and instructing renovate to not change it back again.

#### Which issue(s) this PR fixes

Supersedes https://github.com/open-component-model/open-component-model/pull/2815

