### PR TITLE
docs: add Argo CD as deployer alongside Flux

### DIFF
--- a/website/content/docs/getting-started/deploy-helm-chart.md
+++ b/website/content/docs/getting-started/deploy-helm-chart.md
@@ -200,6 +200,9 @@ ocm get cv $OCM_REPO//ocm.software/ocm-k8s-toolkit/simple:1.0.0
 The ResourceGraphDefinition tells kro how to orchestrate the OCM and Flux resources.
 Create `rgd.yaml` with the following content:
 
+{{< tabs "helm-rgd-deployer" >}}
+{{< tab "Flux" >}}
+
 {{< details "ResourceGraphDefinition (rgd.yaml)" >}}
 ```yaml
 apiVersion: kro.run/v1alpha1
@@ -319,6 +322,110 @@ spec:
               message: ${schema.spec.message}
 ```
 {{< /details >}}
+
+{{< /tab >}}
+{{< tab "Argo CD" >}}
+
+{{< details "ResourceGraphDefinition (rgd.yaml)" >}}
+```yaml
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: simple
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: Simple
+    spec:
+      message: string | default="foo"
+  resources:
+    - id: repository
+      readyWhen:
+        - ${repository.status.conditions.exists(c, c.type == 'Ready' && c.status == 'True')}
+      template:
+        apiVersion: delivery.ocm.software/v1alpha1
+        kind: Repository
+        metadata:
+          name: simple-repository
+        spec:
+          repositorySpec:
+              baseUrl: $OCM_REPO
+              type: OCIRegistry
+          interval: 1m
+    - id: component
+      readyWhen:
+        - ${component.status.conditions.exists(c, c.type == 'Ready' && c.status == 'True')}
+      template:
+        apiVersion: delivery.ocm.software/v1alpha1
+        kind: Component
+        metadata:
+          name: simple-component
+        spec:
+          repositoryRef:
+            name: ${repository.metadata.name}
+          component: ocm.software/ocm-k8s-toolkit/simple
+          semver: 1.0.0
+          interval: 1m
+    - id: resourceChart
+      readyWhen:
+        - ${resourceChart.status.conditions.exists(c, c.type == 'Ready' && c.status == 'True')}
+      template:
+        apiVersion: delivery.ocm.software/v1alpha1
+        kind: Resource
+        metadata:
+          name: simple-resource
+        spec:
+          componentRef:
+            name: ${component.metadata.name}
+          resource:
+            byReference:
+              resource:
+                name: helm-resource
+          additionalStatusFields:
+            oci: resource.access.toOCI()
+    # Argo CD Application deploys the Helm chart directly from the OCI registry.
+    # Values are injected via valuesObject (structured YAML, no escaping issues).
+    - id: argocdApplication
+      readyWhen:
+        - ${argocdApplication.status.conditions.exists(c, c.type == 'Ready' && c.status == 'True')}
+      template:
+        apiVersion: argoproj.io/v1alpha1
+        kind: Application
+        metadata:
+          name: simple
+          namespace: argocd
+          finalizers:
+            - resources-finalizer.argocd.argoproj.io
+        spec:
+          project: default
+          source:
+            chart: podinfo
+            repoURL: oci://${resourceChart.status.additional.oci.registry}/${resourceChart.status.additional.oci.repository}
+            targetRevision: ${resourceChart.status.additional.oci.tag}
+            helm:
+              releaseName: simple
+              valuesObject:
+                ui:
+                  message: ${schema.spec.message}
+          destination:
+            server: https://kubernetes.default.svc
+            namespace: default
+          syncPolicy:
+            automated:
+              prune: true
+              selfHeal: true
+            syncOptions:
+              - CreateNamespace=true
+```
+{{< /details >}}
+
+{{< callout context="note" title="Argo CD and OCI Helm" icon="outline/info-circle" >}}
+Argo CD references the Helm chart by tag (`targetRevision`). To pin to a specific digest instead, use `targetRevision: sha256:<digest>`, which is supported since Argo CD v3.1.
+Values are injected via `helm.valuesObject` (a structured YAML object), which avoids escaping issues that arise with the string-based `helm.values` field.
+{{< /callout >}}
+
+{{< /tab >}}
+{{< /tabs >}}
 {{< /step >}}
 
 {{< step >}}

