### PR TITLE
chore: fix golangci-lint issues in website/hack/generate-cli-docs

### DIFF
--- a/website/hack/generate-cli-docs/generate_markdown.go
+++ b/website/hack/generate-cli-docs/generate_markdown.go
@@ -43,18 +43,19 @@ func genMarkdownTreeCustom(cmd *cobra.Command, dir, parentCmd string, cmdToLink 
 
 	var basename string
 
-	if cmd.IsAdditionalHelpTopicCommand() {
+	switch {
+	case cmd.IsAdditionalHelpTopicCommand():
 		basename = commandToID(cmd.CommandPath()) + ".md"
 		dir = path.Join(dir, "help")
-	} else if cmd.HasAvailableSubCommands() && !cmd.HasParent() {
-		basename = "_index.md"
-	} else if cmd.HasAvailableSubCommands() && cmd.HasParent() {
-		basename = "_index.md"
+	case cmd.HasAvailableSubCommands() && !cmd.HasParent():
+		basename = indexFileName
+	case cmd.HasAvailableSubCommands() && cmd.HasParent():
+		basename = indexFileName
 		dir = path.Join(dir, commandToDir(cmd.CommandPath()))
-	} else if cmd.HasParent() && !cmd.IsAdditionalHelpTopicCommand() {
+	case cmd.HasParent() && !cmd.IsAdditionalHelpTopicCommand():
 		dir = path.Join(dir, commandToDir(cmd.Parent().CommandPath()))
 		basename = commandToID(cmd.CommandPath()) + ".md"
-	} else if cmd.HasParent() && cmd.IsAdditionalHelpTopicCommand() {
+	case cmd.HasParent() && cmd.IsAdditionalHelpTopicCommand():
 		// Put the additional topic into where the command is sitting and not where
 		// subcommand would be.
 		// ocm/add instead of ocm/add/componentversion
@@ -89,17 +90,18 @@ func genMarkdownTreeCustom(cmd *cobra.Command, dir, parentCmd string, cmdToLink 
 		cmdName := commandToID(cmd.Name())
 		title := strings.TrimSuffix(cmdName, path.Ext(cmdName))
 		var url, name string
-		if cmd.IsAdditionalHelpTopicCommand() {
+		switch {
+		case cmd.IsAdditionalHelpTopicCommand():
 			url = "docs/reference/ocm-cli/help/" + strings.ToLower(title) + "/"
 			name = title
-		} else if cmdName == "ocm-cli" {
+		case cmdName == rootDocName:
 			url = "docs/reference/ocm-cli/"
 			title = "OCM CLI"
 			name = "OCM CLI"
-		} else if parentCmd == "ocm-cli" {
+		case parentCmd == rootDocName:
 			url = "docs/reference/ocm-cli/" + strings.ToLower(title) + "/"
 			name = title
-		} else {
+		default:
 			url = "docs/reference/ocm-cli/" + parentCmd + "/" + strings.ToLower(title) + "/"
 			name = fmt.Sprintf("%s %s", parentCmd, title)
 		}
@@ -128,9 +130,9 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, cmdToLink map[string]str
 		return cmdToLink[path]
 	}
 
-	if cmd.Runnable() || cmd.HasAvailableSubCommands() && name != "ocm" {
+	if cmd.Runnable() || cmd.HasAvailableSubCommands() && name != rootCmdName {
 		buf.WriteString("### Usage\n\n")
-		buf.WriteString(fmt.Sprintf("```\n%s\n```\n\n", useLine(cmd)))
+		fmt.Fprintf(buf, "```\n%s\n```\n\n", useLine(cmd))
 	}
 
 	if cmd.IsAvailableCommand() {
@@ -140,7 +142,7 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, cmdToLink map[string]str
 	}
 
 	if len(cmd.Long) > 0 {
-		if name == "ocm" {
+		if name == rootCmdName {
 			buf.WriteString("### Introduction\n\n")
 		} else {
 			buf.WriteString("### Description\n\n")
@@ -153,7 +155,7 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, cmdToLink map[string]str
 		filtered := strings.ReplaceAll(cmd.Example, "<pre>\n", "")
 		filtered = strings.ReplaceAll(filtered, "</pre>\n", "")
 		buf.WriteString("### Examples\n\n")
-		buf.WriteString(fmt.Sprintf("```\n%s\n```\n\n", filtered))
+		fmt.Fprintf(buf, "```\n%s\n```\n\n", filtered)
 	}
 
 	if hasSeeAlso(cmd) {
@@ -166,7 +168,7 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, cmdToLink map[string]str
 				parent = parent.Parent()
 				pname := parent.CommandPath()
 				if parent.HasParent() {
-					buf.WriteString(fmt.Sprintf("* [%s](%s)\t &mdash; %s\n", pname, linkHandler(parent.CommandPath()), parent.Short))
+					fmt.Fprintf(buf, "* [%s](%s)\t &mdash; %s\n", pname, linkHandler(parent.CommandPath()), parent.Short)
 				}
 			}
 		}
@@ -185,7 +187,7 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, cmdToLink map[string]str
 			}
 
 			cname := name + " " + "<b>" + child.Name() + "</b>"
-			buf.WriteString(fmt.Sprintf("* [%s](%s)\t &mdash; %s\n", cname, linkHandler(child.CommandPath()), child.Short))
+			fmt.Fprintf(buf, "* [%s](%s)\t &mdash; %s\n", cname, linkHandler(child.CommandPath()), child.Short)
 		}
 		buf.WriteString("\n")
 
@@ -199,12 +201,11 @@ func genMarkdownCustom(cmd *cobra.Command, w io.Writer, cmdToLink map[string]str
 				subheader = true
 			}
 			cname := name + " " + "<b>" + child.Name() + "</b>"
-			buf.WriteString(fmt.Sprintf("* [%s](%s)\t &mdash; %s\n", cname, cmdToLink[child.CommandPath()], child.Short))
+			fmt.Fprintf(buf, "* [%s](%s)\t &mdash; %s\n", cname, cmdToLink[child.CommandPath()], child.Short)
 		}
 		if subheader {
 			buf.WriteString("\n")
 		}
-
 	}
 
 	_, err := buf.WriteTo(w)
@@ -270,13 +271,13 @@ func useLine(c *cobra.Command) string {
 
 // Normalizes a command path into a stable page identifier.
 func commandToID(command string) string {
-	if command == "ocm" {
-		return "ocm-cli"
+	if command == rootCmdName {
+		return rootDocName
 	}
-	return strings.TrimPrefix(strings.Replace(command, " ", "_", -1), "ocm_")
+	return strings.TrimPrefix(strings.ReplaceAll(command, " ", "_"), "ocm_")
 }
 
 // Normalizes a command path into its directory name.
 func commandToDir(command string) string {
-	return strings.TrimPrefix(strings.Replace(command, " ", "-", -1), "ocm-")
+	return strings.TrimPrefix(strings.ReplaceAll(command, " ", "-"), "ocm-")
 }

--- a/website/hack/generate-cli-docs/generate_root_index.go
+++ b/website/hack/generate-cli-docs/generate_root_index.go
@@ -22,11 +22,11 @@ func genIndexForRootHelpTopics(dir string) (err error) {
 		return fmt.Errorf("failed to gather help topics: %w", err)
 	}
 
-	filename := filepath.Join(dir, "_index.md")
+	filename := filepath.Join(dir, indexFileName)
 
 	f, err := os.Create(filename)
 	if err != nil {
-		return fmt.Errorf("failed to create index file %q: %v", filename, err)
+		return fmt.Errorf("failed to create index file %q: %w", filename, err)
 	}
 	defer func() {
 		if cerr := f.Close(); cerr != nil {
@@ -34,12 +34,12 @@ func genIndexForRootHelpTopics(dir string) (err error) {
 		}
 	}()
 
-	f.WriteString(fmt.Sprintf(fmTmpl, "help", "help", "docs/reference/ocm-cli/help/"))
-	f.WriteString("### Additional Topics\n\n")
+	fmt.Fprintf(f, fmTmpl, "help", "help", "docs/reference/ocm-cli/help/")
+	fmt.Fprint(f, "### Additional Topics\n\n")
 
 	for _, topic := range topics {
 		relref := toRelref(fmt.Sprintf("docs/reference/ocm-cli/help/%s.md", topic))
-		f.WriteString(fmt.Sprintf("* [%s](%s) &mdash; %s\n", topic, relref, topic))
+		fmt.Fprintf(f, "* [%s](%s) &mdash; %s\n", topic, relref, topic)
 	}
 
 	return nil

--- a/website/hack/generate-cli-docs/main.go
+++ b/website/hack/generate-cli-docs/main.go
@@ -12,6 +12,13 @@ import (
 	"ocm.software/ocm/cmds/ocm/app"
 )
 
+// Shared string constants used across the generator.
+const (
+	rootCmdName   = "ocm"
+	rootDocName   = "ocm-cli"
+	indexFileName = "_index.md"
+)
+
 // Lists commands that should be excluded from generated docs.
 var commandDenyList = []string{
 	"bootstrap",
@@ -24,7 +31,7 @@ var commandDenyList = []string{
 	"help",
 	"install",
 	"oci",
-	"ocm",
+	rootCmdName,
 	"toi",
 	"version",
 }
@@ -66,7 +73,7 @@ func run(dir string) error {
 	}
 
 	cmdToLink := buildCmdToLink("docs/reference/ocm-cli")
-	if err := genMarkdownTreeCustom(cmd, dir, "ocm-cli", cmdToLink); err != nil {
+	if err := genMarkdownTreeCustom(cmd, dir, rootDocName, cmdToLink); err != nil {
 		return fmt.Errorf("error generating markdown: %w", err)
 	}
 

--- a/website/hack/generate-cli-docs/map.go
+++ b/website/hack/generate-cli-docs/map.go
@@ -77,7 +77,7 @@ func buildCmdToLink(basePath string) map[string]string {
 		"ocm transfer",
 		"ocm verify componentversions",
 		"ocm verify",
-		"ocm",
+		rootCmdName,
 	}
 
 	cmdToLink := map[string]string{
@@ -103,8 +103,8 @@ func toRelref(path string) string {
 
 // Maps a CLI command to its markdown file path under docs/reference/ocm-cli.
 func commandToDocPath(command string) (string, bool) {
-	if command == "ocm" {
-		return "_index.md", true
+	if command == rootCmdName {
+		return indexFileName, true
 	}
 
 	parts := strings.Fields(command)
@@ -117,7 +117,7 @@ func commandToDocPath(command string) (string, bool) {
 	}
 
 	if len(parts) == 2 {
-		return fmt.Sprintf("%s/_index.md", parts[1]), true
+		return fmt.Sprintf("%s/%s", parts[1], indexFileName), true
 	}
 
 	return fmt.Sprintf("%s/%s.md", parts[1], commandToID(command)), true


### PR DESCRIPTION
## Summary

Resolves all 19 golangci-lint findings in `website/hack/generate-cli-docs/` (goconst, errorlint, gocritic, staticcheck, whitespace).

Addresses the easy-to-fix subset called out in #2687 (comment by @morri-son).

## Test plan

- [x] `golangci-lint run` reports 0 issues
- [x] `go build ./...` clean
- [x] Generated docs byte-for-byte identical to pre-fix output (`diff -r` clean across 69 files)