### PR TITLE
fix(oci): split oci credential repo and credential type scheme

### DIFF
--- a/bindings/go/oci/spec/credentials/scheme.go
+++ b/bindings/go/oci/spec/credentials/scheme.go
@@ -5,24 +5,44 @@ import (
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
+// CredentialRepositoryConfigType is the canonical versioned type for the
+// DockerConfig credential repository configuration.
 var CredentialRepositoryConfigType = runtime.NewVersionedType("DockerConfig", "v1")
 
+// Scheme contains the credential repository configuration types provided by
+// this package (currently DockerConfig).
+//
+// It does NOT contain credential payload types such as OCICredentials.
+// Credential payloads describe authentication material consumed by repositories,
+// while a credential-repository-config scheme describes how to LOCATE
+// credentials and is used by the credential graph to map specs to repository
+// plugins. Conflating the two would cause OCICredentials specs to be wired to
+// the OCICredentialRepository plugin, which is incorrect.
+//
+// To register OCICredentials as a known credential type with the credential
+// graph, use v1.MustRegisterCredentialType or the pre-built CredentialTypeScheme.
 var Scheme = runtime.NewScheme()
+
+// CredentialTypeScheme contains credential payload types that this package
+// owns (currently OCICredentials/v1). It is intended to be passed to
+// CredentialRepositoryRegistry.Register so the credential graph can
+// deserialize typed credentials it finds in configuration.
+var CredentialTypeScheme = runtime.NewScheme()
 
 func init() {
 	MustAddToScheme(Scheme)
+	v1.MustRegisterCredentialType(CredentialTypeScheme)
 }
 
+// MustAddToScheme registers credential repository configuration types provided
+// by this package (DockerConfig) into the given scheme.
+//
+// This MUST NOT be used to register credential payload types such as
+// OCICredentials — see Scheme docs for the rationale.
 func MustAddToScheme(scheme *runtime.Scheme) {
 	dockerConfig := &v1.DockerConfig{}
 	scheme.MustRegisterWithAlias(dockerConfig,
 		CredentialRepositoryConfigType,
 		runtime.NewUnversionedType(v1.DockerConfigType),
-	)
-
-	ociCredentials := &v1.OCICredentials{}
-	scheme.MustRegisterWithAlias(ociCredentials,
-		runtime.NewVersionedType(v1.OCICredentialsType, v1.Version),
-		runtime.NewUnversionedType(v1.OCICredentialsType),
 	)
 }

--- a/bindings/go/oci/spec/credentials/scheme_test.go
+++ b/bindings/go/oci/spec/credentials/scheme_test.go
@@ -1,0 +1,79 @@
+package credentials_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"ocm.software/open-component-model/bindings/go/oci/spec/credentials"
+	credentialsv1 "ocm.software/open-component-model/bindings/go/oci/spec/credentials/v1"
+	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+// TestSchemeContainsOnlyRepositoryConfigTypes verifies that the package-level
+// Scheme exposes the credential repository configuration types
+// (DockerConfig) and does NOT contain credential payload types
+// (OCICredentials).
+//
+// Mixing the two would cause OCICredentials specs to be wired to the
+// OCICredentialRepository plugin via
+// RegisterInternalCredentialRepositoryPlugin, which iterates every type in
+// the scheme returned by GetCredentialRepositoryScheme.
+func TestSchemeContainsOnlyRepositoryConfigTypes(t *testing.T) {
+	dockerConfigType := runtime.NewVersionedType(credentialsv1.DockerConfigType, credentialsv1.Version)
+	ociCredentialsType := runtime.NewVersionedType(credentialsv1.OCICredentialsType, credentialsv1.Version)
+
+	assert.True(t, credentials.Scheme.IsRegistered(dockerConfigType),
+		"DockerConfig must be registered in the credential repository scheme")
+	assert.True(t, credentials.Scheme.IsRegistered(runtime.NewUnversionedType(credentialsv1.DockerConfigType)),
+		"unversioned DockerConfig must be registered in the credential repository scheme")
+
+	assert.False(t, credentials.Scheme.IsRegistered(ociCredentialsType),
+		"OCICredentials is a credential payload, not a repository config, and must not be in Scheme")
+	assert.False(t, credentials.Scheme.IsRegistered(runtime.NewUnversionedType(credentialsv1.OCICredentialsType)),
+		"unversioned OCICredentials must not be in Scheme")
+}
+
+// TestCredentialTypeSchemeContainsOnlyPayloadTypes verifies that
+// CredentialTypeScheme exposes credential payload types (OCICredentials)
+// and does NOT contain credential repository configuration types
+// (DockerConfig). It is the scheme that callers should pass to
+// CredentialRepositoryRegistry.Register to teach the credential graph about
+// typed OCI credentials.
+func TestCredentialTypeSchemeContainsOnlyPayloadTypes(t *testing.T) {
+	dockerConfigType := runtime.NewVersionedType(credentialsv1.DockerConfigType, credentialsv1.Version)
+	ociCredentialsType := runtime.NewVersionedType(credentialsv1.OCICredentialsType, credentialsv1.Version)
+
+	assert.True(t, credentials.CredentialTypeScheme.IsRegistered(ociCredentialsType),
+		"OCICredentials must be registered in the credential type scheme")
+	assert.True(t, credentials.CredentialTypeScheme.IsRegistered(runtime.NewUnversionedType(credentialsv1.OCICredentialsType)),
+		"unversioned OCICredentials must be registered in the credential type scheme")
+
+	assert.False(t, credentials.CredentialTypeScheme.IsRegistered(dockerConfigType),
+		"DockerConfig is a repository config, not a credential payload, and must not be in CredentialTypeScheme")
+	assert.False(t, credentials.CredentialTypeScheme.IsRegistered(runtime.NewUnversionedType(credentialsv1.DockerConfigType)),
+		"unversioned DockerConfig must not be in CredentialTypeScheme")
+}
+
+// TestMustAddToSchemeRegistersDockerConfigOnly verifies the helper used by
+// downstream registrations only adds DockerConfig.
+func TestMustAddToSchemeRegistersDockerConfigOnly(t *testing.T) {
+	scheme := runtime.NewScheme()
+	credentials.MustAddToScheme(scheme)
+
+	assert.True(t, scheme.IsRegistered(runtime.NewVersionedType(credentialsv1.DockerConfigType, credentialsv1.Version)))
+	assert.False(t, scheme.IsRegistered(runtime.NewVersionedType(credentialsv1.OCICredentialsType, credentialsv1.Version)),
+		"MustAddToScheme must not register OCICredentials")
+}
+
+// TestMustRegisterCredentialTypeRegistersOCICredentialsOnly verifies the
+// payload-type helper does not leak DockerConfig into the credential type
+// scheme.
+func TestMustRegisterCredentialTypeRegistersOCICredentialsOnly(t *testing.T) {
+	scheme := runtime.NewScheme()
+	credentialsv1.MustRegisterCredentialType(scheme)
+
+	assert.True(t, scheme.IsRegistered(runtime.NewVersionedType(credentialsv1.OCICredentialsType, credentialsv1.Version)))
+	assert.False(t, scheme.IsRegistered(runtime.NewVersionedType(credentialsv1.DockerConfigType, credentialsv1.Version)),
+		"MustRegisterCredentialType must not register DockerConfig")
+}

--- a/bindings/go/oci/spec/credentials/v1/convert.go
+++ b/bindings/go/oci/spec/credentials/v1/convert.go
@@ -22,8 +22,6 @@ var convertScheme = runtime.NewScheme()
 
 func init() {
 	convertScheme.MustRegisterWithAlias(&OCICredentials{},
-		DockerConfigVersionedType,
-		runtime.NewUnversionedType(DockerConfigType),
 		OCICredentialsVersionedType,
 		runtime.NewUnversionedType(OCICredentialsType),
 	)

--- a/bindings/go/oci/spec/credentials/v1/oci_credentials.go
+++ b/bindings/go/oci/spec/credentials/v1/oci_credentials.go
@@ -9,6 +9,22 @@ const OCICredentialsType = "OCICredentials"
 
 var OCICredentialsVersionedType = runtime.NewVersionedType(OCICredentialsType, Version)
 
+// MustRegisterCredentialType registers OCICredentials/v1 (and its unversioned
+// alias) in the given scheme.
+//
+// OCICredentials is a credential payload type (it carries username/password
+// or tokens that authenticate against an OCI registry). It is NOT a credential
+// repository configuration — it must be registered with the credential-type
+// scheme of the credential graph (see
+// credentialrepository.RepositoryRegistry.Register), never with a scheme that
+// maps repository specs to repository plugins.
+func MustRegisterCredentialType(scheme *runtime.Scheme) {
+	scheme.MustRegisterWithAlias(&OCICredentials{},
+		OCICredentialsVersionedType,
+		runtime.NewUnversionedType(OCICredentialsType),
+	)
+}
+
 // OCICredentials represents typed credentials for OCI registry authentication.
 // It supports username/password and token-based authentication flows used by
 // container registries that implement the OCI distribution specification.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

this decouples the repository type scheme (which contains the docker config repos) and the credential type (which is a single oci registry credential) into different schemes so that they dont get registered incorrectly as repo or credential types respectively

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

This is a follow up from typed credentials where ocm describe types output wrong type configurations

```
+-----------------------+-----------------------------------+--------------------------------------------+
| credential-repository | DockerConfig/v1                   | DockerConfig                               |
|                       | OCICredentials/v1                 | OCICredentials                             |
+-----------------------+-----------------------------------+--------------------------------------------+
| credentials           | DockerConfig/v1                   | DockerConfig                               |
|                       | GPGCredentials/v1alpha1           | GPGCredentials                             |
|                       | HelmHTTPCredentials/v1            | HelmHTTPCredentials                        |
|                       | OCICredentials/v1                 | OCICredentials                             |
|                       | OIDCIdentityToken/v1alpha1        | OIDCIdentityToken                          |
```

DockerConfig is not a valid credential type and OCICredentials is not a valid repository type

#### Testing

`ocm describe types` with go work enabled

##### Verification

- [x] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [x] Tests pass locally (`task test` and `task test/integration` if applicable)
- [x] If touching multiple modules, `go work` is enabled (see `go.work`)
- [x] My changes do not decrease test coverage
- [x] I have tested the changes locally by running `ocm`
