### PR TITLE
chore(website): fix transitive dependency resolution in versioned website

### DIFF
--- a/website/config/_default/module.yaml
+++ b/website/config/_default/module.yaml
@@ -141,6 +141,7 @@ mounts:
 imports:
   - path: ocm.software/open-component-model/website
     version: v0.9.0
+    ignoreImports: true
     mounts:
       - files:
           - '**'

--- a/website/config/_default/module.yaml
+++ b/website/config/_default/module.yaml
@@ -142,6 +142,7 @@ imports:
   - path: ocm.software/open-component-model/website
     version: v0.9.0
     ignoreImports: true
+    ignoreConfig: true
     mounts:
       - files:
           - '**'

--- a/website/scripts/register-docs-version.js
+++ b/website/scripts/register-docs-version.js
@@ -249,14 +249,13 @@ function buildModuleBlocks(version, fullVersion, deps) {
         {
             path: `${MODULE_PREFIX}/website`,
             version: `v${fullVersion}`,
-            // The website module is a self-import: its own `module.yaml` declares
-            // transitive imports (cli, bindings, controller) pinned at whatever
-            // versions were current when the tag was cut. Hugo's "first-wins"
-            // module resolution lets those stale pins override the explicit
-            // imports we list further down. `ignoreImports: true` tells Hugo
-            // to load only this module's `mounts:`, not its `imports:`, so the
-            // pins below are the only source of truth for the 0.X version slot.
+            // Self-import: treat the snapshot as a content-only tarball.
+            // ignoreImports drops its transitive version pins (which override
+            // ours via Hugo's first-wins resolution); ignoreConfig also drops
+            // its mounts/params/hugo.yaml so the parent project is the sole
+            // source of truth for theme, params, and module graph.
             ignoreImports: true,
+            ignoreConfig: true,
             mounts: [{
                 files: ['**', '!blog/**'],
                 source: 'content/',

--- a/website/scripts/register-docs-version.js
+++ b/website/scripts/register-docs-version.js
@@ -249,6 +249,14 @@ function buildModuleBlocks(version, fullVersion, deps) {
         {
             path: `${MODULE_PREFIX}/website`,
             version: `v${fullVersion}`,
+            // The website module is a self-import: its own `module.yaml` declares
+            // transitive imports (cli, bindings, controller) pinned at whatever
+            // versions were current when the tag was cut. Hugo's "first-wins"
+            // module resolution lets those stale pins override the explicit
+            // imports we list further down. `ignoreImports: true` tells Hugo
+            // to load only this module's `mounts:`, not its `imports:`, so the
+            // pins below are the only source of truth for the 0.X version slot.
+            ignoreImports: true,
             mounts: [{
                 files: ['**', '!blog/**'],
                 source: 'content/',

--- a/website/scripts/register-docs-version.test.js
+++ b/website/scripts/register-docs-version.test.js
@@ -135,6 +135,9 @@ test('buildModuleBlocks: website import has correct tag format', () => {
     const website = imports.find(i => i.path.endsWith('/website'));
     assert.ok(website, 'website import should exist');
     assert.equal(website.version, 'v0.3.0');
+    // Self-import: suppress transitive imports so the explicit pins in
+    // module.yaml are the only source of truth for the 0.X version slot.
+    assert.equal(website.ignoreImports, true);
     assert.deepEqual(website.mounts[0].files, ['**', '!blog/**']);
     assert.equal(website.mounts[0].source, 'content/');
     assert.equal(website.mounts[0].target, 'content');

--- a/website/scripts/register-docs-version.test.js
+++ b/website/scripts/register-docs-version.test.js
@@ -135,9 +135,10 @@ test('buildModuleBlocks: website import has correct tag format', () => {
     const website = imports.find(i => i.path.endsWith('/website'));
     assert.ok(website, 'website import should exist');
     assert.equal(website.version, 'v0.3.0');
-    // Self-import: suppress transitive imports so the explicit pins in
-    // module.yaml are the only source of truth for the 0.X version slot.
+    // Self-import: treat the snapshot as a content-only tarball - the parent
+    // project owns the module graph (ignoreImports) and config (ignoreConfig).
     assert.equal(website.ignoreImports, true);
+    assert.equal(website.ignoreConfig, true);
     assert.deepEqual(website.mounts[0].files, ['**', '!blog/**']);
     assert.equal(website.mounts[0].source, 'content/');
     assert.equal(website.mounts[0].target, 'content');


### PR DESCRIPTION
Apparently, when importing the own website as a module, it is possible to overwrite imports through the website module itself: 

```
hugo mod graph # with ignoreImports: false
go: no module dependencies to download
go: no module dependencies to download
ocm.software/open-component-model/website ocm.software/open-component-model/website@v0.9.1
ocm.software/open-component-model/website@v0.9.1 ocm.software/open-component-model/cli@v0.9.0 <------
ocm.software/open-component-model/website@v0.9.1 ocm.software/open-component-model/bindings/go/constructor@v0.0.9
ocm.software/open-component-model/website@v0.9.1 ocm.software/open-component-model/bindings/go/descriptor/v2@v2.0.3-alpha3
ocm.software/open-component-model/website@v0.9.1 ocm.software/open-component-model/bindings/go/oci@v0.0.45
ocm.software/open-component-model/website@v0.9.1 ocm.software/open-component-model/bindings/go/helm@v0.0.0-20260601150938-fdc040441934
ocm.software/open-component-model/website@v0.9.1 ocm.software/open-component-model/bindings/go/rsa@v0.0.0-20260526121250-aae701a4aa9b
ocm.software/open-component-model/website@v0.9.1 ocm.software/open-component-model/bindings/go/gpg@v0.0.0-20260528112443-9cd4df811eb4
ocm.software/open-component-model/website@v0.9.1 ocm.software/open-component-model/bindings/go/sigstore@v0.0.0-20260526121250-aae701a4aa9b
ocm.software/open-component-model/website@v0.9.1 ocm.software/open-component-model/bindings/go/credentials@v0.0.12
ocm.software/open-component-model/website@v0.9.1 ocm.software/open-component-model/kubernetes/controller@v0.9.0 <------
```

vs

```
hugo mod graph # with ignoreImports: true
go: no module dependencies to download
go: no module dependencies to download
ocm.software/open-component-model/website ocm.software/open-component-model/website@v0.9.1
ocm.software/open-component-model/website ocm.software/open-component-model/cli@v0.9.1 <------
ocm.software/open-component-model/website ocm.software/open-component-model/bindings/go/constructor@v0.0.9
ocm.software/open-component-model/website ocm.software/open-component-model/bindings/go/descriptor/v2@v2.0.3-alpha3
ocm.software/open-component-model/website ocm.software/open-component-model/bindings/go/oci@v0.0.45
ocm.software/open-component-model/website ocm.software/open-component-model/bindings/go/helm@v0.0.0-20260601150938-fdc040441934
ocm.software/open-component-model/website ocm.software/open-component-model/bindings/go/rsa@v0.0.0-20260526121250-aae701a4aa9b
ocm.software/open-component-model/website ocm.software/open-component-model/bindings/go/gpg@v0.0.0-20260528112443-9cd4df811eb4
ocm.software/open-component-model/website ocm.software/open-component-model/bindings/go/sigstore@v0.0.0-20260526121250-aae701a4aa9b
ocm.software/open-component-model/website ocm.software/open-component-model/bindings/go/credentials@v0.0.12
ocm.software/open-component-model/website ocm.software/open-component-model/kubernetes/controller@v0.9.1 <------
```


This is a problem when we want to mount a specific version of, for example, the controllers but the overwrite from the website module pins it back to the old version.

This was tested based on https://github.com/open-component-model/open-component-model/pull/2934
