### PR TITLE
chore(website): manually bump versioned website for release `0.9.0`

### DIFF
--- a/website/config/_default/hugo.yaml
+++ b/website/config/_default/hugo.yaml
@@ -1,39 +1,41 @@
+# Hugo Configuration
+# This file is partially auto-generated. Comments may be lost on regeneration.
+# Per-version settings are auto-generated at the end.
+
 title: Open Component Model
 baseurl: https://ocm.software
 canonifyURLs: false
 disableAliases: true
 disableHugoGeneratorInject: true
-# disableKinds: ["taxonomy", "term"]
 enableEmoji: true
 enableGitInfo: false
 enableRobotsTXT: true
 locale: en-US
 summarylength: 20
-
 defaultContentLanguage: en
-disableLanguages: ["de", "nl"]
+disableLanguages:
+  - de
+  - nl
 defaultContentLanguageInSubdir: false
-
 editPage: false
 lastMod: false
-
 defaultContentVersionInSubdir: false
-defaultContentVersion: main
-
+defaultContentVersion: '0.9'
 pagination:
   pagerSize: 10
-
 params:
   social: true
-
 build:
   buildStats:
     enable: true
-
 outputs:
-  home: ["HTML", "searchIndex"]
-  section: ["HTML", "RSS", "SITEMAP"]
-
+  home:
+    - HTML
+    - searchIndex
+  section:
+    - HTML
+    - RSS
+    - SITEMAP
 outputFormats:
   searchIndex:
     mediaType: application/json
@@ -47,31 +49,25 @@ outputFormats:
     isPlainText: true
     noUgly: true
     rel: sitemap
-
 sitemap:
   changefreq: monthly
   filename: sitemap.xml
   priority: 0.5
-
 caches:
   getresource:
-    dir: ":cacheDir/:project"
-    maxAge: -1 # "30m"
-
+    dir: ':cacheDir/:project'
+    maxAge: -1
 taxonomies:
   contributor: contributors
   category: categories
   tag: tags
-
 permalinks:
-  docs: "/docs/:sections[1:]/:title/"
-
+  docs: /docs/:sections[1:]/:title/
 minify:
   disableSVG: true
   tdewolff:
     html:
       keepWhitespace: false
-
 related:
   threshold: 80
   includeNewer: true
@@ -83,20 +79,19 @@ related:
       weight: 80
     - name: date
       weight: 10
-
 imaging:
   anchor: Center
-  bgColor: "#ffffff"
+  bgColor: '#ffffff'
   hint: photo
   quality: 85
   resampleFilter: Lanczos
-
 versions:
   main:
     weight: 1
-  legacy:
+  '0.9':
     weight: 2
-
+  legacy:
+    weight: 3
 services:
   rss:
     limit: 20

--- a/website/config/_default/module.yaml
+++ b/website/config/_default/module.yaml
@@ -1,180 +1,249 @@
-# Module Configuration File
+# Hugo Module Configuration
+# This file is partially auto-generated. Comments may be lost on regeneration.
 #
-# This file configures Hugo module settings, particularly module mounts which
-# define how content is organized within the project.
-#
-# Mounts specify file paths in your project that Hugo should use when building
-# the site. They allow for custom directory structures and integrating content
-# from different locations.
-#
-# At the end of this file, there are per-version mounts and imports for
-# reference documentation, allowing different versions of content to be
-# served based on the site's versioning strategy.
+# Static mounts (data, layouts, i18n, archetypes, assets, static) are fixed.
+# Per-version imports are auto-generated at the end.
 
 mounts:
-  ## data
   - source: node_modules/@thulite/doks-core/data
     target: data
-
   - source: data
     target: data
-
-  ## layouts
   - source: layouts
     target: layouts
-
-  # Exclude 'home.html' to avoid conflicts with a custom home page layout defined in the local 'layouts' directory.
-  # Hugo >= 0.153 deprecates `excludeFiles`; use `files` glob slice instead.
-  - files: ["**", "!home.html"]
+  - files:
+      - '**'
+      - '!home.html'
     source: node_modules/@thulite/doks-core/layouts
     target: layouts
-
   - source: node_modules/@thulite/core/layouts
     target: layouts
-
   - source: node_modules/@thulite/seo/layouts
     target: layouts
-
   - source: node_modules/@thulite/images/layouts
     target: layouts
-
   - source: node_modules/@thulite/inline-svg/layouts
     target: layouts
