### PR TITLE
feat(release): add publish OCM component-versions for CLI, controller and product to release workflow

### DIFF
--- a/.github/workflows/publish-components.yml
+++ b/.github/workflows/publish-components.yml
@@ -1,0 +1,274 @@
+name: Publish OCM components
+
+# Publishes ocm.software/{cli,controller,ocm} component-versions to GHCR.
+# The CLI binary used to invoke `ocm add component-version` is the one this
+# release just built — downloaded from `cli_artifact_name`. Image and chart
+# artefacts referenced by the constructors are pinned by digest, not fetched.
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Bare semver, no leading 'v' (0.7.0 or 0.7.0-rc.1). Matches the OCI tags pipeline.yml pushes for the CLI/controller image and chart."
+        required: true
+        type: string
+      cli_image_digest:
+        description: "Digest of the multi-arch CLI OCI image already pushed to ghcr.io/<owner>/cli."
+        required: true
+        type: string
+      controller_image_digest:
+        description: "Digest of the controller image already pushed to ghcr.io/<owner>/kubernetes/controller."
+        required: true
+        type: string
+      controller_chart_digest:
+        description: "Digest of the Helm chart already pushed to ghcr.io/<owner>/kubernetes/controller/chart."
+        required: true
+        type: string
+      cli_artifact_name:
+        description: "Artifact name containing tmp/bin/ocm-<os>-<arch> for all platforms."
+        required: true
+        type: string
+      conflict_policy:
+        description: "Passed to `ocm add component-version --component-version-conflict-policy`. 'replace' keeps reruns idempotent."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  publish:
+    name: Publish ${{ inputs.version }}
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Compute image refs and CLI binary path
+        env:
+          OWNER: ${{ github.repository_owner }}
+          CLI_ASSETS: ${{ runner.temp }}/cli-assets
+          VERSION: ${{ inputs.version }}
+          CLI_IMAGE_DIGEST: ${{ inputs.cli_image_digest }}
+          CONTROLLER_IMAGE_DIGEST: ${{ inputs.controller_image_digest }}
+          CONTROLLER_CHART_DIGEST: ${{ inputs.controller_chart_digest }}
+        run: |
+          set -euo pipefail
+          OWNER="${OWNER,,}"
+          arch=$(dpkg --print-architecture)
+          {
+            echo "REPO_ROOT=$REGISTRY/$OWNER"
+            echo "CLI_IMAGE_REF=$REGISTRY/$OWNER/cli:${VERSION}@${CLI_IMAGE_DIGEST}"
+            echo "CONTROLLER_IMAGE_REF=$REGISTRY/$OWNER/kubernetes/controller:${VERSION}@${CONTROLLER_IMAGE_DIGEST}"
+            echo "CONTROLLER_CHART_REF=$REGISTRY/$OWNER/kubernetes/controller/chart:${VERSION}@${CONTROLLER_CHART_DIGEST}"
+            echo "CLI_BIN=$CLI_ASSETS/bin/ocm-linux-$arch"
+          } >> "$GITHUB_ENV"
+
+      - name: Download CLI artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ inputs.cli_artifact_name }}
+          path: ${{ runner.temp }}/cli-assets
+
+      - name: Make CLI binaries executable
+        env:
+          CLI_ASSETS: ${{ runner.temp }}/cli-assets
+        run: |
+          set -euo pipefail
+          chmod +x "$CLI_ASSETS"/bin/ocm-*
+          test -x "$CLI_BIN"
+
+      - name: Generate CLI component-constructor
+        env:
+          VERSION: ${{ inputs.version }}
+          CLI_ASSETS: ${{ runner.temp }}/cli-assets
+          OUT: ${{ runner.temp }}/cli-component-constructor.yaml
+        run: |
+          set -euo pipefail
+          cat > "$OUT" <<EOF
+          name: ocm.software/cli
+          version: ${VERSION}
+          provider:
+            name: ocm.software
+          resources:
+            - name: cli
+              type: executable
+              version: ${VERSION}
+              labels:
+                - name: downloadName
+                  value: ocm
+              extraIdentity:
+                os: linux
+                architecture: amd64
+              relation: local
+              input:
+                type: file
+                path: ${CLI_ASSETS}/bin/ocm-linux-amd64
+            - name: cli
+              type: executable
+              version: ${VERSION}
+              labels:
+                - name: downloadName
+                  value: ocm
+              extraIdentity:
+                os: linux
+                architecture: arm64
+              relation: local
+              input:
+                type: file
+                path: ${CLI_ASSETS}/bin/ocm-linux-arm64
+            - name: cli
+              type: executable
+              version: ${VERSION}
+              labels:
+                - name: downloadName
+                  value: ocm
+              extraIdentity:
+                os: darwin
+                architecture: amd64
+              relation: local
+              input:
+                type: file
+                path: ${CLI_ASSETS}/bin/ocm-darwin-amd64
+            - name: cli
+              type: executable
+              version: ${VERSION}
+              labels:
+                - name: downloadName
+                  value: ocm
+              extraIdentity:
+                os: darwin
+                architecture: arm64
+              relation: local
+              input:
+                type: file
+                path: ${CLI_ASSETS}/bin/ocm-darwin-arm64
+            - name: cli
+              type: executable
+              version: ${VERSION}
+              labels:
+                - name: downloadName
+                  value: ocm
+              extraIdentity:
+                os: windows
+                architecture: amd64
+              relation: local
+              input:
+                type: file
+                path: ${CLI_ASSETS}/bin/ocm-windows-amd64
+            - name: cli
+              type: executable
+              version: ${VERSION}
+              labels:
+                - name: downloadName
+                  value: ocm
+              extraIdentity:
+                os: windows
+                architecture: arm64
+              relation: local
+              input:
+                type: file
+                path: ${CLI_ASSETS}/bin/ocm-windows-arm64
+            - name: image
+              type: ociImage
+              version: ${VERSION}
+              relation: local
+              access:
+                type: ociArtifact
+                imageReference: ${CLI_IMAGE_REF}
+          EOF
+
+      - name: Generate controller component-constructor
+        env:
+          VERSION: ${{ inputs.version }}
+          OUT: ${{ runner.temp }}/controller-component-constructor.yaml
+        run: |
+          set -euo pipefail
+          cat > "$OUT" <<EOF
+          name: ocm.software/controller
+          version: ${VERSION}
+          provider:
+            name: ocm.software
+          resources:
+            - name: image
+              type: ociImage
+              version: ${VERSION}
+              relation: local
+              access:
+                type: ociArtifact
+                imageReference: ${CONTROLLER_IMAGE_REF}
+            - name: chart
+              type: helmChart
+              version: ${VERSION}
+              relation: local
+              access:
+                type: ociArtifact
+                imageReference: ${CONTROLLER_CHART_REF}
+          EOF
+
+      - name: Generate product component-constructor
+        env:
+          VERSION: ${{ inputs.version }}
+          OUT: ${{ runner.temp }}/product-component-constructor.yaml
+        run: |
+          set -euo pipefail
+          cat > "$OUT" <<EOF
+          name: ocm.software/ocm
+          version: ${VERSION}
+          provider:
+            name: ocm.software
+          componentReferences:
+            - name: cli
+              componentName: ocm.software/cli
+              version: ${VERSION}
+            - name: controller
+              componentName: ocm.software/controller
+              version: ${VERSION}
+          EOF
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Write OCM config
+        run: |
+          set -euo pipefail
+          cat > "$HOME/.ocmconfig" <<EOF
+          type: generic.config.ocm.software/v1
+          configurations:
+            - type: credentials.config.ocm.software
+              repositories:
+                - repository:
+                    type: DockerConfig/v1
+                    dockerConfigFile: $HOME/.docker/config.json
+                    propagateConsumerIdentity: true
+          EOF
+
+      - name: Publish component-versions
+        env:
+          CONFLICT_POLICY: ${{ inputs.conflict_policy }}
+          TMP: ${{ runner.temp }}
+        run: |
+          set -euo pipefail
+          "$CLI_BIN" add component-version \
+            --config "$HOME/.ocmconfig" \
+            --repository "$REPO_ROOT" \
+            --constructor "$TMP/cli-component-constructor.yaml" \
+            --component-version-conflict-policy "$CONFLICT_POLICY"
+          "$CLI_BIN" add component-version \
+            --config "$HOME/.ocmconfig" \
+            --repository "$REPO_ROOT" \
+            --constructor "$TMP/controller-component-constructor.yaml" \
+            --component-version-conflict-policy "$CONFLICT_POLICY"
+          "$CLI_BIN" add component-version \
+            --config "$HOME/.ocmconfig" \
+            --repository "$REPO_ROOT" \
+            --constructor "$TMP/product-component-constructor.yaml" \
+            --component-version-conflict-policy "$CONFLICT_POLICY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,12 +44,6 @@ jobs:
   # PHASE 1: RELEASE CANDIDATE
   # ===========================================================================
 
