### PR TITLE
chore(website): add script to detect Doks theme overlay/layout drift

### DIFF
--- a/website/CONTRIBUTING.md
+++ b/website/CONTRIBUTING.md
@@ -55,6 +55,79 @@ npm run lint:scripts
 npm run lint:scripts:fix
 ```
 
+## Theme overlays
+
+The website builds on the [@thulite/doks-core](https://www.npmjs.com/package/@thulite/doks-core) Hugo theme. Some
+templates and shortcodes from the theme are *shadowed* — a file with the same path under `website/layouts/` overrides
+the theme's version. Hugo's template lookup picks the project file first, so the theme's original is never rendered.
+
+Shadowing is the supported way to customize Doks. The cost is **drift**: when the theme is upgraded, the upstream
+file may change in ways that are not reflected in our shadow, and Hugo gives no warning.
+
+### Tagging a shadow
+
+Every file under `website/layouts/` that is derived from `@thulite/doks-core` must declare its baseline upstream
+version with a Hugo comment near the top of the file:
+
+```html
+{{- /*
+  Based on: @thulite/doks-core@<version> (path: <upstream-relative-path>)
+  See website/CONTRIBUTING.md "Theme overlays" for the audit/update process.
+*/ -}}
+```
+
+For example:
+
+```html
+{{- /*
+  Based on: @thulite/doks-core@1.9.3 (path: layouts/_shortcodes/callout.html)
+  ...
+*/ -}}
+```
+
+Files **without** this tag are treated as project-original (no upstream counterpart) and are not audited. If you add
+a new shadow, you must add the tag — otherwise drift on that file goes unnoticed.
+
+If the upstream file itself credits an even earlier source (e.g. Doks adapted its `callout` shortcode from Bootstrap),
+preserve that attribution as a separate `Originally adapted from: <url>` line below the `Based on:` tag.
+
+### Auditing
+
+The audit script compares each tagged shadow against the upstream file at both the *recorded* version (from the tag)
+and the *installed* version (from `node_modules/@thulite/doks-core/package.json`):
+
+```bash
+cd website
+npm run audit:overlays            # report only files that need attention
+npm run audit:overlays -- -v      # also show files that are clean
+```
+
+For each shadow it reports one of:
+
+| Status      | Meaning                                                                                                    | Action                                                                  |
+|-------------|------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
+| `OK`        | Recorded baseline matches the installed upstream byte-for-byte.                                            | None.                                                                   |
+| `STALE_TAG` | Recorded version differs from installed, but upstream content is unchanged at both versions.               | Bump the version in the tag.                                            |
+| `DRIFT`     | Upstream file changed between the recorded version and the installed version.                              | Review the diff. Port any improvements into the shadow, then bump tag.  |
+| `REMOVED`   | Upstream file no longer exists at the installed version.                                                   | The shadow may be obsolete or moved upstream — investigate and resolve. |
+| `ERROR`     | The tag is malformed, the upstream tarball cannot be fetched, or the recorded path doesn't exist upstream. | Fix the tag.                                                            |
+
+Exit code is non-zero if any shadow is in `DRIFT`, `REMOVED`, or `ERROR`. `OK` and `STALE_TAG` are informational.
+
+### When to run the audit
+
+- **Before bumping `@thulite/doks-core`**: run the audit on the current state to confirm a clean baseline.
+- **After bumping `@thulite/doks-core`**: run again. Any new `DRIFT` reports show what changed upstream that we may
+  need to port. Any `REMOVED` reports show files that disappeared from upstream — decide whether the shadow is still
+  useful.
+- **When adding a new shadow**: tag it with the currently installed version. The audit then tracks it on future
+  bumps.
+
+### Pinning the theme version
+
+`package.json` should pin `@thulite/doks-core` to an exact version (`"1.9.3"`, not `"^1.9.3"`). Floating versions
+turn theme upgrades into surprise drift; pinning makes upgrades deliberate.
+
 ## Content Authoring Guide
 
 The rest of this document covers how to create and place documentation content. All new content should follow the

--- a/website/layouts/_markup/render-codeblock-mermaid.html
+++ b/website/layouts/_markup/render-codeblock-mermaid.html
@@ -1,4 +1,0 @@
-<pre class="mermaid">
-  {{ .Inner | htmlEscape | safeHTML }}
-</pre>
-{{ .Page.Store.Set "hasMermaid" true }}

--- a/website/layouts/_partials/sidebar/render-section-menu.html
+++ b/website/layouts/_partials/sidebar/render-section-menu.html
@@ -5,7 +5,9 @@ only text and toggle the <details> open/close. This override replaces the text
 with an <a> link so clicking the section title navigates to the section overview
 page. The disclosure triangle still toggles expand/collapse via JS in custom.js.
 
-Based on: https://discourse.gohugo.io/t/automated-nested-menus/42835/2
+Based on: @thulite/doks-core@1.9.3 (path: layouts/_partials/sidebar/render-section-menu.html)
+Originally adapted from: https://discourse.gohugo.io/t/automated-nested-menus/42835/2
+See website/CONTRIBUTING.md "Theme overlays" for the audit/update process.
 */}}
 
 {{- /* Configure. */}}

--- a/website/layouts/_shortcodes/callout.html
+++ b/website/layouts/_shortcodes/callout.html
@@ -1,6 +1,8 @@
 {{- /*
 Usage: `callout "type"`, where `type` is one of "note" (default), "info", "danger", or "warning"
-Based on: https://github.com/twbs/bootstrap/blob/283cbd902669732943885e94115a0e29a952baf6/site/layouts/shortcodes/callout.html
+Based on: @thulite/doks-core@1.9.3 (path: layouts/_shortcodes/callout.html)
+Originally adapted from: https://github.com/twbs/bootstrap/blob/283cbd902669732943885e94115a0e29a952baf6/site/layouts/shortcodes/callout.html
+See website/CONTRIBUTING.md "Theme overlays" for the audit/update process.
 */ -}}
 {{- $css_class := "" -}}
 {{- if .IsNamedParams -}}

--- a/website/layouts/blog/list.html
+++ b/website/layouts/blog/list.html
@@ -1,3 +1,8 @@
+{{- /*
+  Based on: @thulite/doks-core@1.9.3 (path: layouts/blog/list.html)
+  Local change: adds preview-badge partial next to blog post titles in list view.
+  See website/CONTRIBUTING.md "Theme overlays" for the audit/update process.
+*/ -}}
 {{ define "main" }}
 <div class="row justify-content-center">
   <div class="col-md-12 col-lg-9">

--- a/website/layouts/blog/single.html
+++ b/website/layouts/blog/single.html
@@ -1,3 +1,8 @@
+{{- /*
+  Based on: @thulite/doks-core@1.9.3 (path: layouts/blog/single.html)
+  Local change: adds preview-banner partial below blog post title.
+  See website/CONTRIBUTING.md "Theme overlays" for the audit/update process.
+*/ -}}
 {{ define "main" }}
 <article>
 <div class="row justify-content-center">

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@tabler/icons": "^3.41.0",
-        "@thulite/doks-core": "^1.9.3",
+        "@thulite/doks-core": "1.9.3",
         "@thulite/images": "^3.3.4",
         "@thulite/inline-svg": "^1.2.2",
         "@thulite/seo": "^2.4.3",

--- a/website/package.json
+++ b/website/package.json
@@ -16,6 +16,7 @@
     "dev": "HUGO_PARAMS_COMMITFULL=$(git log -1 --format=%H -- .) HUGO_PARAMS_COMMITSHORT=$(git log -1 --format=%h -- .) ./node_modules/.bin/hugo server --bind=0.0.0.0 --disableFastRender --noHTTPCache",
     "hugo": "./node_modules/.bin/hugo",
     "info": "npm list",
+    "audit:overlays": "node scripts/audit-overlays.mjs",
     "lint:markdown": "markdownlint-cli2 --config ../.github/config/website.markdownlint-cli2.yaml \"**/*.md\" \"!node_modules/**\" \"!content_versioned/version-legacy/**\"",
     "lint:scripts": "eslint --cache assets/js",
     "lint:styles": "stylelint --cache \"assets/scss/**/*.{css,sass,scss}\"",
@@ -32,7 +33,7 @@
   },
   "dependencies": {
     "@tabler/icons": "^3.41.0",
-    "@thulite/doks-core": "^1.9.3",
+    "@thulite/doks-core": "1.9.3",
     "@thulite/images": "^3.3.4",
     "@thulite/inline-svg": "^1.2.2",
     "@thulite/seo": "^2.4.3",

--- a/website/scripts/audit-overlays.mjs
+++ b/website/scripts/audit-overlays.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+// Audit website/layouts/ for drift against @thulite/doks-core upstream.
+// See website/CONTRIBUTING.md "Theme overlays" for the workflow.
+//
+// Usage: audit-overlays.mjs [-v|--verbose]
+//        npm run audit:overlays [-v|--verbose]
+// Exit non-zero on DRIFT, REMOVED, or ERROR.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const PKG = '@thulite/doks-core';
+const TAG_RE = /Based on:\s*@thulite\/doks-core@(\d+\.\d+\.\d+)\s*\(path:\s*(\S+?)\s*\)/;
+
+const WEBSITE = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const LAYOUTS = join(WEBSITE, 'layouts');
+const INSTALLED = join(WEBSITE, 'node_modules', '@thulite', 'doks-core');
+const CACHE = join(homedir(), '.cache', 'ocm-overlay-audit');
+const VERBOSE = process.argv.slice(2).some((a) => a === '-v' || a === '--verbose');
+
+function readOrNull(path) {
+  try { return readFileSync(path); }
+  catch (e) { if (e.code === 'ENOENT') return null; throw e; }
+}
+
+function* walkLayouts(dir) {
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) yield* walkLayouts(p);
+    else if (e.isFile() && (p.endsWith('.html') || p.endsWith('.xml'))) yield p;
+  }
+}
+
+function fetchUpstream(version) {
+  const dir = join(CACHE, version, 'package');
+  if (existsSync(dir)) return dir;
+  mkdirSync(join(CACHE, version), { recursive: true });
+  const stage = mkdtempSync(join(tmpdir(), 'ocm-audit-'));
+  try {
+    const tarball = execFileSync('npm', ['pack', `${PKG}@${version}`, '--silent'],
+      { cwd: stage, encoding: 'utf8' }).trim().split('\n').pop();
+    execFileSync('tar', ['-xzf', join(stage, tarball), '-C', join(CACHE, version)]);
+  } finally {
+    rmSync(stage, { recursive: true, force: true });
+  }
+  return dir;
+}
+
+// `git diff --no-index` emits a/<path> and b/<path> headers using the actual
+// paths it was given, so staging the files under version-named dirs gives us
+// readable headers without post-processing.
+function unifiedDiff(upstreamPath, recVer, instVer, recBuf, instBuf) {
+  const stage = mkdtempSync(join(tmpdir(), 'ocm-audit-diff-'));
+  const a = join(recVer, upstreamPath);
+  const b = join(instVer, upstreamPath);
+  mkdirSync(join(stage, dirname(a)), { recursive: true });
+  mkdirSync(join(stage, dirname(b)), { recursive: true });
+  writeFileSync(join(stage, a), recBuf);
+  writeFileSync(join(stage, b), instBuf);
+  try {
+    return execFileSync('git', ['--no-pager', 'diff', '--no-index', '--no-color', '--', a, b],
+      { cwd: stage, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+  } catch (e) {
+    return e.stdout ?? '';
+  } finally {
+    rmSync(stage, { recursive: true, force: true });
+  }
+}
+
+function classify(shadow, instVer) {
+  const { shadowPath, recVer, upstreamPath } = shadow;
+  const id = { shadow: relative(WEBSITE, shadowPath), upstreamPath, recVer };
+
+  if (upstreamPath.includes('..') || !upstreamPath.startsWith('layouts/')) {
+    return { ...id, status: 'ERROR', detail: 'path must be under layouts/ — fix the tag' };
+  }
+
+  let recRoot;
+  try {
+    recRoot = fetchUpstream(recVer);
+  } catch (e) {
+    return { ...id, status: 'ERROR', detail: `failed to fetch ${PKG}@${recVer} (${e.message.split('\n', 1)[0]})` };
+  }
+
+  const recBuf = readOrNull(join(recRoot, upstreamPath));
+  if (!recBuf) return { ...id, status: 'ERROR', detail: `path not found in ${PKG}@${recVer} — fix the tag` };
+
+  const instBuf = readOrNull(join(INSTALLED, upstreamPath));
+  if (!instBuf) return { ...id, status: 'REMOVED', detail: `path no longer exists in ${PKG}@${instVer}` };
+
+  if (recBuf.equals(instBuf)) {
+    return recVer === instVer
+      ? { ...id, status: 'OK' }
+      : { ...id, status: 'STALE_TAG', detail: `bump tag to @${instVer} — upstream content unchanged` };
+  }
+
+  return {
+    ...id,
+    status: 'DRIFT',
+    detail: `upstream changed between @${recVer} and @${instVer}`,
+    diff: unifiedDiff(upstreamPath, recVer, instVer, recBuf, instBuf),
+  };
+}
+
+function findShadows() {
+  const shadows = [];
+  for (const path of walkLayouts(LAYOUTS)) {
+    const m = readFileSync(path, 'utf8').slice(0, 4096).match(TAG_RE);
+    if (m) shadows.push({ shadowPath: path, recVer: m[1], upstreamPath: m[2] });
+  }
+  return shadows;
+}
+
+function reportSection(status, items) {
+  if (!items?.length || (status === 'OK' && !VERBOSE)) return;
+  console.log(`── ${status} (${items.length}) ──`);
+  for (const r of items) {
+    console.log(`  ${r.shadow}`);
+    console.log(`    upstream: ${r.upstreamPath}  recorded: @${r.recVer}`);
+    if (r.detail) console.log(`    ${r.detail}`);
+    if (r.diff) for (const line of r.diff.split('\n')) console.log(`    │ ${line}`);
+  }
+  console.log('');
+}
+
+function main() {
+  const installedPkg = readOrNull(join(INSTALLED, 'package.json'));
+  if (!installedPkg) {
+    console.error(`error: ${PKG} not installed at ${INSTALLED}. Run \`npm install\` in website/.`);
+    process.exit(2);
+  }
+  const instVer = JSON.parse(installedPkg).version;
+
+  const shadows = findShadows();
+  if (!shadows.length) {
+    console.log('No tagged shadows found. See CONTRIBUTING.md "Theme overlays" to register one.');
+    return;
+  }
+
+  console.log(`Auditing ${shadows.length} shadow(s) against ${PKG}@${instVer}\n`);
+  const results = shadows.map((s) => classify(s, instVer));
+  const grouped = Object.groupBy(results, (r) => r.status);
+
+  const order = ['DRIFT', 'REMOVED', 'ERROR', 'STALE_TAG', 'OK'];
+  for (const status of order) reportSection(status, grouped[status]);
+
+  const summary = order.filter((s) => grouped[s]?.length).map((s) => `${grouped[s].length} ${s.toLowerCase()}`).join(', ');
+  console.log(`Summary: ${summary}`);
+
+  const fail = (grouped.DRIFT?.length ?? 0) + (grouped.REMOVED?.length ?? 0) + (grouped.ERROR?.length ?? 0);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
## Summary

