### PR TITLE
chore(deps): update go module directive to v1.26.4 (fixes #3010)

### DIFF
--- a/bindings/go/blob/go.mod
+++ b/bindings/go/blob/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/blob
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/opencontainers/go-digest v1.0.0

--- a/bindings/go/cel/go.mod
+++ b/bindings/go/cel/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/cel
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/google/cel-go v0.28.1

--- a/bindings/go/configuration/go.mod
+++ b/bindings/go/configuration/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/configuration
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/bindings/go/constructor/go.mod
+++ b/bindings/go/constructor/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/constructor
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/opencontainers/go-digest v1.0.0

--- a/bindings/go/constructor/integration/go.mod
+++ b/bindings/go/constructor/integration/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/constructor/integration
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/opencontainers/go-digest v1.0.0

--- a/bindings/go/credentials/go.mod
+++ b/bindings/go/credentials/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/credentials
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/bindings/go/ctf/go.mod
+++ b/bindings/go/ctf/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/ctf
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/nlepage/go-tarfs v1.2.1

--- a/bindings/go/dag/go.mod
+++ b/bindings/go/dag/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/dag
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/bindings/go/descriptor/normalisation/go.mod
+++ b/bindings/go/descriptor/normalisation/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/descriptor/normalisation
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467

--- a/bindings/go/descriptor/runtime/go.mod
+++ b/bindings/go/descriptor/runtime/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/descriptor/runtime
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/bindings/go/descriptor/v2/go.mod
+++ b/bindings/go/descriptor/v2/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/descriptor/v2
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2

--- a/bindings/go/generator/go.mod
+++ b/bindings/go/generator/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/generator
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/bindings/go/gpg/go.mod
+++ b/bindings/go/gpg/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/gpg
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/ProtonMail/go-crypto v1.4.1

--- a/bindings/go/helm/go.mod
+++ b/bindings/go/helm/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/helm
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/opencontainers/go-digest v1.0.0

--- a/bindings/go/http/go.mod
+++ b/bindings/go/http/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/http
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/bindings/go/http/integration/go.mod
+++ b/bindings/go/http/integration/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/http/integration
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Shopify/toxiproxy/v2 v2.12.0

--- a/bindings/go/input/dir/go.mod
+++ b/bindings/go/input/dir/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/input/dir
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/bindings/go/input/file/go.mod
+++ b/bindings/go/input/file/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/input/file
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/gabriel-vasile/mimetype v1.4.13

--- a/bindings/go/input/utf8/go.mod
+++ b/bindings/go/input/utf8/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/input/utf8
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/bindings/go/oci/go.mod
+++ b/bindings/go/oci/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/oci
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0

--- a/bindings/go/oci/integration/go.mod
+++ b/bindings/go/oci/integration/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/oci/integration
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/nlepage/go-tarfs v1.2.1

--- a/bindings/go/plugin/go.mod
+++ b/bindings/go/plugin/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/plugin
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/invopop/jsonschema v0.14.0

--- a/bindings/go/repository/go.mod
+++ b/bindings/go/repository/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/repository
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0

--- a/bindings/go/rsa/go.mod
+++ b/bindings/go/rsa/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/rsa
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/bindings/go/runtime/go.mod
+++ b/bindings/go/runtime/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/runtime
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467

--- a/bindings/go/signing/go.mod
+++ b/bindings/go/signing/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/signing
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/bindings/go/sigstore/go.mod
+++ b/bindings/go/sigstore/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/sigstore
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0

--- a/bindings/go/sigstore/integration/go.mod
+++ b/bindings/go/sigstore/integration/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/sigstore/integration
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/bindings/go/transfer/go.mod
+++ b/bindings/go/transfer/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/transfer
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/opencontainers/image-spec v1.1.1

--- a/bindings/go/transfer/integration/go.mod
+++ b/bindings/go/transfer/integration/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/transfer/integration
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/opencontainers/go-digest v1.0.0

--- a/bindings/go/transform/go.mod
+++ b/bindings/go/transform/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/bindings/go/transform
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/google/cel-go v0.28.1

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/cli
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0

--- a/cli/integration/go.mod
+++ b/cli/integration/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/cli/integration
 
-go 1.26.3
+go 1.26.4
 
 replace ocm.software/open-component-model/cli => ../
 

--- a/conformance/scenarios/sovereign/components/notes/go.mod
+++ b/conformance/scenarios/sovereign/components/notes/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-component-model/open-component-model/conformance/scenarios/sovereign/components/notes
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/gorilla/mux v1.8.1

--- a/kubernetes/controller/Dockerfile
+++ b/kubernetes/controller/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} golang:1.26.3@sha256:2d6c80227255c3112a4d08e67ba98e58efd3846daf15d9d7d4c389565d881b1a AS builder
+FROM --platform=${BUILDPLATFORM} golang:1.26.4@sha256:f96cc555eb8db430159a3aa6797cd5bae561945b7b0fe7d0e284c63a3b291609 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/kubernetes/controller/go.mod
+++ b/kubernetes/controller/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/open-component-model/kubernetes/controller
 
-go 1.26.3
+go 1.26.4
 
 // Replace digest lib to master to gather access to BLAKE3.
 // xref: https://github.com/opencontainers/go-digest/pull/66

--- a/website/go.mod
+++ b/website/go.mod
@@ -1,3 +1,3 @@
 module ocm.software/open-component-model/website
 
-go 1.26.3
+go 1.26.4


### PR DESCRIPTION
#3010 updates the golang version but the docker image for go is not bumped yet so the CI is failing. I don't know yet, why that image was not bumped, but this PR will fix the go bump for now

Fixes #3010 