-
-  ## i18n
   - source: node_modules/@thulite/doks-core/i18n
     target: i18n
-
   - source: i18n
     target: i18n
-
-  ## archetypes
   - source: node_modules/@thulite/doks-core/archetypes
     target: archetypes
-
   - source: archetypes
     target: archetypes
-
-  ## assets
   - source: node_modules/@thulite/core/assets
     target: assets
-
   - source: node_modules/@thulite/doks-core/assets
     target: assets
-
   - source: node_modules/@tabler/icons/icons
     target: assets/svgs/tabler-icons
-
   - source: node_modules/@thulite/images/assets
     target: assets
-
   - source: assets
     target: assets
-
-  ## static
   - source: node_modules/@thulite/doks-core/static
     target: static
-
   - source: static
     target: static
-
-  # Versioning content with mounts and imports
-  ## per-version mounts of content folders
-  ## per-version imports of reference docs using module imports
-  ### legacy: no import (uses embedded reference docs in content folder)
-  ### main: tracks HEAD via sibling-path mounts (monorepo-local, no module import)
-  ### x.y: uses module imports pinned to release tags
-
-  # Shared blog content (single source of truth across all site versions)
   - source: content/blog
     target: content/blog
-
-  # legacy (only mount, no imports)
-  - files: ["**", "!blog/**"]
+  - files:
+      - '**'
+      - '!blog/**'
     source: content_versioned/version-legacy
     target: content
     sites:
       matrix:
-        versions: ["legacy"]
-
-  # main (tracks HEAD of monorepo via sibling-path mounts; CRDs are regenerated
-  # from kubernetes/controller/api/v1alpha1 into bin/gen/crd at build time)
-  - files: ["**", "!blog/**"]
+        versions:
+          - legacy
+  - files:
+      - '**'
+      - '!blog/**'
     source: content
     target: content
     sites:
       matrix:
-        versions: ["main"]
-
+        versions:
+          - main
   - source: ../cli/docs/reference
     target: content/docs/reference/ocm-cli
     sites:
       matrix:
-        versions: ["main"]
-
+        versions:
+          - main
   - source: ../bindings/go/constructor/spec/v1/resources
     target: static/main/schemas/bindings/go/constructor
     sites:
       matrix:
-        versions: ["main"]
-
+        versions:
+          - main
   - source: ../bindings/go/descriptor/v2/resources
     target: static/main/schemas/bindings/go/descriptor/v2
     sites:
       matrix:
-        versions: ["main"]
-
+        versions:
+          - main
   - source: ../bindings/go/http/spec/config/v1alpha1/schemas
     target: static/main/schemas/bindings/go/http
     sites:
       matrix:
-        versions: ["main"]
-
+        versions:
+          - main
   - source: ../bindings/go/oci/spec/credentials/v1/schemas
     target: static/main/schemas/bindings/go/credentials/oci/v1
     sites:
       matrix:
-        versions: ["main"]
-
+        versions:
+          - main
   - source: ../bindings/go/helm/spec/credentials/v1/schemas
     target: static/main/schemas/bindings/go/credentials/helm/v1
     sites:
       matrix:
-        versions: ["main"]
-
+        versions:
+          - main
   - source: ../bindings/go/rsa/spec/credentials/v1/schemas
     target: static/main/schemas/bindings/go/credentials/rsa/v1
     sites:
       matrix:
-        versions: ["main"]
-
+        versions:
+          - main
   - source: ../bindings/go/gpg/spec/credentials/v1alpha1/schemas
     target: static/main/schemas/bindings/go/credentials/gpg/v1alpha1
     sites:
       matrix:
-        versions: ["main"]
-
+        versions:
+          - main
   - source: ../bindings/go/sigstore/spec/credentials/oidcidentitytoken/v1alpha1/schemas
     target: static/main/schemas/bindings/go/credentials/sigstore/oidcidentitytoken/v1alpha1
     sites:
       matrix:
-        versions: ["main"]
-
+        versions:
+          - main
   - source: ../bindings/go/sigstore/spec/credentials/trustedroot/v1alpha1/schemas
     target: static/main/schemas/bindings/go/credentials/sigstore/trustedroot/v1alpha1
     sites:
       matrix:
-        versions: ["main"]
-
+        versions:
+          - main
   - source: ../bindings/go/credentials/spec/config/v1/schemas
     target: static/main/schemas/bindings/go/credentials/direct/v1
     sites:
       matrix:
