### PR TITLE
chore: Make `sed` invocation BSD/GNU agnostic

### DIFF
--- a/kubernetes/controller/Taskfile.yml
+++ b/kubernetes/controller/Taskfile.yml
@@ -256,7 +256,7 @@ tasks:
       - '"{{.HELM_DOCS}}"'
       # Strip SHA digests from README.md for cleaner documentation
       # The digest is kept in values.yaml for security, but removed from docs for readability
-      - sed 's/@sha256:[a-f0-9]\{64\}//g' README.md > README.md.tmp && mv README.md.tmp README.md
+      - tmp=$(mktemp) && sed 's/@sha256:[a-f0-9]\{64\}//g' README.md > "$tmp" && mv "$tmp" README.md
     sources:
       - chart/values.yaml
       - chart/README.md

--- a/kubernetes/controller/Taskfile.yml
+++ b/kubernetes/controller/Taskfile.yml
@@ -256,7 +256,7 @@ tasks:
       - '"{{.HELM_DOCS}}"'
       # Strip SHA digests from README.md for cleaner documentation
       # The digest is kept in values.yaml for security, but removed from docs for readability
-      - sed -i'' -e 's/@sha256:[a-f0-9]\{64\}//g' README.md
+      - sed 's/@sha256:[a-f0-9]\{64\}//g' README.md > README.md.tmp && mv README.md.tmp README.md
     sources:
       - chart/values.yaml
       - chart/README.md


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

> ## How GNU sed Handles In-Place Editing
> 
> GNU sed accepts -i without an argument to edit files in place without creating a backup. GNU sed also accepts -i.bak to create a backup with the .bak extension. The -i flag and the backup extension are a single argument.
> ## How BSD sed Handles In-Place Editing
>
>BSD sed requires a separate argument after -i— even if the argument is an empty string. sed -i '' 's/old/new/' file edits in place without a backup. sed -i .bak 's/old/new/' file creates a backup. Omitting the argument after -i causes BSD sed to interpret the next argument as the backup extension.

https://console9.com/wiki/articles/sed/explanations/gnu-vs-bsd/

Which is why running `task helm/validate` I get an error due to an unexpected new file `README.md-e`.

Using an explicit temp file and avoiding the `-i` parameter should make it work on both.

#### Which issue(s) this PR fixes
Incompatibility of `task helm/validate` with MacOS `sed`

#### Testing
-

##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [x] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