-  # === Copied from release-candidate-version.yml ===
-  # Changes vs the original:
-  #   removed the `component_path` input since it's not per component anymore.
-  #   cliff config path change: `${component_path}/cliff.toml` → `cliff.toml` (root).
-  #   canonical tag added: v* alongside the existing per-component tags.
-  #   Outputs added: `cli_module_*_tag` and `controller_module_*_tag` (RC + promotion).
   prepare:
     name: Prepare Release Metadata
     runs-on: ubuntu-24.04-arm
@@ -144,13 +138,7 @@ jobs:
           script: |
             const script = await import('${{ github.workspace }}/.github/scripts/release-versioning.js');
             await script.determineLatestRelease({ core, github, context });
-  # === release-candidate-version.yml ===
 
-  # === Copied from controller-release.yml::tag_rc ===
-  # Changes vs the original:
-  #   calls `createRcTags` (plural) instead of `createRcTag`
-  #   passes both CANONICAL_TAG and a comma-separated ADDITIONAL_TAGS list
-  #   so cli/v* and kubernetes/controller/v* are emitted on the same commit
   tag_rc:
     name: Create and Push RC Tags
     runs-on: ubuntu-24.04-arm
@@ -210,12 +198,9 @@ jobs:
           script: |
             const script = await import('${{ github.workspace }}/.github/scripts/create-tag.js');
             await script.createRcTags({ core });