-        versions: ["main"]
-
+        versions:
+          - main
   - source: ../kubernetes/controller/bin/gen/crd
     target: static/main/schemas/kubernetes/controller
     sites:
       matrix:
-        versions: ["main"]
-
+        versions:
+          - main
+imports:
+  - path: ocm.software/open-component-model/website
+    version: v0.9.0
+    mounts:
+      - files:
+          - '**'
+          - '!blog/**'
+        source: content/
+        target: content
+        sites:
+          matrix:
+            versions:
+              - '0.9'
+  - path: ocm.software/open-component-model/cli
+    version: v0.9.0
+    mounts:
+      - source: docs/reference
+        target: content/docs/reference/ocm-cli
+        sites:
+          matrix:
+            versions:
+              - '0.9'
+  - path: ocm.software/open-component-model/bindings/go/constructor
+    version: v0.0.9
+    mounts:
+      - source: spec/v1/resources
+        target: static/0.9/schemas/bindings/go/constructor
+        sites:
+          matrix:
+            versions:
+              - '0.9'
+  - path: ocm.software/open-component-model/bindings/go/descriptor/v2
+    version: v2.0.3-alpha3
+    mounts:
+      - source: resources
+        target: static/0.9/schemas/bindings/go/descriptor/v2
+        sites:
+          matrix:
+            versions:
+              - '0.9'
+  - path: ocm.software/open-component-model/bindings/go/oci
+    version: v0.0.45
+    mounts:
+      - source: spec/credentials/v1/schemas
+        target: static/0.9/schemas/bindings/go/credentials/oci/v1
+        sites:
+          matrix:
+            versions:
+              - '0.9'
+  - path: ocm.software/open-component-model/bindings/go/helm
+    version: v0.0.0-20260601150938-fdc040441934
+    mounts:
+      - source: spec/credentials/v1/schemas
+        target: static/0.9/schemas/bindings/go/credentials/helm/v1
+        sites:
+          matrix:
+            versions:
+              - '0.9'
+  - path: ocm.software/open-component-model/bindings/go/rsa
+    version: v0.0.0-20260526121250-aae701a4aa9b
+    mounts:
+      - source: spec/credentials/v1/schemas
+        target: static/0.9/schemas/bindings/go/credentials/rsa/v1
+        sites:
+          matrix:
+            versions:
+              - '0.9'
+  - path: ocm.software/open-component-model/bindings/go/gpg
+    version: v0.0.0-20260528112443-9cd4df811eb4
+    mounts:
+      - source: spec/credentials/v1alpha1/schemas
+        target: static/0.9/schemas/bindings/go/credentials/gpg/v1alpha1
+        sites:
+          matrix:
+            versions:
+              - '0.9'
+  - path: ocm.software/open-component-model/bindings/go/sigstore
+    version: v0.0.0-20260526121250-aae701a4aa9b
+    mounts:
+      - source: spec/credentials/oidcidentitytoken/v1alpha1/schemas
+        target: static/0.9/schemas/bindings/go/credentials/sigstore/oidcidentitytoken/v1alpha1
+        sites:
+          matrix:
+            versions:
+              - '0.9'
+      - source: spec/credentials/trustedroot/v1alpha1/schemas
+        target: static/0.9/schemas/bindings/go/credentials/sigstore/trustedroot/v1alpha1
+        sites:
+          matrix:
+            versions:
+              - '0.9'
+  - path: ocm.software/open-component-model/bindings/go/credentials
+    version: v0.0.12
+    mounts:
+      - source: spec/config/v1/schemas
+        target: static/0.9/schemas/bindings/go/credentials/direct/v1
+        sites:
+          matrix:
+            versions:
+              - '0.9'
+  - path: ocm.software/open-component-model/kubernetes/controller
+    version: v0.9.0
+    mounts:
+      - source: config/crd/bases
+        target: static/0.9/schemas/kubernetes/controller
+        sites:
+          matrix:
+            versions:
+              - '0.9'


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

As discussed [here](https://github.com/open-component-model/ocm-project/issues/1147#issuecomment-4779793318), we decided to manually create the PR for the versioned release.

The changed files are a result of running `node scripts/register-docs-version.js "$VERSION" --cli-gomod cli-go.mod` where version is `0.9.0`.

Related to https://github.com/open-component-model/ocm-project/issues/1147