we already have several layout overlays that shadow the Doks theme's originals. #2827 adds some more. It makes sense to check if our implementation drifted from upstream when we bump the Doks version.

This PR creates a script that detects drift between our `@thulite/doks-core` theme shadows and upstream. Should be executed every time the Doks theme package is updated (currently pinned to 1.9.3) by executing `npm run audit:overlays`:

- Each shadow under `website/layouts/` now declares its baseline:
  `Based on: @thulite/doks-core@<version> (path: <upstream-path>)`
- `npm run audit:overlays` compares each tagged shadow against upstream at
  both the recorded and the installed version. Statuses: OK · STALE_TAG ·
  DRIFT · REMOVED · ERROR. Exit non-zero on the last three; DRIFT prints
  a unified diff.
- `@thulite/doks-core` pinned to exact version; theme bumps become
  deliberate PRs.
- CONTRIBUTING.md documents the workflow.

Tagged shadows: `callout`, `render-section-menu`, `blog/list`, `blog/single`.
The byte-identical `render-codeblock-mermaid` shadow is removed (Hugo falls
through to the theme version). Our `footer.html` and `home.html` are completely rewritten, so not tagged.

## Test plan

- [x] `npm run audit:overlays` clean (4 ok, exit 0)
- [x] DRIFT, STALE_TAG, ERROR (missing path), ERROR (path escape) verified
      with synthetic baseline tags
- [x] `npm run build` clean after removing the mermaid shadow
- [x] ESLint, markdownlint clean on touched files