-  # === controller-release.yml::tag_rc ===
 
-  # === This is completely new. It starts the orchestration process for building and testing the components. ===
-  # It uses the new workflow helper called `pipeline.yaml`.
-  # This will execute conformance tests, e2e tests, validations and builds for the respective components.
-  # This pipeline here is a daily pipeline as well.
+  # Orchestrates build + conformance + e2e + publish for CLI and controller.
+  # Reused by daily CI on main; here it runs on the RC commit.
   build_and_test:
     name: Build and Test
     if: ${{ github.event.inputs.dry_run == 'false' && needs.tag_rc.outputs.pushed == 'true' }}
@@ -232,9 +217,6 @@ jobs:
       ref: ${{ needs.prepare.outputs.new_tag }}
       build_version: ${{ needs.prepare.outputs.base_version }}
 
-  # === Copied from cli-release.yml::release_rc + controller-release.yml::release_rc ===
-  # Combines into one pre-release containing both CLI assets (binaries + OCI tarballs)
-  # and the controller chart. Summary will have digests for both.
   release_rc:
     name: Create RC Pre-Release
     if: ${{ github.event.inputs.dry_run == 'false' && needs.tag_rc.outputs.pushed == 'true' }}
@@ -313,18 +295,30 @@ jobs:
               .addEOL()
               .addLink('View Release', release.data.html_url)
               .write();
-  # === cli-release.yml::release_rc + controller-release.yml::release_rc ===
+
+  # Publishes ocm.software/{cli,controller,ocm} for the RC, referencing the
+  # just-pushed CLI image, controller image and chart by digest.
+  publish_components_rc:
+    name: Publish OCM Components (RC)
+    if: ${{ github.event.inputs.dry_run == 'false' && needs.tag_rc.outputs.pushed == 'true' }}
+    needs: [prepare, tag_rc, build_and_test]
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    uses: ./.github/workflows/publish-components.yml
+    with:
+      version: ${{ needs.prepare.outputs.new_version }}
+      cli_image_digest: ${{ needs.build_and_test.outputs.cli_image_digest }}
+      controller_image_digest: ${{ needs.build_and_test.outputs.controller_image_digest }}
+      controller_chart_digest: ${{ needs.build_and_test.outputs.controller_chart_digest }}
+      cli_artifact_name: ${{ needs.build_and_test.outputs.cli_artifact_name }}
+      conflict_policy: replace
 
   # ===========================================================================
   # PHASE 2: FINAL RELEASE (after environment gate)
   # ===========================================================================
 
