### PR TITLE
chore(releases-011): Cherry-pick #3070

### DIFF
--- a/cli/cmd/configuration/ocm_config.go
+++ b/cli/cmd/configuration/ocm_config.go
@@ -18,6 +18,7 @@ import (
 const (
 	OCMConfigDirectoryName   = ".ocm"
 	OCMConfigFileName        = OCMConfigDirectoryName + "/config"
+	XDGOCMConfigFileName     = "ocm/config"
 	NestedOCMConfigFileName  = ".ocmconfig"
 	OCMConfigEnvironmentKey  = "OCM_CONFIG"
 	OCMConfigCommandArgument = "config"
@@ -43,10 +44,10 @@ By default (without specifying custom locations with this flag), the file will b
 - $HOME/.ocm/config
 - $HOME/.ocmconfig
 3. The current working directory:
-- $PWD/ocm/config
+- $PWD/.ocm/config
 - $PWD/.ocmconfig
 4. The directory of the current executable:
-- $EXE_DIR/ocm/config
+- $EXE_DIR/.ocm/config
 - $EXE_DIR/.ocmconfig
 If multiple configuration files are found, they will be merged in the order they are discovered.
 Using the option, the specified configuration file(s) will be used instead of the lookup above.`)
@@ -141,7 +142,7 @@ func GetConfigFromPath(path string) (_ *genericv1.Config, err error) {
 }
 
 // GetOCMConfigPaths searches for the OCM configuration file in the following locations (in order):
-// 1. The path specified in the OCM_CONFIG_PATH environment variable
+// 1. The path specified in the OCM_CONFIG environment variable
 // 2. The XDG_CONFIG_HOME directory (if set), or the default XDG home ($HOME/.config), or the user's home directory
 //   - $XDG_CONFIG_HOME/ocm/config
 //   - $XDG_CONFIG_HOME/.ocmconfig
@@ -151,11 +152,11 @@ func GetConfigFromPath(path string) (_ *genericv1.Config, err error) {
 //   - $HOME/.ocmconfig
 //
 // 3. The current working directory:
-//   - $PWD/ocm/config
+//   - $PWD/.ocm/config
 //   - $PWD/.ocmconfig
 //
 // 4. The directory of the current executable:
-//   - $EXE_DIR/ocm/config
+//   - $EXE_DIR/.ocm/config
 //   - $EXE_DIR/.ocmconfig
 //
 // Returns:
@@ -202,14 +203,13 @@ func getFromEnvironment(options OCMConfigOptions) string {
 func getFromXDGOrHomeDir(o OCMConfigOptions) []string {
 	paths := []string{}
 	if xdg := o.Getenv("XDG_CONFIG_HOME"); xdg != "" {
-		if subPaths := checkConfigPaths(o, xdg); len(subPaths) > 0 {
+		if subPaths := checkXDGConfigPaths(o, xdg); len(subPaths) > 0 {
 			paths = append(paths, subPaths...)
 		}
 	}
 
-	// Check default XDG home ($HOME/.config)
 	if home, err := o.UserHomeDir(); err == nil {
-		if subPaths := checkConfigPaths(o, filepath.Join(home, ".config")); len(subPaths) > 0 {
+		if subPaths := checkXDGConfigPaths(o, filepath.Join(home, ".config")); len(subPaths) > 0 {
 			paths = append(paths, subPaths...)
 		}
 		if subPaths := checkConfigPaths(o, home); len(subPaths) > 0 {
@@ -243,16 +243,24 @@ func getFromExecutableDir(o OCMConfigOptions) []string {
 	return []string{}
 }
 
-// checkConfigPaths searches for both config file variations in a given base directory.
-//
-// Parameters:
-//   - base (string): The directory to search in.
-//
-// Returns:
-//   - []string: A slice of valid config file paths found; otherwise, an empty slice.
+// checkConfigPaths searches for config file variations in a given base directory
+// using dotfile names (.ocm/config, .ocmconfig). This is used for directories where
+// hidden files are the convention (e.g. $HOME, $PWD, $EXE_DIR).
 func checkConfigPaths(o OCMConfigOptions, base string) []string {
+	return checkPaths(o, base, []string{OCMConfigFileName, NestedOCMConfigFileName})
+}
+
+// checkXDGConfigPaths searches for config file variations in a given XDG config
+// directory using non-dot names (ocm/config, .ocmconfig). This is used for directories
+// that are already config directories (e.g. $XDG_CONFIG_HOME, $HOME/.config) following the
+// convention of not prefixing with another '.'
+func checkXDGConfigPaths(o OCMConfigOptions, base string) []string {
+	return checkPaths(o, base, []string{XDGOCMConfigFileName, NestedOCMConfigFileName})
+}
+
+func checkPaths(o OCMConfigOptions, base string, names []string) []string {
 	paths := []string{}
-	for _, name := range []string{OCMConfigFileName, NestedOCMConfigFileName} {
+	for _, name := range names {
 		path := filepath.Clean(filepath.Join(base, name))
 		if _, err := o.Stat(path); err == nil {
 			paths = append(paths, path)

--- a/cli/cmd/configuration/ocm_config_test.go
+++ b/cli/cmd/configuration/ocm_config_test.go
@@ -42,9 +42,9 @@ func TestGetOCMConfigPaths(t *testing.T) {
 			want: func(workingDirectory, executableDirectory string) []string {
 				return []string{
 					"/ocm-config",
-					"/xdg/.ocm/config",
+					"/xdg/ocm/config",
 					"/xdg/.ocmconfig",
-					"/home/user/.config/.ocm/config",
+					"/home/user/.config/ocm/config",
 					"/home/user/.config/.ocmconfig",
 					"/home/user/.ocm/config",
 					"/home/user/.ocmconfig",

--- a/cli/docs/reference/ocm.md
+++ b/cli/docs/reference/ocm.md
@@ -35,10 +35,10 @@ ocm [sub-command] [flags]
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_add.md
+++ b/cli/docs/reference/ocm_add.md
@@ -35,10 +35,10 @@ ocm add {component-version|component-versions|cv|cvs} [flags]
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_add_component-version.md
+++ b/cli/docs/reference/ocm_add_component-version.md
@@ -145,10 +145,10 @@ add component-version --repository ./archive --constructor component-constructor
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_completion.md
+++ b/cli/docs/reference/ocm_completion.md
@@ -37,10 +37,10 @@ See each sub-command's help for details on how to use the generated script.
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_completion_bash.md
+++ b/cli/docs/reference/ocm_completion_bash.md
@@ -60,10 +60,10 @@ ocm completion bash
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_completion_fish.md
+++ b/cli/docs/reference/ocm_completion_fish.md
@@ -51,10 +51,10 @@ ocm completion fish [flags]
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_completion_powershell.md
+++ b/cli/docs/reference/ocm_completion_powershell.md
@@ -48,10 +48,10 @@ ocm completion powershell [flags]
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_completion_zsh.md
+++ b/cli/docs/reference/ocm_completion_zsh.md
@@ -62,10 +62,10 @@ ocm completion zsh [flags]
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_describe.md
+++ b/cli/docs/reference/ocm_describe.md
@@ -35,10 +35,10 @@ ocm describe [flags]
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_describe_types.md
+++ b/cli/docs/reference/ocm_describe_types.md
@@ -128,10 +128,10 @@ ocm describe types [subsystem [type [field-path]]] [flags]
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_download.md
+++ b/cli/docs/reference/ocm_download.md
@@ -35,10 +35,10 @@ ocm download {resource|resources|plugin|plugins} [flags]
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_download_plugin.md
+++ b/cli/docs/reference/ocm_download_plugin.md
@@ -61,10 +61,10 @@ ocm download plugin [flags]
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_download_resource.md
+++ b/cli/docs/reference/ocm_download_resource.md
@@ -65,10 +65,10 @@ ocm download resource [flags]
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_generate.md
+++ b/cli/docs/reference/ocm_generate.md
@@ -40,10 +40,10 @@ to quickly create a Cobra application.
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_generate_docs.md
+++ b/cli/docs/reference/ocm_generate_docs.md
@@ -42,10 +42,10 @@ ocm generate docs [-d <directory>] [--mode <format>] [flags]
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_get.md
+++ b/cli/docs/reference/ocm_get.md
@@ -35,10 +35,10 @@ ocm get {component-version|component-versions|cv|cvs|config|cfg} [flags]
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_get_component-version.md
+++ b/cli/docs/reference/ocm_get_component-version.md
@@ -80,10 +80,10 @@ get cvs oci::http://localhost:8080//ocm.software/ocmcli
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_get_config.md
+++ b/cli/docs/reference/ocm_get_config.md
@@ -55,10 +55,10 @@ ocm get config [flags]
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_get_types.md
+++ b/cli/docs/reference/ocm_get_types.md
@@ -128,10 +128,10 @@ ocm get types [subsystem [type [field-path]]] [flags]
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_plugin.md
+++ b/cli/docs/reference/ocm_plugin.md
@@ -35,10 +35,10 @@ ocm plugin [flags]
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_plugin_registry.md
+++ b/cli/docs/reference/ocm_plugin_registry.md
@@ -35,10 +35,10 @@ ocm plugin registry {get|list} [flags]
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_plugin_registry_get.md
+++ b/cli/docs/reference/ocm_plugin_registry_get.md
@@ -47,10 +47,10 @@ ocm plugin registry get <plugin-name[:version]> [flags]
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_plugin_registry_list.md
+++ b/cli/docs/reference/ocm_plugin_registry_list.md
@@ -46,10 +46,10 @@ ocm plugin registry list [flags]
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_sign.md
+++ b/cli/docs/reference/ocm_sign.md
@@ -35,10 +35,10 @@ ocm sign {component-version|component-versions|cv|cvs} [flags]
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_sign_component-version.md
+++ b/cli/docs/reference/ocm_sign_component-version.md
@@ -200,10 +200,10 @@ sign component-version ghcr.io/open-component-model/ocm//ocm.software/ocmcli:0.2
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_transfer.md
+++ b/cli/docs/reference/ocm_transfer.md
@@ -35,10 +35,10 @@ ocm transfer {component-version|component-versions|cv|cvs} [flags]
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_transfer_component-version.md
+++ b/cli/docs/reference/ocm_transfer_component-version.md
@@ -121,10 +121,10 @@ transfer component-version --transfer-spec spec.yaml
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_verify.md
+++ b/cli/docs/reference/ocm_verify.md
@@ -35,10 +35,10 @@ ocm verify {component-version|component-versions|cv|cvs} [flags]
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_verify_component-version.md
+++ b/cli/docs/reference/ocm_verify_component-version.md
@@ -170,10 +170,10 @@ verify component-version ghcr.io/open-component-model/ocm//ocm.software/ocmcli:0
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.

--- a/cli/docs/reference/ocm_version.md
+++ b/cli/docs/reference/ocm_version.md
@@ -62,10 +62,10 @@ ocm version --format legacyjson
                                            - $HOME/.ocm/config
                                            - $HOME/.ocmconfig
                                            3. The current working directory:
-                                           - $PWD/ocm/config
+                                           - $PWD/.ocm/config
                                            - $PWD/.ocmconfig
                                            4. The directory of the current executable:
-                                           - $EXE_DIR/ocm/config
+                                           - $EXE_DIR/.ocm/config
                                            - $EXE_DIR/.ocmconfig
                                            If multiple configuration files are found, they will be merged in the order they are discovered.
                                            Using the option, the specified configuration file(s) will be used instead of the lookup above.


### PR DESCRIPTION
Cherry-pick #3070 which introduces a fix for checking the correct paths where to find ocm configs (fixed #3061)