### PR TITLE
fix(oci): include SubPath in OCI credential consumer identity

### DIFF
--- a/bindings/go/oci/spec/identity/v1/type.go
+++ b/bindings/go/oci/spec/identity/v1/type.go
@@ -13,6 +13,12 @@ func IdentityFromOCIRepository(repository *oci.Repository) (runtime.Identity, er
 	if err != nil {
 		return nil, fmt.Errorf("could not parse OCI repository URL: %w", err)
 	}
+	// When SubPath is explicitly set, use it directly (BaseUrl is host-only).
+	// When SubPath is empty, ParseURLToIdentity already extracted any path
+	// component from BaseUrl into identity[IdentityAttributePath].
+	if repository.SubPath != "" {
+		identity[runtime.IdentityAttributePath] = repository.SubPath
+	}
 	identity.SetType(Type)
 	return identity, nil
 }
@@ -21,6 +27,9 @@ func OCIRegistryIdentityFromOCIRepository(repository *oci.Repository) (*OCIRegis
 	identity, err := runtime.ParseURLToIdentity(repository.BaseUrl)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse OCI repository URL: %w", err)
+	}
+	if repository.SubPath != "" {
+		identity[runtime.IdentityAttributePath] = repository.SubPath
 	}
 	return FromIdentity(identity), nil
 }

--- a/bindings/go/oci/spec/identity/v1/type.go
+++ b/bindings/go/oci/spec/identity/v1/type.go
@@ -2,23 +2,32 @@ package v1
 
 import (
 	"fmt"
+	"strings"
 
 	"ocm.software/open-component-model/bindings/go/oci/spec/repository/v1/ctf"
 	"ocm.software/open-component-model/bindings/go/oci/spec/repository/v1/oci"
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
+// applySubPath sets the path identity attribute from subPath when non-empty,
+// overriding any path already extracted from BaseUrl. The leading slash is
+// stripped to match the normalization applied by ParseURLToIdentity.
+func applySubPath(identity runtime.Identity, subPath string) {
+	if subPath != "" {
+		identity[runtime.IdentityAttributePath] = strings.TrimPrefix(subPath, "/")
+	}
+}
+
 func IdentityFromOCIRepository(repository *oci.Repository) (runtime.Identity, error) {
 	identity, err := runtime.ParseURLToIdentity(repository.BaseUrl)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse OCI repository URL: %w", err)
 	}
-	// When SubPath is explicitly set, use it directly (BaseUrl is host-only).
+	// When SubPath is explicitly set, it takes precedence over any path
+	// component already extracted from BaseUrl.
 	// When SubPath is empty, ParseURLToIdentity already extracted any path
 	// component from BaseUrl into identity[IdentityAttributePath].
-	if repository.SubPath != "" {
-		identity[runtime.IdentityAttributePath] = repository.SubPath
-	}
+	applySubPath(identity, repository.SubPath)
 	identity.SetType(Type)
 	return identity, nil
 }
@@ -28,9 +37,7 @@ func OCIRegistryIdentityFromOCIRepository(repository *oci.Repository) (*OCIRegis
 	if err != nil {
 		return nil, fmt.Errorf("could not parse OCI repository URL: %w", err)
 	}
-	if repository.SubPath != "" {
-		identity[runtime.IdentityAttributePath] = repository.SubPath
-	}
+	applySubPath(identity, repository.SubPath)
 	return FromIdentity(identity), nil
 }
 