-  # === Copied from cli-release.yml::verify_attestations + controller-release.yml::verify_attestations and merged ===
-  # All four attestation verifications:
-  #   CLI binaries (cli-release.yml)
-  #   CLI OCI image (cli-release.yml)
-  #   Controller image (controller-release.yml)
-  #   Controller chart (controller-release.yml)
   verify_attestations:
     name: Verify RC Attestations
     needs: [prepare, build_and_test, release_rc]
@@ -385,11 +379,7 @@ jobs:
           CHART_DIGEST: ${{ needs.build_and_test.outputs.controller_chart_digest }}
         run: |
           gh attestation verify "oci://$CONTROLLER_CHART@${CHART_DIGEST}" --repo "$GH_REPO"
-  # === cli-release.yml::verify_attestations + controller-release.yml::verify_attestations ===
 
-  # === Copied from controller-release.yml::promote_and_release_final + cli-release.yml::promote_final + cli-release.yml::release_final and merged ===
-  # These are literally copied verbatim from the original files from the above sentence.
-  # All I changed was applying some of the zizmor stuff.
   promote_and_release_final:
     name: Promote and Release Final
     needs: [prepare, build_and_test, verify_attestations]
@@ -402,6 +392,11 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+    outputs:
+      # Exposed for publish_components_final, which references the chart by
+      # digest. The chart is re-packaged at promotion (final version stripped
+      # of `-rc.N`) so the digest differs from the RC chart digest.
+      final_chart_digest: ${{ steps.chart-digest.outputs.digest }}
     steps:
       - name: Compute image refs (lowercase owner)
         env:
@@ -567,7 +562,9 @@ jobs:
           VERSION: ${{ needs.prepare.outputs.base_version }}
         run: |
           set -euo pipefail
-          echo "digest=$(oras resolve $CONTROLLER_CHART:${VERSION})" >> "$GITHUB_OUTPUT"
+          digest=$(oras resolve "$CONTROLLER_CHART:${VERSION}")
+          [[ "$digest" == sha256:* ]] || { echo "::error::oras resolve returned unexpected digest: $digest"; exit 1; }
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Attest final chart
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
@@ -622,7 +619,6 @@ jobs:
           script: |
             const script = await import('${{ github.workspace }}/.github/scripts/publish-final-release.js');
             await script.default({ github, context, core });
-  # === controller-release.yml::promote_and_release_final + cli-release.yml::promote_final + cli-release.yml::release_final ===
 
   verify_install_script:
     name: Verify install script for ${{ needs.prepare.outputs.base_version }}
@@ -634,11 +630,28 @@ jobs:
     permissions:
       contents: read
 
-  # === Website version release ===
-  # Replaces the old standalone website-version-release.yml. Runs after the
-  # final promotion succeeded, when the website/v0.X.Y tag exists. Opens a PR
-  # to main pinning Hugo module imports to the just-created website tag, with
-  # binding versions resolved from the released CLI module's go.mod.
+  # Counterpart of publish_components_rc for the final release.
+  publish_components_final:
+    name: Publish OCM Components (Final)
+    if: ${{ github.event.inputs.dry_run == 'false' }}
+    needs: [prepare, build_and_test, promote_and_release_final]
+    permissions:
+      contents: read
+      packages: write
+      actions: read
+    uses: ./.github/workflows/publish-components.yml
+    with:
+      version: ${{ needs.prepare.outputs.base_version }}
+      cli_image_digest: ${{ needs.build_and_test.outputs.cli_image_digest }}
+      controller_image_digest: ${{ needs.build_and_test.outputs.controller_image_digest }}
+      controller_chart_digest: ${{ needs.promote_and_release_final.outputs.final_chart_digest }}
+      cli_artifact_name: ${{ needs.build_and_test.outputs.cli_artifact_name }}
+      conflict_policy: replace
+
+  # Runs after the final promotion succeeded, when the website/v0.X.Y tag
+  # exists. Opens a PR to main pinning Hugo module imports to the just-created
+  # website tag, with binding versions resolved from the released CLI module's
+  # go.mod.
   create_website_update_pr:
     name: Open website update PR
     needs: [prepare, promote_and_release_final]
