### PR TITLE
fix(website): collapse deprecated type aliases in schema renderer

### DIFF
--- a/website/assets/js/schema/json-schema-converter.test.ts
+++ b/website/assets/js/schema/json-schema-converter.test.ts
@@ -22,7 +22,8 @@ function checkFieldShape(field: SchemaField) {
   assert.equal(typeof field.name, "string");
   assert.equal(typeof field.type, "string");
   assert.equal(typeof field.description, "string");
-  assert.ok(field.constValue === null || typeof field.constValue === "string");
+  assert.ok(Array.isArray(field.constValues));
+  field.constValues.forEach((value) => assert.equal(typeof value, "string"));
   assert.ok(Array.isArray(field.deprecatedConstValues));
   field.deprecatedConstValues.forEach((value) => assert.equal(typeof value, "string"));
   assert.equal(typeof field.required, "boolean");
@@ -221,7 +222,7 @@ describe("edge cases", () => {
     assert.equal(label.variants, null);
   });
 
-  it("type const-only oneOf collapses into primary and deprecated values", () => {
+  it("type const-only oneOf collapses into active and deprecated values", () => {
     const model = jsonSchemaToModel({
       type: "object",
       properties: {
@@ -246,7 +247,7 @@ describe("edge cases", () => {
     const type = model.sections[0].fields.find((f) => f.name === "type")!;
     assert.equal(type.type, "string");
     assert.equal(type.description, "Type represents a structured type.");
-    assert.equal(type.constValue, "RSA/v1");
+    assert.deepEqual(type.constValues, ["RSA/v1"]);
     assert.deepEqual(type.deprecatedConstValues, ["RSA/v1alpha1", "RSA"]);
     assert.equal(type.variants, null);
   });
@@ -265,20 +266,21 @@ describe("edge cases", () => {
     });
 
     const mode = model.sections[0].fields.find((f) => f.name === "mode")!;
-    assert.equal(mode.constValue, null);
+    assert.deepEqual(mode.constValues, []);
     assert.deepEqual(mode.deprecatedConstValues, []);
     assert.equal(mode.variants!.length, 2);
   });
 
-  it("type oneOf with multiple active consts stays polymorphic", () => {
+  it("type oneOf with multiple active consts lists all values without variants", () => {
     const model = jsonSchemaToModel({
       type: "object",
       properties: {
         type: {
           oneOf: [
-            { const: "RSA/v1" },
-            { const: "ECDSA/v1" },
-            { deprecated: true, const: "RSA" },
+            { const: "DirectCredentials/v1" },
+            { const: "Credentials/v1" },
+            { deprecated: true, const: "Credentials" },
+            { deprecated: true, const: "DirectCredentials" },
           ],
         },
       },
@@ -286,12 +288,12 @@ describe("edge cases", () => {
     });
 
     const type = model.sections[0].fields.find((f) => f.name === "type")!;
-    assert.equal(type.constValue, null);
-    assert.deepEqual(type.deprecatedConstValues, []);
-    assert.equal(type.variants!.length, 3);
+    assert.deepEqual(type.constValues, ["DirectCredentials/v1", "Credentials/v1"]);
+    assert.deepEqual(type.deprecatedConstValues, ["Credentials", "DirectCredentials"]);
+    assert.equal(type.variants, null);
   });
 
-  it("type oneOf with only deprecated consts has no primary value", () => {
+  it("type oneOf with only deprecated consts has no active value", () => {
     const model = jsonSchemaToModel({
       type: "object",
       properties: {
@@ -306,7 +308,7 @@ describe("edge cases", () => {
     });
 
     const type = model.sections[0].fields.find((f) => f.name === "type")!;
-    assert.equal(type.constValue, null);
+    assert.deepEqual(type.constValues, []);
     assert.deepEqual(type.deprecatedConstValues, ["RSA/v1alpha1", "RSA"]);
     assert.equal(type.variants, null);
   });

--- a/website/assets/js/schema/json-schema-converter.test.ts
+++ b/website/assets/js/schema/json-schema-converter.test.ts
@@ -269,4 +269,45 @@ describe("edge cases", () => {
     assert.deepEqual(mode.deprecatedConstValues, []);
     assert.equal(mode.variants!.length, 2);
   });
+
+  it("type oneOf with multiple active consts stays polymorphic", () => {
+    const model = jsonSchemaToModel({
+      type: "object",
+      properties: {
+        type: {
+          oneOf: [
+            { const: "RSA/v1" },
+            { const: "ECDSA/v1" },
+            { deprecated: true, const: "RSA" },
+          ],
+        },
+      },
+      required: ["type"],
+    });
+
+    const type = model.sections[0].fields.find((f) => f.name === "type")!;
+    assert.equal(type.constValue, null);
+    assert.deepEqual(type.deprecatedConstValues, []);
+    assert.equal(type.variants!.length, 3);
+  });
+
+  it("type oneOf with only deprecated consts has no primary value", () => {
+    const model = jsonSchemaToModel({
+      type: "object",
+      properties: {
+        type: {
+          oneOf: [
+            { deprecated: true, const: "RSA/v1alpha1" },
+            { deprecated: true, const: "RSA" },
+          ],
+        },
+      },
+      required: ["type"],
+    });
+
+    const type = model.sections[0].fields.find((f) => f.name === "type")!;
+    assert.equal(type.constValue, null);
+    assert.deepEqual(type.deprecatedConstValues, ["RSA/v1alpha1", "RSA"]);
+    assert.equal(type.variants, null);
+  });
 });

--- a/website/assets/js/schema/json-schema-converter.test.ts
+++ b/website/assets/js/schema/json-schema-converter.test.ts
@@ -22,6 +22,9 @@ function checkFieldShape(field: SchemaField) {
   assert.equal(typeof field.name, "string");
   assert.equal(typeof field.type, "string");
   assert.equal(typeof field.description, "string");
+  assert.ok(field.constValue === null || typeof field.constValue === "string");
+  assert.ok(Array.isArray(field.deprecatedConstValues));
+  field.deprecatedConstValues.forEach((value) => assert.equal(typeof value, "string"));
   assert.equal(typeof field.required, "boolean");
   assert.equal(typeof field.immutable, "boolean");
   if (field.properties) field.properties.forEach(checkFieldShape);
@@ -216,5 +219,54 @@ describe("edge cases", () => {
     assert.equal(label.type, "string");
     assert.equal(label.description, "a label");
     assert.equal(label.variants, null);
+  });
+
+  it("type const-only oneOf collapses into primary and deprecated values", () => {
+    const model = jsonSchemaToModel({
+      type: "object",
+      properties: {
+        type: {
+          $ref: "#/$defs/runtimeType",
+          oneOf: [
+            { const: "RSA/v1" },
+            { deprecated: true, const: "RSA/v1alpha1" },
+            { deprecated: true, const: "RSA" },
+          ],
+        },
+      },
+      required: ["type"],
+      $defs: {
+        runtimeType: {
+          type: "string",
+          description: "Type represents a structured type.",
+        },
+      },
+    });
+
+    const type = model.sections[0].fields.find((f) => f.name === "type")!;
+    assert.equal(type.type, "string");
+    assert.equal(type.description, "Type represents a structured type.");
+    assert.equal(type.constValue, "RSA/v1");
+    assert.deepEqual(type.deprecatedConstValues, ["RSA/v1alpha1", "RSA"]);
+    assert.equal(type.variants, null);
+  });
+
+  it("non-type const-only oneOf remains polymorphic", () => {
+    const model = jsonSchemaToModel({
+      type: "object",
+      properties: {
+        mode: {
+          oneOf: [
+            { const: "active" },
+            { deprecated: true, const: "legacy" },
+          ],
+        },
+      },
+    });
+
+    const mode = model.sections[0].fields.find((f) => f.name === "mode")!;
+    assert.equal(mode.constValue, null);
+    assert.deepEqual(mode.deprecatedConstValues, []);
+    assert.equal(mode.variants!.length, 2);
   });
 });

--- a/website/assets/js/schema/json-schema-converter.ts
+++ b/website/assets/js/schema/json-schema-converter.ts
@@ -76,40 +76,35 @@ function constStrings(branches: SchemaNode[]): string[] {
 }
 
 /**
- * Find a oneOf/anyOf union whose branches are all bare `const` aliases and that
- * collapses to at most one active value. Returns null when there is no such
- * union or when multiple active values keep the field genuinely polymorphic.
+ * A oneOf/anyOf union whose branches are all bare `const` aliases enumerates the
+ * allowed literal values of a field (e.g. a `type` discriminator and its
+ * deprecated aliases) rather than describing polymorphic object shapes.
  */
-function collapsibleConstAliasUnion(node: SchemaNode): { kw: "oneOf" | "anyOf"; branches: SchemaNode[] } | null {
+function constAliasUnion(node: SchemaNode): { kw: "oneOf" | "anyOf"; branches: SchemaNode[] } | null {
     for (const kw of ["oneOf", "anyOf"] as const) {
         const branches = node[kw];
-        if (!Array.isArray(branches) || !branches.length || !branches.every(isConstAliasBranch)) continue;
-        if (branches.filter((branch) => !branch.deprecated).length > 1) return null;
-        return {kw, branches};
+        if (Array.isArray(branches) && branches.length && branches.every(isConstAliasBranch)) return {kw, branches};
     }
     return null;
 }
 
-function constAliasesFrom(node: SchemaNode): { constValue: string | null; deprecatedConstValues: string[] } {
-    const union = collapsibleConstAliasUnion(node);
+function constAliasesFrom(node: SchemaNode): { constValues: string[]; deprecatedConstValues: string[] } {
+    const union = constAliasUnion(node);
     if (!union) {
         return {
-            constValue: typeof node.const === "string" ? node.const : null,
+            constValues: typeof node.const === "string" ? [node.const] : [],
             deprecatedConstValues: [],
         };
     }
 
-    const active = constStrings(union.branches.filter((branch) => !branch.deprecated));
-    const deprecated = constStrings(union.branches.filter((branch) => branch.deprecated));
-
     return {
-        constValue: active[0] ?? null,
-        deprecatedConstValues: deprecated,
+        constValues: constStrings(union.branches.filter((branch) => !branch.deprecated)),
+        deprecatedConstValues: constStrings(union.branches.filter((branch) => branch.deprecated)),
     };
 }
 
 function withoutConstAliasUnion(node: SchemaNode): SchemaNode {
-    const union = collapsibleConstAliasUnion(node);
+    const union = constAliasUnion(node);
     if (!union) return node;
 
     const {[union.kw]: _, ...rest} = node;
@@ -155,7 +150,7 @@ function fieldsFrom(node: SchemaNode, root: SchemaNode, seen: Set<string>): Sche
 function convertField(name: string, raw: SchemaNode, requiredList: string[], root: SchemaNode, seen = new Set<string>()): SchemaField {
     const prop = resolve(raw, root, new Set(seen));
     const isTypeField = name === "type";
-    const constAliases = isTypeField ? constAliasesFrom(prop) : {constValue: null, deprecatedConstValues: []};
+    const constAliases = isTypeField ? constAliasesFrom(prop) : {constValues: [], deprecatedConstValues: []};
     const displayProp = isTypeField ? withoutConstAliasUnion(prop) : prop;
     const immutable = prop["x-kubernetes-validations"]?.some((v: {
         rule?: string
@@ -178,7 +173,7 @@ function convertField(name: string, raw: SchemaNode, requiredList: string[], roo
             });
             return {
                 name, type: normalizeType(displayProp.type), description: displayProp.description || "",
-                constValue: constAliases.constValue, deprecatedConstValues: constAliases.deprecatedConstValues,
+                constValues: constAliases.constValues, deprecatedConstValues: constAliases.deprecatedConstValues,
                 required, immutable, properties: null, variants,
             };
         }
@@ -203,7 +198,7 @@ function convertField(name: string, raw: SchemaNode, requiredList: string[], roo
                 });
                 return {
                     name, type: `[]${normalizeType(items.type)}`, description: displayProp.description || "",
-                    constValue: constAliases.constValue, deprecatedConstValues: constAliases.deprecatedConstValues,
+                    constValues: constAliases.constValues, deprecatedConstValues: constAliases.deprecatedConstValues,
                     required, immutable, properties: null, variants,
                 };
             }
@@ -211,7 +206,7 @@ function convertField(name: string, raw: SchemaNode, requiredList: string[], roo
 
         return {
             name, type: `[]${normalizeType(items.type)}`, description: displayProp.description || "",
-            constValue: constAliases.constValue, deprecatedConstValues: constAliases.deprecatedConstValues,
+            constValues: constAliases.constValues, deprecatedConstValues: constAliases.deprecatedConstValues,
             required, immutable, variants: null,
             properties: items.properties ? fieldsFrom(items, root, new Set(seen)) : null,
         };
@@ -220,7 +215,7 @@ function convertField(name: string, raw: SchemaNode, requiredList: string[], roo
     // Plain object or scalar
     return {
         name, type: normalizeType(displayProp.type), description: displayProp.description || "",
-        constValue: constAliases.constValue, deprecatedConstValues: constAliases.deprecatedConstValues,
+        constValues: constAliases.constValues, deprecatedConstValues: constAliases.deprecatedConstValues,
         required, immutable, variants: null,
         properties: displayProp.properties ? fieldsFrom(displayProp, root, new Set(seen)) : null,
     };

--- a/website/assets/js/schema/json-schema-converter.ts
+++ b/website/assets/js/schema/json-schema-converter.ts
@@ -69,42 +69,51 @@ function isConstAliasBranch(node: SchemaNode): boolean {
     return typeof node.const === "string" && !node.properties && !node.items && !node.oneOf && !node.anyOf;
 }
 
-function constAliasesFrom(node: SchemaNode): { constValue: string | null; deprecatedConstValues: string[] } {
+function constStrings(branches: SchemaNode[]): string[] {
+    return branches
+        .map((branch) => branch.const)
+        .filter((value): value is string => typeof value === "string");
+}
+
+/**
+ * Find a oneOf/anyOf union whose branches are all bare `const` aliases and that
+ * collapses to at most one active value. Returns null when there is no such
+ * union or when multiple active values keep the field genuinely polymorphic.
+ */
+function collapsibleConstAliasUnion(node: SchemaNode): { kw: "oneOf" | "anyOf"; branches: SchemaNode[] } | null {
     for (const kw of ["oneOf", "anyOf"] as const) {
-        if (!Array.isArray(node[kw])) continue;
+        const branches = node[kw];
+        if (!Array.isArray(branches) || !branches.length || !branches.every(isConstAliasBranch)) continue;
+        if (branches.filter((branch) => !branch.deprecated).length > 1) return null;
+        return {kw, branches};
+    }
+    return null;
+}
 
-        const branches = node[kw] as SchemaNode[];
-        if (!branches.length || !branches.every(isConstAliasBranch)) continue;
-
-        const active = branches.find((branch) => !branch.deprecated)?.const;
-        const deprecated = branches
-            .filter((branch) => branch.deprecated)
-            .map((branch) => branch.const)
-            .filter((value): value is string => typeof value === "string");
-
+function constAliasesFrom(node: SchemaNode): { constValue: string | null; deprecatedConstValues: string[] } {
+    const union = collapsibleConstAliasUnion(node);
+    if (!union) {
         return {
-            constValue: typeof active === "string" ? active : branches[0].const || null,
-            deprecatedConstValues: deprecated,
+            constValue: typeof node.const === "string" ? node.const : null,
+            deprecatedConstValues: [],
         };
     }
 
+    const active = constStrings(union.branches.filter((branch) => !branch.deprecated));
+    const deprecated = constStrings(union.branches.filter((branch) => branch.deprecated));
+
     return {
-        constValue: typeof node.const === "string" ? node.const : null,
-        deprecatedConstValues: [],
+        constValue: active[0] ?? null,
+        deprecatedConstValues: deprecated,
     };
 }
 
 function withoutConstAliasUnion(node: SchemaNode): SchemaNode {
-    if (!Array.isArray(node.oneOf) && !Array.isArray(node.anyOf)) return node;
+    const union = collapsibleConstAliasUnion(node);
+    if (!union) return node;
 
-    for (const kw of ["oneOf", "anyOf"] as const) {
-        if (Array.isArray(node[kw]) && (node[kw] as SchemaNode[]).every(isConstAliasBranch)) {
-            const {[kw]: _, ...rest} = node;
-            return rest;
-        }
-    }
-
-    return node;
+    const {[union.kw]: _, ...rest} = node;
+    return rest;
 }
 
 /**

--- a/website/assets/js/schema/json-schema-converter.ts
+++ b/website/assets/js/schema/json-schema-converter.ts
@@ -65,6 +65,48 @@ function normalizeType(type: string | string[] | undefined): string {
     return type || "object";
 }
 
+function isConstAliasBranch(node: SchemaNode): boolean {
+    return typeof node.const === "string" && !node.properties && !node.items && !node.oneOf && !node.anyOf;
+}
+
+function constAliasesFrom(node: SchemaNode): { constValue: string | null; deprecatedConstValues: string[] } {
+    for (const kw of ["oneOf", "anyOf"] as const) {
+        if (!Array.isArray(node[kw])) continue;
+
+        const branches = node[kw] as SchemaNode[];
+        if (!branches.length || !branches.every(isConstAliasBranch)) continue;
+
+        const active = branches.find((branch) => !branch.deprecated)?.const;
+        const deprecated = branches
+            .filter((branch) => branch.deprecated)
+            .map((branch) => branch.const)
+            .filter((value): value is string => typeof value === "string");
+
+        return {
+            constValue: typeof active === "string" ? active : branches[0].const || null,
+            deprecatedConstValues: deprecated,
+        };
+    }
+
+    return {
+        constValue: typeof node.const === "string" ? node.const : null,
+        deprecatedConstValues: [],
+    };
+}
+
+function withoutConstAliasUnion(node: SchemaNode): SchemaNode {
+    if (!Array.isArray(node.oneOf) && !Array.isArray(node.anyOf)) return node;
+
+    for (const kw of ["oneOf", "anyOf"] as const) {
+        if (Array.isArray(node[kw]) && (node[kw] as SchemaNode[]).every(isConstAliasBranch)) {
+            const {[kw]: _, ...rest} = node;
+            return rest;
+        }
+    }
+
+    return node;
+}
+
 /**
  * Merge shared parent properties into a oneOf/anyOf branch.
  */
@@ -103,6 +145,9 @@ function fieldsFrom(node: SchemaNode, root: SchemaNode, seen: Set<string>): Sche
  */
 function convertField(name: string, raw: SchemaNode, requiredList: string[], root: SchemaNode, seen = new Set<string>()): SchemaField {
     const prop = resolve(raw, root, new Set(seen));
+    const isTypeField = name === "type";
+    const constAliases = isTypeField ? constAliasesFrom(prop) : {constValue: null, deprecatedConstValues: []};
+    const displayProp = isTypeField ? withoutConstAliasUnion(prop) : prop;
     const immutable = prop["x-kubernetes-validations"]?.some((v: {
         rule?: string
     }) => v.rule?.includes("== oldSelf")) || false;
@@ -110,10 +155,10 @@ function convertField(name: string, raw: SchemaNode, requiredList: string[], roo
 
     // Polymorphic oneOf/anyOf
     for (const kw of ["oneOf", "anyOf"] as const) {
-        if (Array.isArray(prop[kw])) {
-            const hasSharedProps = !!prop.properties;
-            const variants: FieldVariant[] = (prop[kw] as SchemaNode[]).map((branch, i) => {
-                const merged = mergeParentInto(branch, prop, kw);
+        if (Array.isArray(displayProp[kw])) {
+            const hasSharedProps = !!displayProp.properties;
+            const variants: FieldVariant[] = (displayProp[kw] as SchemaNode[]).map((branch, i) => {
+                const merged = mergeParentInto(branch, displayProp, kw);
                 const resolved = resolve(merged, root, new Set(seen));
                 const title = variantTitle(resolved, i);
                 const fields = resolved.properties ? fieldsFrom(resolved, root, new Set(seen)) : null;
@@ -123,15 +168,16 @@ function convertField(name: string, raw: SchemaNode, requiredList: string[], roo
                 };
             });
             return {
-                name, type: normalizeType(prop.type), description: prop.description || "",
+                name, type: normalizeType(displayProp.type), description: displayProp.description || "",
+                constValue: constAliases.constValue, deprecatedConstValues: constAliases.deprecatedConstValues,
                 required, immutable, properties: null, variants,
             };
         }
     }
 
     // Array with items
-    if (prop.type === "array" && prop.items) {
-        const items = resolve(prop.items, root, new Set(seen));
+    if (displayProp.type === "array" && displayProp.items) {
+        const items = resolve(displayProp.items, root, new Set(seen));
 
         for (const kw of ["oneOf", "anyOf"] as const) {
             if (Array.isArray(items[kw])) {
@@ -147,14 +193,16 @@ function convertField(name: string, raw: SchemaNode, requiredList: string[], roo
                     };
                 });
                 return {
-                    name, type: `[]${normalizeType(items.type)}`, description: prop.description || "",
+                    name, type: `[]${normalizeType(items.type)}`, description: displayProp.description || "",
+                    constValue: constAliases.constValue, deprecatedConstValues: constAliases.deprecatedConstValues,
                     required, immutable, properties: null, variants,
                 };
             }
         }
 
         return {
-            name, type: `[]${normalizeType(items.type)}`, description: prop.description || "",
+            name, type: `[]${normalizeType(items.type)}`, description: displayProp.description || "",
+            constValue: constAliases.constValue, deprecatedConstValues: constAliases.deprecatedConstValues,
             required, immutable, variants: null,
             properties: items.properties ? fieldsFrom(items, root, new Set(seen)) : null,
         };
@@ -162,9 +210,10 @@ function convertField(name: string, raw: SchemaNode, requiredList: string[], roo
 
     // Plain object or scalar
     return {
-        name, type: normalizeType(prop.type), description: prop.description || "",
+        name, type: normalizeType(displayProp.type), description: displayProp.description || "",
+        constValue: constAliases.constValue, deprecatedConstValues: constAliases.deprecatedConstValues,
         required, immutable, variants: null,
-        properties: prop.properties ? fieldsFrom(prop, root, new Set(seen)) : null,
+        properties: displayProp.properties ? fieldsFrom(displayProp, root, new Set(seen)) : null,
     };
 }
 

--- a/website/assets/js/schema/json-schema-converter.ts
+++ b/website/assets/js/schema/json-schema-converter.ts
@@ -173,7 +173,7 @@ function convertField(name: string, raw: SchemaNode, requiredList: string[], roo
             });
             return {
                 name, type: normalizeType(displayProp.type), description: displayProp.description || "",
-                constValues: constAliases.constValues, deprecatedConstValues: constAliases.deprecatedConstValues,
+                ...constAliases,
                 required, immutable, properties: null, variants,
             };
         }
@@ -198,7 +198,7 @@ function convertField(name: string, raw: SchemaNode, requiredList: string[], roo
                 });
                 return {
                     name, type: `[]${normalizeType(items.type)}`, description: displayProp.description || "",
-                    constValues: constAliases.constValues, deprecatedConstValues: constAliases.deprecatedConstValues,
+                    ...constAliases,
                     required, immutable, properties: null, variants,
                 };
             }
@@ -206,7 +206,7 @@ function convertField(name: string, raw: SchemaNode, requiredList: string[], roo
 
         return {
             name, type: `[]${normalizeType(items.type)}`, description: displayProp.description || "",
-            constValues: constAliases.constValues, deprecatedConstValues: constAliases.deprecatedConstValues,
+            ...constAliases,
             required, immutable, variants: null,
             properties: items.properties ? fieldsFrom(items, root, new Set(seen)) : null,
         };
@@ -215,7 +215,7 @@ function convertField(name: string, raw: SchemaNode, requiredList: string[], roo
     // Plain object or scalar
     return {
         name, type: normalizeType(displayProp.type), description: displayProp.description || "",
-        constValues: constAliases.constValues, deprecatedConstValues: constAliases.deprecatedConstValues,
+        ...constAliases,
         required, immutable, variants: null,
         properties: displayProp.properties ? fieldsFrom(displayProp, root, new Set(seen)) : null,
     };

--- a/website/assets/js/schema/schema-model.types.ts
+++ b/website/assets/js/schema/schema-model.types.ts
@@ -4,6 +4,8 @@ export interface SchemaField {
   name: string;
   type: string;
   description: string;
+  constValue: string | null;
+  deprecatedConstValues: string[];
   required: boolean;
   immutable: boolean;
   properties: SchemaField[] | null;

--- a/website/assets/js/schema/schema-model.types.ts
+++ b/website/assets/js/schema/schema-model.types.ts
@@ -4,7 +4,7 @@ export interface SchemaField {
   name: string;
   type: string;
   description: string;
-  constValue: string | null;
+  constValues: string[];
   deprecatedConstValues: string[];
   required: boolean;
   immutable: boolean;

--- a/website/assets/js/schema/schema-renderer.tsx
+++ b/website/assets/js/schema/schema-renderer.tsx
@@ -92,7 +92,7 @@ function FieldRow({field, depth = 0, parentPath = ""}: {field: SchemaFieldType; 
                             )}
                             {field.deprecatedConstValues.map((value) => (
                                 <code key={value} className="sr-const-value sr-const-value--deprecated">
-                                    {value}
+                                    <span className="visually-hidden">deprecated: </span>{value}
                                 </code>
                             ))}
                         </div>

--- a/website/assets/js/schema/schema-renderer.tsx
+++ b/website/assets/js/schema/schema-renderer.tsx
@@ -1,4 +1,5 @@
 import {render} from "preact";
+import type {ComponentChildren} from "preact";
 import {useState, useEffect} from "preact/hooks";
 import {jsonSchemaToModel} from "./json-schema-converter.ts";
 import {crdYamlToModels, isYamlUrl} from "./crd-yaml-converter.ts";
@@ -150,7 +151,7 @@ function VariantRows({variants, depth, parentPath = ""}: {variants: FieldVariant
     );
 }
 
-function FieldTable({title, description, fields}: {title: string; description: string; fields: SchemaFieldType[]}) {
+function FieldTable({title, description, fields, footer}: {title: string; description: string; fields: SchemaFieldType[]; footer?: ComponentChildren}) {
     if (!fields?.length) return null;
     return (
         <div className="sr-section">
@@ -170,27 +171,51 @@ function FieldTable({title, description, fields}: {title: string; description: s
                     </tbody>
                 </table>
             </div>
+            {footer}
         </div>
     );
 }
 
+function fieldsHaveDeprecated(fields: SchemaFieldType[] | null): boolean {
+    return !!fields?.some((field) =>
+        field.deprecatedConstValues.length > 0 ||
+        fieldsHaveDeprecated(field.properties) ||
+        !!field.variants?.some((variant) => fieldsHaveDeprecated(variant.properties)),
+    );
+}
+
 function SchemaView({model, schemaUrl}: {model: SchemaModelType; schemaUrl: string}) {
+    const hasDeprecated = model.sections.some((section) => fieldsHaveDeprecated(section.fields));
+    // Render the footer inside the last populated section so it sits directly below
+    // the table, rather than after the section's (shared, large) bottom margin.
+    const lastWithFields = model.sections.reduce(
+        (last, section, i) => (section.fields?.length ? i : last), -1);
+    const footer = (
+        <div className="sr-footer">
+            {hasDeprecated && (
+                <p className="sr-footer__note">
+                    <span className="sr-footer__dashed">Dashed outline</span> marks a
+                    deprecated value — still accepted, but avoid in new configurations.
+                </p>
+            )}
+            <ul>
+                <li>
+                    <a href={schemaUrl} target="_blank" rel="noopener noreferrer">
+                        View raw schema source
+                    </a>
+                </li>
+            </ul>
+        </div>
+    );
     return (
         <>
             <SchemaHeader meta={model.meta}/>
-            {model.sections.map((section) => (
+            {model.sections.map((section, i) => (
                 <FieldTable key={section.title} title={section.title}
-                            description={section.description} fields={section.fields}/>
+                            description={section.description} fields={section.fields}
+                            footer={i === lastWithFields ? footer : undefined}/>
             ))}
-            <div className="sr-footer">
-                <ul>
-                    <li>
-                        <a href={schemaUrl} target="_blank" rel="noopener noreferrer">
-                            View raw schema source
-                        </a>
-                    </li>
-                </ul>
-            </div>
+            {lastWithFields === -1 && footer}
         </>
     );
 }

--- a/website/assets/js/schema/schema-renderer.tsx
+++ b/website/assets/js/schema/schema-renderer.tsx
@@ -85,11 +85,11 @@ function FieldRow({field, depth = 0, parentPath = ""}: {field: SchemaFieldType; 
                 </td>
                 <td className="sr-field-type">
                     <span className={`sr-type-badge ${typeClass(field.type)}`}>{field.type}</span>
-                    {(field.constValue || field.deprecatedConstValues.length > 0) && (
+                    {(field.constValues.length > 0 || field.deprecatedConstValues.length > 0) && (
                         <div className="sr-const-values" aria-label={`${field.name} allowed values`}>
-                            {field.constValue && (
-                                <code className="sr-const-value">{field.constValue}</code>
-                            )}
+                            {field.constValues.map((value) => (
+                                <code key={value} className="sr-const-value">{value}</code>
+                            ))}
                             {field.deprecatedConstValues.map((value) => (
                                 <code key={value} className="sr-const-value sr-const-value--deprecated">
                                     <span className="visually-hidden">deprecated: </span>{value}

--- a/website/assets/js/schema/schema-renderer.tsx
+++ b/website/assets/js/schema/schema-renderer.tsx
@@ -85,6 +85,18 @@ function FieldRow({field, depth = 0, parentPath = ""}: {field: SchemaFieldType; 
                 </td>
                 <td className="sr-field-type">
                     <span className={`sr-type-badge ${typeClass(field.type)}`}>{field.type}</span>
+                    {(field.constValue || field.deprecatedConstValues.length > 0) && (
+                        <div className="sr-const-values" aria-label={`${field.name} allowed values`}>
+                            {field.constValue && (
+                                <code className="sr-const-value">{field.constValue}</code>
+                            )}
+                            {field.deprecatedConstValues.map((value) => (
+                                <code key={value} className="sr-const-value sr-const-value--deprecated">
+                                    {value}
+                                </code>
+                            ))}
+                        </div>
+                    )}
                 </td>
                 <td className="sr-field-desc sr-field-desc--col">
                     {descContent}

--- a/website/assets/scss/components/_schema-renderer.scss
+++ b/website/assets/scss/components/_schema-renderer.scss
@@ -297,6 +297,34 @@ $schema-max-depth: 8;
   white-space: nowrap;
 }
 
+.sr-const-values {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-top: 0.375rem;
+  max-width: 18rem;
+}
+
+.sr-const-value {
+  display: inline-block;
+  padding: 0.15rem 0.4rem;
+  border: 1px solid var(--bs-border-color);
+  border-radius: 4px;
+  background-color: var(--bs-body-bg);
+  color: var(--bs-body-color);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  line-height: 1.35;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.sr-const-value--deprecated {
+  color: var(--bs-secondary-color);
+  text-decoration: line-through;
+  opacity: 0.8;
+}
+
 $schema-type-colors: (
   string:  (#dbeafe, #1e40af, #1e3a5f, #93c5fd),
   number:  (#fce7f3, #9f1239, #4a1942, #f9a8d4),

--- a/website/assets/scss/components/_schema-renderer.scss
+++ b/website/assets/scss/components/_schema-renderer.scss
@@ -300,7 +300,8 @@ $schema-max-depth: 8;
 .sr-const-values {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.25rem;
+  row-gap: 0.5rem;
+  column-gap: 0.25rem;
   margin-top: 0.375rem;
   max-width: 18rem;
 }
@@ -320,9 +321,22 @@ $schema-max-depth: 8;
 }
 
 .sr-const-value--deprecated {
+  border-style: dashed;
+  border-color: var(--bs-border-color);
+  background-color: var(--bs-body-bg);
   color: var(--bs-secondary-color);
-  text-decoration: line-through;
-  opacity: 0.8;
+  font-size: 0.625rem;
+  font-weight: 500;
+}
+
+.sr-footer__note {
+  margin-bottom: 0.5rem;
+  color: var(--bs-secondary-color);
+  font-size: 0.8125rem;
+}
+
+.sr-footer__dashed {
+  border-bottom: 1px dashed var(--bs-border-color);
 }
 
 $schema-type-colors: (
@@ -414,9 +428,8 @@ $schema-type-colors: (
 
 // Footer
 .sr-footer {
-  margin-top: 1.5rem;
+  margin-top: 0.375rem;
   font-size: 1rem;
-  margin-bottom: 1.5rem;
 }
 
 // Mobile: description row instead of column


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Collapses const-only `oneOf`/`anyOf` unions on `type` fields into a primary value plus deprecated aliases so the website schema renderer no longer shows empty, changeless variants.

#### Which issue(s) this PR fixes

Fixes open-component-model/ocm-project#1140

#### Testing

##### How to test the changes

Run the website schema converter tests: `cd website && node --test assets/js/schema/json-schema-converter.test.ts` (the "edge cases" suite covers alias collapsing).

##### Verification

- [x] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [x] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [x] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