--- a/website/content/docs/getting-started/setup-controller-environment.md
+++ b/website/content/docs/getting-started/setup-controller-environment.md
@@ -31,10 +31,10 @@ scenario.
 
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) installed
 - [Helm](https://helm.sh/docs/intro/install/) installed
-- [Flux CLI](https://fluxcd.io/flux/installation/#install-the-flux-cli) installed
 - [kind](https://kind.sigs.k8s.io/docs/user/quick-start) installed (or access to a remote Kubernetes cluster)
 - [OCM CLI]({{< relref "ocm-cli-installation.md" >}}) installed
 - Access to an OCI registry (e.g., [ghcr.io](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages))
+- **Deployer:** [Flux CLI](https://fluxcd.io/flux/installation/#install-the-flux-cli) (if using Flux) or nothing extra (if using Argo CD — installed via `kubectl apply`)
 
 ## Setup Workflow
 
@@ -140,11 +140,13 @@ kro-5644d5759f-82nsx   1/1     Running   0          2m22s
 {{< /step >}}
 {{< step >}}
 
-### Install a Deployer: Flux
+### Install a Deployer
 
-We use [Flux](https://fluxcd.io/) as deployer. In theory, you could use any other deployer
-that is able to apply a deployable resource to a Kubernetes cluster,
-for instance [Argo CD](https://argo-cd.readthedocs.io/en/stable/).
+Both [Flux](https://fluxcd.io/) and [Argo CD](https://argo-cd.readthedocs.io/en/stable/) are supported as deployers.
+Choose the one you're already using or prefer.
+
+{{< tabs "deployer-install" >}}
+{{< tab "Flux" >}}
 
 Install the controllers using the Flux CLI:
 
@@ -219,6 +221,83 @@ source-controller-6ff87cb475-2h2lv           1/1     Running     0              
 ```
 </details>
 
+{{< /tab >}}
+{{< tab "Argo CD" >}}
+
+Install Argo CD into its own namespace:
+
+```shell
+kubectl create namespace argocd
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+```
+
+Wait for all pods to become ready:
+
+```shell
+kubectl wait --for=condition=Ready pods --all -n argocd --timeout=120s
+```
+
+<details>
+<summary>You should see this output</summary>
+
+```text
+pod/argocd-application-controller-0 condition met
+pod/argocd-applicationset-controller-68fd97ccb6-nkcbg condition met
+pod/argocd-dex-server-99ff57675-9qk2l condition met
+pod/argocd-notifications-controller-8596549fb6-bldjz condition met
+pod/argocd-redis-6f6867546c-vs6c6 condition met
+pod/argocd-repo-server-59444f4bbb-gbzxn condition met
+pod/argocd-server-765575f778-j8krk condition met
+```
+</details>
+<br>
+
+Verify Argo CD is running:
+
+```shell
+kubectl get pods -n argocd
+```
+
+<details>
+<summary>You should see this output</summary>
+
+```text
+NAME                                                READY   STATUS    RESTARTS   AGE
+argocd-application-controller-0                     1/1     Running   0          42s
+argocd-applicationset-controller-68fd97ccb6-nkcbg   1/1     Running   0          43s
+argocd-dex-server-99ff57675-9qk2l                   1/1     Running   0          43s
+argocd-notifications-controller-8596549fb6-bldjz    1/1     Running   0          43s
+argocd-redis-6f6867546c-vs6c6                       1/1     Running   0          42s
+argocd-repo-server-59444f4bbb-gbzxn                 1/1     Running   0          42s
+argocd-server-765575f778-j8krk                      1/1     Running   0          42s
+```
+</details>
+<br>
+
+Enable OCI Helm support — required for deploying Helm charts from OCI registries:
+
+```shell
+kubectl patch configmap argocd-cmd-params-cm -n argocd \
+  --type merge -p '{"data":{"application.helm.enableOCI":"true"}}'
+kubectl rollout restart deployment argocd-repo-server -n argocd
+kubectl rollout status deployment argocd-repo-server -n argocd --timeout=60s
+```
+
+<details>
+<summary>You should see this output</summary>
+
+```text
+configmap/argocd-cmd-params-cm patched
+deployment.apps/argocd-repo-server restarted
+Waiting for deployment "argocd-repo-server" rollout to finish: 1 old replicas are pending termination...
+Waiting for deployment "argocd-repo-server" rollout to finish: 1 old replicas are pending termination...
+deployment "argocd-repo-server" successfully rolled out
+```
+</details>
+
+{{< /tab >}}
+{{< /tabs >}}
+
 {{< /step >}}
 {{< step >}}
 
@@ -273,10 +352,10 @@ ocm-k8s-toolkit-controller-manager-79b7975755-vxtqt   1/1     Running   0       
 
 ### Verify Complete Setup
 
-Check all components are running:
+Check all components are running (adapt the namespace filter to the deployer you installed):
 
 ```shell
-kubectl get pods --all-namespaces | grep -E '(kro-system|flux-system|ocm-k8s-toolkit-system)'
+kubectl get pods --all-namespaces | grep -E '(kro-system|flux-system|argocd|ocm-k8s-toolkit-system)'
 ```
 
 <details>

--- a/website/content/docs/how-to/use-argocd-as-deployer.md
+++ b/website/content/docs/how-to/use-argocd-as-deployer.md
@@ -10,10 +10,15 @@ This guide shows how to use [Argo CD](https://argo-cd.readthedocs.io/en/stable/)
 setup, as an alternative to Flux. Argo CD and Flux are peer options — you express the deployer by including the
 appropriate resource in your `ResourceGraphDefinition`.
 
+## Estimated time
+
+~10 minutes
+
 ## Prerequisites
 
-- [Controller environment]({{< relref "setup-controller-environment.md" >}}) with OCM Controllers and kro installed,
-  and Argo CD chosen as the deployer
+- [Controller environment]({{< relref "setup-controller-environment.md" >}}) set up with OCM Controllers, kro, and
+  Argo CD installed (follow the **Argo CD** tab in the
+  [Install a Deployer]({{< relref "setup-controller-environment.md" >}}#install-a-deployer) section)
 - [Custom RBAC]({{< relref "custom-rbac.md" >}}) configured to allow the controller to manage `ResourceGraphDefinitions`
 - [OCM CLI]({{< relref "ocm-cli-installation.md" >}}) installed
 - Access to an OCI registry

--- a/website/content/docs/how-to/use-argocd-as-deployer.md
+++ b/website/content/docs/how-to/use-argocd-as-deployer.md
@@ -1,0 +1,367 @@
+---
+title: "Use Argo CD as a Deployer"
+description: "Deploy OCM-managed Helm charts and Kustomize overlays to Kubernetes using Argo CD as the GitOps deployer."
+icon: "🚀"
+weight: 37
+toc: true
+---
+
+This guide shows how to use [Argo CD](https://argo-cd.readthedocs.io/en/stable/) as the deployer in an OCM controller
+setup, as an alternative to Flux. Argo CD and Flux are peer options — you express the deployer by including the
+appropriate resource in your `ResourceGraphDefinition`.
+
+## Prerequisites
+
+- [Controller environment]({{< relref "setup-controller-environment.md" >}}) with OCM Controllers and kro installed,
+  and Argo CD chosen as the deployer
+- [Custom RBAC]({{< relref "custom-rbac.md" >}}) configured to allow the controller to manage `ResourceGraphDefinitions`
+- [OCM CLI]({{< relref "ocm-cli-installation.md" >}}) installed
+- Access to an OCI registry
+
+## Install Argo CD
+
+If Argo CD is not yet installed on your cluster, follow these steps. Skip this section if it is already running.
+
+```shell
+kubectl create namespace argocd
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+```
+
+<details>
+<summary>You should see this output</summary>
+
+```text
+namespace/argocd created
+customresourcedefinition.apiextensions.k8s.io/applications.argoproj.io created
+customresourcedefinition.apiextensions.k8s.io/appprojects.argoproj.io created
+serviceaccount/argocd-application-controller created
+serviceaccount/argocd-applicationset-controller created
+serviceaccount/argocd-dex-server created
+serviceaccount/argocd-notifications-controller created
+serviceaccount/argocd-redis created
+serviceaccount/argocd-repo-server created
+serviceaccount/argocd-server created
+role.rbac.authorization.k8s.io/argocd-application-controller created
+...
+[59 resources created in total]
+```
+</details>
+<br>
+
+Wait for all pods to become ready:
+
+```shell
+kubectl wait --for=condition=Ready pods --all -n argocd --timeout=120s
+```
+
+<details>
+<summary>You should see this output</summary>
+
+```text
+pod/argocd-application-controller-0 condition met
+pod/argocd-applicationset-controller-68fd97ccb6-nkcbg condition met
+pod/argocd-dex-server-99ff57675-9qk2l condition met
+pod/argocd-notifications-controller-8596549fb6-bldjz condition met
+pod/argocd-redis-6f6867546c-vs6c6 condition met
+pod/argocd-repo-server-59444f4bbb-gbzxn condition met
+pod/argocd-server-765575f778-j8krk condition met
+```
+</details>
+<br>
+
+```shell
+kubectl get pods -n argocd
+```
+
+<details>
+<summary>You should see this output</summary>
+
+```text
+NAME                                                READY   STATUS    RESTARTS   AGE
+argocd-application-controller-0                     1/1     Running   0          42s
+argocd-applicationset-controller-68fd97ccb6-nkcbg   1/1     Running   0          43s
+argocd-dex-server-99ff57675-9qk2l                   1/1     Running   0          43s
+argocd-notifications-controller-8596549fb6-bldjz    1/1     Running   0          43s
+argocd-redis-6f6867546c-vs6c6                       1/1     Running   0          42s
+argocd-repo-server-59444f4bbb-gbzxn                 1/1     Running   0          42s
+argocd-server-765575f778-j8krk                      1/1     Running   0          42s
+```
+</details>
+<br>
+
+Enable OCI Helm support and restart the repo server:
+
+```shell
+kubectl patch configmap argocd-cmd-params-cm -n argocd \
+  --type merge -p '{"data":{"application.helm.enableOCI":"true"}}'
+kubectl rollout restart deployment argocd-repo-server -n argocd
+kubectl rollout status deployment argocd-repo-server -n argocd --timeout=60s
+```
+
+<details>
+<summary>You should see this output</summary>
+
+```text
+configmap/argocd-cmd-params-cm patched
+deployment.apps/argocd-repo-server restarted
+Waiting for deployment "argocd-repo-server" rollout to finish: 1 old replicas are pending termination...
+Waiting for deployment "argocd-repo-server" rollout to finish: 1 old replicas are pending termination...
+deployment "argocd-repo-server" successfully rolled out
+```
+</details>
+
+## How Deployers Work in kro
+
+In the OCM controller stack, deployment happens through a `ResourceGraphDefinition` (RGD) managed by
+[kro](https://kro.run). The RGD describes a graph of Kubernetes resources. You include the deployer's
+own CRD — Flux's `HelmRelease` / `OCIRepository`, or Argo CD's `Application` — as a resource in that
+graph. The OCM `Resource` controller resolves the artifact location and publishes it in its `.status`;
+the deployer resource then picks that up via kro's CEL expressions.
+
+This means Argo CD is not a plugin — it is a Kubernetes operator whose CRDs you reference in your RGD.
+
+## Flux vs Argo CD at a Glance
+
+| | Flux | Argo CD |
+|---|---|---|
+| Helm source type | `OCIRepository` + `HelmRelease` | `Application` with inline OCI source |
+| Helm digest pinning | `spec.ref.digest` | `spec.source.targetRevision: sha256:<digest>` (since v3.1) |
+| Helm value injection | `HelmRelease.spec.values` (string) | `Application.spec.source.helm.valuesObject` (structured YAML) |
+| Kustomize + CEL patches | YAML block scalars | JSON arrays (kro constraint — applies to both deployers) |
+| Operator namespace | `flux-system` | `argocd` |
+
+{{< callout context="note" title="Kustomize patches and CEL" icon="outline/info-circle" >}}
+When a kro CEL expression (`${…}`) appears inside a Kustomize patch, kro cannot parse multi-line YAML
+block scalars. Use JSON arrays for the patch value instead. This is a kro constraint that affects both
+Flux and Argo CD equally — it is not Argo CD-specific.
+{{< /callout >}}
+
+## Deploy a Helm Chart
+
+### ResourceGraphDefinition
+
+The Argo CD `Application` resource replaces Flux's `OCIRepository` + `HelmRelease` pair. Everything
+else in the RGD — `Repository`, `Component`, `Resource` — is identical.
+
+```yaml
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: helm-simple
+spec:
+  schema:
+    apiVersion: v1alpha1
+    kind: HelmSimple
+    spec:
+      prefix: string | default="helm-simple"
+      message: string | default="hello"
+  resources:
+    - id: repository
+      readyWhen:
+        - ${repository.status.conditions.exists(c, c.type == 'Ready' && c.status == 'True')}
+      template:
+        apiVersion: delivery.ocm.software/v1alpha1
+        kind: Repository
+        metadata:
+          name: "${schema.spec.prefix}-repository"
+        spec:
+          repositorySpec:
+            baseUrl: $OCM_REPO
+            type: OCIRegistry
+          interval: 1m
+
+    - id: component
+      readyWhen:
+        - ${component.status.conditions.exists(c, c.type == 'Ready' && c.status == 'True')}
+      template:
+        apiVersion: delivery.ocm.software/v1alpha1
+        kind: Component
+        metadata:
+          name: "${schema.spec.prefix}-component"
+        spec:
+          repositoryRef:
+            name: ${repository.metadata.name}
+          component: ocm.software/ocm-k8s-toolkit/simple
+          semver: 1.0.0
+          interval: 1m
+
+    - id: resourceChart
+      readyWhen:
+        - ${resourceChart.status.conditions.exists(c, c.type == 'Ready' && c.status == 'True')}
+      template:
+        apiVersion: delivery.ocm.software/v1alpha1
+        kind: Resource
+        metadata:
+          name: "${schema.spec.prefix}-resource"
+        spec:
+          componentRef:
+            name: ${component.metadata.name}
+          resource:
+            byReference:
+              resource:
+                name: helm-resource
+          additionalStatusFields:
+            registry: resource.access.toOCI().registry
+            repository: resource.access.toOCI().repository
+            tag: resource.access.toOCI().tag
+
+    # Argo CD Application — replaces Flux OCIRepository + HelmRelease
+    - id: argocdApplication
+      template:
+        apiVersion: argoproj.io/v1alpha1
+        kind: Application
+        metadata:
+          name: "${schema.spec.prefix}"
+          namespace: argocd
+          finalizers:
+            - resources-finalizer.argocd.argoproj.io
+        spec:
+          project: default
+          source:
+            chart: podinfo
+            repoURL: oci://${resourceChart.status.additional.registry}/${resourceChart.status.additional.repository}
+            targetRevision: ${resourceChart.status.additional.tag}
+            helm:
+              releaseName: "${schema.spec.prefix}"
+              valuesObject:
+                ui:
+                  message: ${schema.spec.message}
+          destination:
+            server: https://kubernetes.default.svc
+            namespace: default
+          syncPolicy:
+            automated:
+              prune: true
+              selfHeal: true
+            syncOptions:
+              - CreateNamespace=true
+```
+
+{{< callout context="tip" title="Digest pinning" icon="outline/shield-check" >}}
+To pin the Helm chart to an immutable digest instead of a tag, replace `targetRevision` with the digest:
+
+```yaml
+targetRevision: sha256:<digest-from-resourceChart.status.additional.digest>
+```
+
+This is supported since Argo CD v3.1. Expose the digest in `additionalStatusFields` the same way as `tag`.
+{{< /callout >}}
+
+### Apply and Verify
+
+```shell
+envsubst < rgd.yaml | kubectl apply -f -
+```
+
+Create an instance:
+
+```yaml
+apiVersion: kro.run/v1alpha1
+kind: HelmSimple
+metadata:
+  name: my-app
+spec:
+  prefix: my-app
+  message: "Deployed with OCM and Argo CD!"
+```
+
+```shell
+kubectl apply -f instance.yaml
+```
+
+Check the Argo CD Application status:
+
+```shell
+kubectl get applications -n argocd
+```
+
+## Localization (Helm Values)
+
+When an OCM component bundles both a Helm chart and an image reference, kro CEL expressions inject
+the resolved image coordinates into the Argo CD `valuesObject`. This avoids the escaping issues of
+the string-based `values` field.
+
+```yaml
+    - id: argocdApplication
+      template:
+        ...
+        spec:
+          source:
+            helm:
+              valuesObject:
+                image:
+                  repository: ${resourceImage.status.additional.registry}/${resourceImage.status.additional.repository}
+                  tag: ${resourceImage.status.additional.tag}
+                ui:
+                  message: ${schema.spec.message}
+```
+
+See `kubernetes/controller/examples/helm-configuration-localization/rgd.yaml` for the full example.
+
+## Deploy a Kustomize Overlay
+
+For Kustomize sources, Argo CD uses a single `Application` resource with `spec.source.path` pointing
+to the overlay directory. The Git commit SHA comes from the OCM Resource's status.
+
+```yaml
+    - id: argocdApplication
+      template:
+        apiVersion: argoproj.io/v1alpha1
+        kind: Application
+        metadata:
+          name: "${schema.spec.prefix}"
+          namespace: argocd
+          finalizers:
+            - resources-finalizer.argocd.argoproj.io
+        spec:
+          project: default
+          source:
+            repoURL: ${resourceKustomization.status.resource.access.repoUrl}
+            targetRevision: ${resourceKustomization.status.resource.access.commit}
+            path: "kustomize"
+            kustomize:
+              patches:
+                # JSON array form required when the patch contains a CEL expression (kro constraint)
+                - patch: |
+                    - op: replace
+                      path: /metadata/name
+                      value: my-app-podinfo
+                  target:
+                    kind: Deployment
+                    name: podinfo
+          destination:
+            server: https://kubernetes.default.svc
+            namespace: default
+          syncPolicy:
+            automated:
+              prune: true
+              selfHeal: true
+            syncOptions:
+              - CreateNamespace=true
+```
+
+{{< callout context="caution" title="CEL expressions in Kustomize patches" icon="outline/alert-triangle" >}}
+Static patches (no `${…}` CEL references) can use regular YAML block scalars. Patches that contain
+CEL expressions must use the JSON array form shown above — kro cannot parse multi-line YAML block
+scalars containing `${…}` references. This applies to both Argo CD and Flux.
+{{< /callout >}}
+
+## Troubleshooting
+
+### Argo CD Application stuck in `OutOfSync`
+
+- Verify Argo CD has OCI Helm support enabled: check `argocd-cmd-params-cm` for
+  `application.helm.enableOCI: "true"`.
+- Confirm the `Application` namespace is `argocd` and the destination namespace exists or
+  `CreateNamespace=true` is set in `syncOptions`.
+
+### CEL expressions not resolving
+
+- The OCM `Resource` must be in `Ready` state before kro propagates its status into the `Application`.
+  Add a `readyWhen` condition on the `resourceChart` resource if it is missing.
+
+## Related
+
+- [Tutorial: Deploy a Helm Chart]({{< relref "deploy-helm-chart.md" >}}) — Flux-based walkthrough of the same scenario
+- [Tutorial: Deploy a Helm Chart (Bootstrap)]({{< relref "docs/tutorials/deploy-helm-chart-bootstrap.md" >}}) — Packaging the RGD inside the OCM component
+- [Concept: OCM Controllers]({{< relref "ocm-controllers.md" >}})

--- a/website/content/docs/tutorials/deploy-helm-chart-bootstrap.md
+++ b/website/content/docs/tutorials/deploy-helm-chart-bootstrap.md
@@ -8,6 +8,10 @@ toc: true
 
 ## What You'll Learn
 
+{{< callout context="tip" title="Argo CD users" icon="outline/info-circle" >}}
+This tutorial uses Flux as the deployer. The bootstrap pattern works identically with Argo CD — the `ResourceGraphDefinition` inside the OCM component simply contains an Argo CD `Application` resource instead of Flux's `OCIRepository` + `HelmRelease`. See [Use Argo CD as a Deployer]({{< relref "/docs/how-to/use-argocd-as-deployer.md" >}}) for the Argo CD-specific patterns.
+{{< /callout >}}
+
 In this tutorial, you'll learn how to package deployment instructions (a `ResourceGraphDefinition`) inside an OCM
 component, so operators can deploy your Helm chart without knowing the underlying resource structure. You'll also learn
 **localization**—how to automatically update image references in the

--- a/website/content/docs/tutorials/deploy-helm-chart-bootstrap.md
+++ b/website/content/docs/tutorials/deploy-helm-chart-bootstrap.md
@@ -8,10 +8,6 @@ toc: true
 
 ## What You'll Learn
 
-{{< callout context="tip" title="Argo CD users" icon="outline/info-circle" >}}
-This tutorial uses Flux as the deployer. The bootstrap pattern works identically with Argo CD — the `ResourceGraphDefinition` inside the OCM component simply contains an Argo CD `Application` resource instead of Flux's `OCIRepository` + `HelmRelease`. See [Use Argo CD as a Deployer]({{< relref "/docs/how-to/use-argocd-as-deployer.md" >}}) for the Argo CD-specific patterns.
-{{< /callout >}}
-
 In this tutorial, you'll learn how to package deployment instructions (a `ResourceGraphDefinition`) inside an OCM
 component, so operators can deploy your Helm chart without knowing the underlying resource structure. You'll also learn
 **localization**—how to automatically update image references in the
@@ -29,7 +25,7 @@ By the end, you'll have:
 Before starting, make sure you have set up your environment as described in the [setup guide]({{< relref "setup-controller-environment.md" >}}).
 {{< /callout >}}
 
-- [Controller environment]({{< relref "setup-controller-environment.md" >}}) with OCM Controllers, kro, and Flux installed
+- [Controller environment]({{< relref "setup-controller-environment.md" >}}) with OCM Controllers, kro, and a deployer (Flux or Argo CD) installed
 - [Custom RBAC]({{< relref "custom-rbac.md" >}}) configured to allow the controller to manage `ResourceGraphDefinitions`
 - [OCM CLI]({{< relref "ocm-cli-installation.md" >}}) installed
 - Access to an OCI registry (e.g., [ghcr.io](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages))
@@ -112,8 +108,8 @@ flowchart TB
                 subgraph rgd[RGD: Bootstrap]
                     rgdResourceHelm[Resource: HelmChart]
                     rgdResourceImage[Resource: Image]
-                    rgdSource[Flux: OCI Repository]
-                    rgdHelmRelease[Flux: HelmRelease]
+                    rgdSource[Deployer: Source]
+                    rgdHelmRelease[Deployer: Release]
                 end
                 crdBootstrap[CRD: Bootstrap]
                 subgraph instanceBootstrap[Instance: Bootstrap]
@@ -121,9 +117,9 @@ flowchart TB
                         k8sResourceHelm[Resource: HelmChart]
                         k8sResourceImage[Resource: Image]
                     end
-                    subgraph flux[Flux]
-                        source[OCI Repository]
-                        helmRelease[HelmRelease]
+                    subgraph deployer[Deployer]
+                        source[Source]
+                        helmRelease[Release]
                     end
                     k8sResourceImage ---info[localization reference] --> helmRelease
                 end
@@ -207,6 +203,10 @@ As you can see, the resource `resource-graph-definition` is of type `blob` and c
 following content:
 
 {{< details "ResourceGraphDefinition (resourceGraphDefinition.yaml)" >}}
+
+The `resourceChart` and `resourceImage` resources are identical for both deployers.
+Choose your deployer tab for the deployer-specific resources:
+
 ```yaml
 apiVersion: kro.run/v1alpha1
 kind: ResourceGraphDefinition
@@ -266,6 +266,12 @@ spec:
             oci: resource.access.toOCI()
           # ocmConfig is required, if the OCM repository requires credentials to access it.
           # ocmConfig:
+```
+
+{{< tabs "bootstrap-rgd-deployer" >}}
+{{< tab "Flux" >}}
+
+```yaml
     # OCIRepository watches and downloads the resource from the location provided by the Resource status.
     # The Helm chart location (url) refers to the status of the resource helm-resource.
     - id: ocirepository
@@ -316,6 +322,48 @@ spec:
               repository: ${resourceImage.status.additional.oci.registry}/${resourceImage.status.additional.oci.repository}
               tag: latest@${resourceImage.status.additional.oci.digest}
 ```
+
+{{< /tab >}}
+{{< tab "Argo CD" >}}
+
+```yaml
+    # Argo CD Application deploys the Helm chart directly from the OCI registry.
+    # Values are injected via valuesObject (structured YAML, avoids escaping issues).
+    - id: argocdApplication
+      template:
+        apiVersion: argoproj.io/v1alpha1
+        kind: Application
+        metadata:
+          name: bootstrap
+          namespace: argocd
+          finalizers:
+            - resources-finalizer.argocd.argoproj.io
+        spec:
+          project: default
+          source:
+            chart: podinfo
+            repoURL: oci://${resourceChart.status.additional.oci.registry}/${resourceChart.status.additional.oci.repository}
+            targetRevision: ${resourceChart.status.additional.oci.tag}
+            helm:
+              releaseName: bootstrap-release
+              valuesObject:
+                image:
+                  repository: ${resourceImage.status.additional.oci.registry}/${resourceImage.status.additional.oci.repository}
+                  tag: latest@${resourceImage.status.additional.oci.digest}
+          destination:
+            server: https://kubernetes.default.svc
+            namespace: default
+          syncPolicy:
+            automated:
+              prune: true
+              selfHeal: true
+            syncOptions:
+              - CreateNamespace=true
+```
+
+{{< /tab >}}
+{{< /tabs >}}
+
 {{< /details >}}
 
 To make your component public in GitHub Container Registry, go to the `packages` tab in your GitHub repository `https://github.com/$GITHUB_USERNAME?tab=packages`,
@@ -352,18 +400,18 @@ Then update the resources to use credentials:
          name: ghcr-secret
    ```
 
-2. **Flux OCIRepository**: Uncomment `secretRef` in the RGD's ocirepository
-resource:
+2. **Flux OCIRepository**: Uncomment `secretRef` in the RGD's ocirepository resource (Flux only):
 
    ```yaml
    secretRef:
      name: ghcr-secret
    ```
+   For Argo CD, add a `secretRef` under `spec.source` in the Application resource instead — see the [Argo CD private registry docs](https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#repositories).
 3. **Pod imagePullSecrets**: The deployed pods also need credentials to pull
-images. Add this to the HelmRelease values in the RGD:
+images. Add this to the HelmRelease values (Flux) or `valuesObject` (Argo CD) in the RGD:
 
    ```yaml
-   values:
+   values:        # use valuesObject: for Argo CD
      image:
        repository: ${resourceImage.status.additional.oci.registry}/${resourceImage.status.additional.oci.repository}
        tag: latest@${resourceImage.status.additional.oci.digest}


### PR DESCRIPTION
## Summary

- **Set up Controller Environments**: converts "Install a Deployer: Flux" into a tabbed section with Flux and Argo CD install instructions. OCI Helm support enablement included
- **Deploy Helm Charts** (Getting Started): tabs the deployer-specific RGD block (Flux: `OCIRepository` + `HelmRelease` / Argo CD: `Application` + `valuesObject`)
- **Deploy Helm Charts with Bootstrap Setup** (Tutorial): tabs the deployer block inside the bundled `resourceGraphDefinition.yaml`; shared OCM resources stay outside the tabs; credentials section updated to be deployer-agnostic
- **New how-to: Use Argo CD as a Deployer**: full reference page covering installation, Helm + Kustomize RGD patterns, localization via `valuesObject`, digest pinning (since Argo CD v3.1), and troubleshooting

## Test plan

- [ ] `npm run dev` in `./website` — Hugo builds without errors
- [ ] All four changed pages render at `/main/docs/…` with tabs switching correctly
- [ ] New how-to page appears in sidebar nav under How-to Guides
- [ ] Internal links resolve (no 404s)
- [ ] Workflow tested end-to-end with Argo CD on a kind cluster (console outputs in `<details>` blocks are real, captured during development)