@@ -739,4 +752,3 @@ jobs:
             ````
             ${{ steps.register.outputs.log }}
             ````
-  # === Website version release ===

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -77,18 +77,21 @@ flowchart TD
     end
 
     Pipeline --> ReleaseRC[release_rc<br/>GitHub pre-release<br/>binaries + OCI tarballs + chart + changelog]
+    Pipeline --> PubCompRC[publish_components_rc<br/>ocm.software/cli, /controller, /ocm<br/>conflict: replace]
     ReleaseRC --> Gate{{release environment<br/>manual approval}}
     Gate --> Verify[verify_attestations<br/>CLI binaries, CLI OCI,<br/>controller image, chart]
     Verify --> Promote[promote_and_release_final<br/>tag v0.X.Y + cli/v0.X.Y + kubernetes/controller/v0.X.Y + website/v0.X.Y<br/>oras retag images, set :latest if applicable<br/>repackage chart, diff vs RC, push + attest<br/>publish final GitHub release]
+    Promote --> PubCompFinal[publish_components_final<br/>ocm.software/cli, /controller, /ocm<br/>conflict: replace]
     Promote --> WebsiteDocs[create_website_update_pr<br/>open docs PR to main<br/>pin Hugo module imports to website/v0.X.Y]
-    WebsiteDocs --> End([Final release live])
+    PubCompFinal --> End([Final release live])
+    WebsiteDocs --> End
 
     classDef rc fill:#e0f2fe,stroke:#0284c7,color:#0c4a6e
     classDef final fill:#dcfce7,stroke:#16a34a,color:#14532d
     classDef gate fill:#fef3c7,stroke:#d97706,color:#78350f
 
