### PR TITLE
docs(website): remove stale Helm #911 future-feature callout

### DIFF
--- a/website/content/docs/how-to/transfer-helm-charts.md
+++ b/website/content/docs/how-to/transfer-helm-charts.md
@@ -60,18 +60,10 @@ Add the component version to a CTF archive:
 
 ```bash
 ocm add cv --repository ctf::<path/to/archive> \
-  --constructor constructor.yaml \
-  --skip-reference-digest-processing
+  --constructor constructor.yaml
 ```
 
 {{< /step >}}
-
-{{<callout context="caution" title="Why --skip-reference-digest-processing?" icon="outline/alert-triangle">}}
-The `--skip-reference-digest-processing` flag is required because the `Helm/v1` access type currently cannot be fully resolved during `add cv`.
-The chart is not downloaded at this stage, so digest calculation is not possible. The digests are computed later during transfer when the chart is
-actually fetched.
-Full Helm support is being tracked as a future feature in [ocm-project#911](https://github.com/open-component-model/ocm-project/issues/911).
-{{< /callout >}}
 
 {{< step >}}
 


### PR DESCRIPTION
[ocm-project#911](https://github.com/open-component-model/ocm-project/issues/911) is closed and the underlying limitation is implemented (Helm digest processor auto-computes digests for `Helm/v1` access during `add cv`, see `Test_Integration_HelmAccess_DigestProcessor`).

Removes the obsolete callout from `transfer-helm-charts.md` and drops the no-longer-needed `--skip-reference-digest-processing` flag from the `add cv` example.