### PR TITLE
fix(deps): migrate js-yaml usage to v5 API

### DIFF
--- a/.github/scripts/prepare-registry-constructor.js
+++ b/.github/scripts/prepare-registry-constructor.js
@@ -1,6 +1,6 @@
 // @ts-check
 import fs from 'fs';
-import yaml from 'js-yaml';
+import { load as yamlLoad, dump as yamlDump } from 'js-yaml';
 import {computeNextVersions} from "./release-versioning.js";
 import {execSync} from "child_process";
 import {dirname} from "path";
@@ -157,7 +157,7 @@ export function prepareRegistryConstructor(core, {
 }) {
     const defaultOverrides = ["0.0.0-main", "v0.0.0-main"];
     const template = fs.readFileSync(constructorPath, 'utf8');
-    const constructor = yaml.load(template);
+    const constructor = yamlLoad(template);
 
     // Initialize or copy component references
     constructor.componentReferences = registryExists
@@ -297,7 +297,7 @@ export default async function prepareRegistryConstructorAction({core}) {
         });
 
         // Write updated constructor
-        const rendered = yaml.dump(constructor, {lineWidth: -1});
+        const rendered = yamlDump(constructor, {lineWidth: -1});
         fs.writeFileSync(constructorPath, rendered, 'utf8');
         core.debug(`Constructor:\n${rendered}`);
 

--- a/website/assets/js/schema/crd-yaml-converter.ts
+++ b/website/assets/js/schema/crd-yaml-converter.ts
@@ -1,6 +1,6 @@
 /** Converts Kubernetes CRD YAML into SchemaModel(s). Handles multi-doc and multi-version CRDs. */
 
-import yaml from "js-yaml";
+import { loadAll } from "js-yaml";
 import { jsonSchemaToModel } from "./json-schema-converter.ts";
 import type { CrdDocument, CrdVersion } from "./crd-yaml-converter.types.ts";
 import type { SchemaMeta, SchemaModel } from "./schema-model.types.ts";
@@ -32,7 +32,7 @@ function versionToModel(crd: CrdDocument, version: CrdVersion): SchemaModel {
 
 /** Convert a CRD YAML string into one or more SchemaModels. */
 export function crdYamlToModels(text: string): SchemaModel[] {
-  const docs = yaml.loadAll(text).filter(Boolean) as Record<string, unknown>[];
+  const docs = loadAll(text).filter(Boolean) as Record<string, unknown>[];
   const crds = docs.filter((d) => d.kind === "CustomResourceDefinition") as unknown as CrdDocument[];
   if (!crds.length) return [];
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -20,7 +20,6 @@
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
-        "@types/js-yaml": "4.0.9",
         "@types/node": "25.9.4",
         "eslint": "10.5.0",
         "globals": "17.6.0",
@@ -2319,13 +2318,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true,
       "license": "MIT"
     },

--- a/website/package.json
+++ b/website/package.json
@@ -41,7 +41,6 @@
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
-    "@types/js-yaml": "4.0.9",
     "@types/node": "25.9.4",
     "eslint": "10.5.0",
     "globals": "17.6.0",


### PR DESCRIPTION
## Summary

- Replaces `import yaml from 'js-yaml'` (default import) with named imports (`load`, `dump`, `loadAll`) — js-yaml v5 no longer provides a default ESM export
- Removes the `@types/js-yaml` dev dependency since v5 ships its own TypeScript declarations

Fixes the Netlify deploy failure on #2923.

## Test plan

- [x] `.github/scripts` tests pass (5/5)
- [x] `website/scripts/register-docs-version.test.js` passes (53/53)
- [x] ESLint passes on changed files
- [x] Hugo's ESBuild bundling will resolve the named import correctly