-    class Prepare,TagRC,Pipeline,ReleaseRC,BuildCLI,BuildCtl,Conf,PubCLI,PubCtl rc
-    class Verify,Promote,WebsiteDocs final
+    class Prepare,TagRC,Pipeline,ReleaseRC,PubCompRC,BuildCLI,BuildCtl,Conf,PubCLI,PubCtl rc
+    class Verify,Promote,PubCompFinal,WebsiteDocs final
     class Gate gate
 ```
 
@@ -107,6 +110,29 @@ The website integrates into the same workflow run, after `promote_and_release_fi
 * When more than 10 minors would be live, the oldest is retired (entry removed from `hugo.yaml`, imports removed from `module.yaml`). Retirement logic lives in `website/scripts/register-docs-version.js`.
 
 There is no `website/v0.X.Y-rc.N` tag. The website has no RC artifacts to validate (it's a docs site, not a binary or image), so the RC variant would have no consumer.
+
+## OCM components produced
+
+Every release publishes three OCM component-versions to `ghcr.io/<owner>/component-descriptors/`, all carrying the same version as the GitHub release. Both RC and final publications use the `replace` conflict policy so that reruns after a transient failure are idempotent. The release workflow's `concurrency` group prevents parallel runs for the same version.
+
+| Component | Reference |
+|---|---|
+| `ocm.software/cli` | multi-arch binaries (linux/darwin/windows × amd64/arm64) + the CLI OCI image referenced by digest |
+| `ocm.software/controller` | controller OCI image + Helm chart, both referenced by digest |
+| `ocm.software/ocm` | product wrapper referencing the two components above via `componentReferences` |
+
+Consume:
+
+```bash
+# The whole product (CLI + controller) for a given release
+ocm get component-version ghcr.io/open-component-model//ocm.software/ocm:0.7.0
+
+# Pull a CLI binary for your platform
+ocm download resource ghcr.io/open-component-model//ocm.software/cli:0.7.0 \
+  --identity name=cli,os=linux,architecture=amd64
+```
+
+The `ocm.software/ocm` product version is the recommended entry point — it pins the exact CLI and controller versions that were released together.
 
 ## Release responsible
 

--- a/docs/adr/0010_release_strategy.md
+++ b/docs/adr/0010_release_strategy.md
@@ -31,7 +31,6 @@ The team already operates GitHub‑based release workflows for OCM v1. We consid
 
 ### Out of scope (for this ADR)
 
-* **Root ocm component** Not implemented in this ADR; later, it will share **X.Y** and **patch in tandem** when any sub‑component patches are created.
 * **Emergency patches:** Any special treatment/definition of emergency patches; we define the process only for "normal" patches.
 * **Support policy details beyond y‑2:** We set **y‑2** support (≈3 months) now; exact branch retirement/EOL steps will be defined later.
 * **Testing strategy expansion:** Beyond current component‑specific tests; additional integration/system/conformance testing is excluded from this ADR.
@@ -178,6 +177,27 @@ git tag -v <tag>
 * Tags are immutable. Never delete or overwrite a published annotated tag.
 * If a final release has a defect, ship a corrective patch (vX.Y.Z+1) and mark the previous final as superseded in the notes.
 * RC defects found after promotion follow the same corrective-patch route.
+
+### OCM components produced
+
+Every release publishes three OCM component-versions to `ghcr.io/<owner>/component-descriptors/`, alongside the raw artifacts the GitHub release ships. This is the implementation of the originally out-of-scope "Root ocm component" item from this ADR.
+
+* **`ocm.software/cli`** — six executable resources (linux/darwin/windows × amd64/arm64) embedded as local blobs plus the multi-arch CLI OCI image referenced by digest.
+* **`ocm.software/controller`** — controller image and Helm chart, both referenced by digest.
+* **`ocm.software/ocm`** — product wrapper; pure `componentReferences` to the two above. This is the canonical "what was released" handle.
+
+All three carry the same bare semver as the GitHub release (`0.X.Y` final, `0.X.Y-rc.N` RC; no leading `v` — matches the OCI tags that `pipeline.yml` pushes for the underlying image and chart). They are published on **both** RC and final phases of the release workflow so that consumers can validate the component shape against an RC before a final lands.
+
+**Conflict policy:** Both RC and final publications use `--component-version-conflict-policy replace`. This keeps reruns after a transient failure idempotent (mid-run flakes leave part of the three component-versions written; the rerun completes the rest without operator intervention). The release workflow's `concurrency` group and `create-tag.js`'s tag-existence checks prevent concurrent or diverging runs for the same version, so `replace` cannot silently overwrite a different commit's artifact.
+
+**Resource form:**
+
+* OCI artefacts (CLI image, controller image, Helm chart) are referenced **by digest** via `access.ociArtifact`. The image and chart are pushed earlier in the same release run; the component-version pins their digests, not their tags. Storage is not duplicated.
+* CLI binaries are embedded **by value** via `input.type: file`. There is no per-platform OCI store for the six binaries, so digest-pinning is not available. This duplicates ~180 MB per release between the GitHub release assets and the component-version local blobs — an acceptable cost for offline transportability of the component-version.
+
+**Constructor evolution:** within a single MAJOR, resources may be **added** to a component-version without breaking consumers (additive change). Removing a resource, renaming a `name`, or changing `extraIdentity` is a breaking change and requires a MAJOR bump. This invariant ties constructor evolution to the existing semver contract.
+
+See [RELEASE_PROCESS.md § OCM components produced](../../RELEASE_PROCESS.md#ocm-components-produced) for consumer-facing pull commands.
 
 ### Roles and Responsibilities
 


### PR DESCRIPTION
Publishes three OCM component-versions to `ghcr.io` on every release (RC and final):

- `ocm.software/cli` — 6 binaries (local blobs) + multi-arch CLI image by digest
- `ocm.software/controller` — controller image + Helm chart, both by digest
- `ocm.software/ocm` — product wrapper referencing the two via `componentReferences`

All three carry the same semver as the GitHub release. Both RC and final use `--component-version-conflict-policy replace` for idempotent reruns.

New reusable workflow `.github/workflows/publish-components.yml` called twice from `release.yml` (RC + final). All three constructors generated inline via shell heredoc. `promote_and_release_final` gets a new output `final_chart_digest` as the chart is repackaged at promotion, so the digest differs from RC.

Updated `RELEASE_PROCESS.md` with a new "OCM components produced" section. ADR 0010 was updated, too.

I validated this end-to-end on my `morri-son/open-component-model` fork (I needed to tweak the workflow a bit and replace OCMBot and GPG signing requirements to be able to go without the secrets we use on main)