--- a/bindings/go/oci/spec/identity/v1/type_test.go
+++ b/bindings/go/oci/spec/identity/v1/type_test.go
@@ -204,6 +204,19 @@ func TestIdentityFromOCIRepository(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "SubPath with leading slash is normalized",
+			repository: oci.Repository{
+				BaseUrl: "registry.onstackit.cloud",
+				SubPath: "/k7e-components-pre",
+			},
+			want: runtime.Identity{
+				runtime.IdentityAttributeType:     Type.String(),
+				runtime.IdentityAttributeHostname: "registry.onstackit.cloud",
+				runtime.IdentityAttributePath:     "k7e-components-pre",
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/bindings/go/oci/spec/identity/v1/type_test.go
+++ b/bindings/go/oci/spec/identity/v1/type_test.go
@@ -166,6 +166,44 @@ func TestIdentityFromOCIRepository(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 		},
+		{
+			name: "SubPath sets path in identity",
+			repository: oci.Repository{
+				BaseUrl: "registry.onstackit.cloud",
+				SubPath: "k7e-components-pre",
+			},
+			want: runtime.Identity{
+				runtime.IdentityAttributeType:     Type.String(),
+				runtime.IdentityAttributeHostname: "registry.onstackit.cloud",
+				runtime.IdentityAttributePath:     "k7e-components-pre",
+			},
+			wantErr: false,
+		},
+		{
+			name: "explicit SubPath wins over path in BaseUrl",
+			repository: oci.Repository{
+				BaseUrl: "registry.onstackit.cloud/base",
+				SubPath: "k7e",
+			},
+			want: runtime.Identity{
+				runtime.IdentityAttributeType:     Type.String(),
+				runtime.IdentityAttributeHostname: "registry.onstackit.cloud",
+				runtime.IdentityAttributePath:     "k7e",
+			},
+			wantErr: false,
+		},
+		{
+			name: "auto-extraction: empty SubPath uses path from BaseUrl",
+			repository: oci.Repository{
+				BaseUrl: "ghcr.io/open-component-model/ocm",
+			},
+			want: runtime.Identity{
+				runtime.IdentityAttributeType:     Type.String(),
+				runtime.IdentityAttributeHostname: "ghcr.io",
+				runtime.IdentityAttributePath:     "open-component-model/ocm",
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
#### What this PR does / why we need it

`IdentityFromOCIRepository` and `OCIRegistryIdentityFromOCIRepository` built the credential lookup identity solely from `repository.BaseUrl`, ignoring the `SubPath` field entirely. This meant path-scoped consumer entries in `.ocmconfig` were unreachable — the lookup identity never carried a `path` attribute, so the credential graph always matched the first unscoped (hostname-only) entry regardless of the configured path patterns.

The fix applies the same normalization already used by \`buildResolver\` for the actual OCI client:

- **Explicit `SubPath`**: takes precedence over any path component already extracted from `BaseUrl`
- **Empty `SubPath`**: `ParseURLToIdentity` already auto-extracts the path from `BaseUrl`, so no additional code is needed for this case

This allows users to configure separate credentials per registry path on a shared hostname, e.g.:

```yaml
type: credentials.config.ocm.software
consumers:
  - identities:
      - type: OCIRegistry
        hostname: registry.onstackit.cloud
        path: k7e-components-pre/*
    credentials:
      - type: Credentials/v1
        properties:
          username: user-a
          password: pass-a
  - identities:
      - type: OCIRegistry
        hostname: registry.onstackit.cloud
        path: k7e/*
    credentials:
      - type: Credentials/v1
        properties:
          username: user-b
          password: pass-b
```

#### Which issue(s) this PR fixes

Fixes #2990

#### ⚠️ Breaking Change / Migration Notes

Before this fix, `SubPath` was never included in the credential lookup identity. As a result, credential entries with a `path` attribute in `.ocmconfig` were silently ignored — the lookup identity never carried a path, so the path-pattern match in `IdentityMatchesPath` was skipped and the entry matched all requests for that hostname regardless of path.

**After this fix**, path-scoped credential entries behave as intended: a configured entry with `path: some/pattern` only matches requests whose path matches that glob pattern.

**Who is affected**: users who have a credential config with a `path`-scoped identity entry and relied on it matching all requests to that hostname (because the path was never checked). Example of a config that previously matched all paths on the host but now only matches the stated pattern:

```yaml
- identities:
    - type: OCIRegistry
      hostname: registry.onstackit.cloud
      path: k7e-components-pre/*   # was previously ignored; now enforced
  credentials:
    - type: Credentials/v1
      properties:
        username: user-a
        password: pass-a
```

**Migration**: to apply credentials to all paths on a hostname, remove the `path` attribute from the identity entry. A hostname-only identity (no `path`) still matches all requests for that host. To scope credentials per path, add separate entries per pattern as shown in the multi-entry example above.

#### Testing

##### How to test the changes

Configure two credential entries for the same hostname with different `path` patterns as shown above. Run `ocm transfer` from `registry.onstackit.cloud/k7e-components-pre/...` to `registry.onstackit.cloud/k7e/...` — each path should resolve its own credentials instead of falling through to a hostname-only fallback.

##### Verification

- [x] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [x] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [x] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`