### PR TITLE
chore(deps): ignore updates for github.com/go-ini/ini

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -178,6 +178,26 @@
       ]
     },
     {
+      // github.com/go-ini/ini renamed its module path to gopkg.in/ini.v1 at
+      // v1.67.1 (the same commit is tagged on both paths). We still carry a
+      // legacy `require github.com/go-ini/ini v1.67.0`, pulled in transitively
+      // by yq/v4 and ocm.software/ocm (OCM v1). Any bump on the OLD path is
+      // structurally impossible: v1.67.1+ declare `module gopkg.in/ini.v1`, so
+      // `go get github.com/go-ini/ini@v1.67.3` fails with "module declares its
+      // path as gopkg.in/ini.v1 but was required as github.com/go-ini/ini".
+      // That failure breaks the go.sum artifact step for the whole PR (#3098).
+      // Freeze it here; the canonical gopkg.in/ini.v1 path keeps updating.
+      // Do NOT remove without confirming both transitive importers have dropped
+      // the legacy path.
+      matchManagers: [
+        'gomod',
+      ],
+      matchDepNames: [
+        'github.com/go-ini/ini',
+      ],
+      enabled: false,
+    },
+    {
       matchManagers: [
         'gomod',
       ],


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

`github.com/go-ini/ini` renamed its module path to `gopkg.in/ini.v1` at `v1.67.1` (the same commit is tagged on both paths). We still carry a legacy `require github.com/go-ini/ini v1.67.0`, pulled in transitively by `yq/v4` and `ocm.software/ocm` (OCM v1). Any bump on the OLD path is structurally impossible: `v1.67.1+` declare `module gopkg.in/ini.v1`, so `go get github.com/go-ini/ini@v1.67.3` fails with "module declares its path as gopkg.in/ini.v1 but was required as github.com/go-ini/ini". That failure breaks the go.sum artifact step for the whole PR (#3098).

#### Which issue(s) this PR fixes

Related to #3098 

#### Testing

I [ran renovate locally with that config](https://github.com/frewilhelm/open-component-model/pull/600/changes) and it did not update the module.

No other module imports `github.com/go-ini/ini`:

```
$> grep -iIr 'github.com/go-ini/ini'
./website/hack/generate-cli-docs/go.mod:	github.com/go-ini/ini v1.67.0 // indirect
./website/hack/generate-cli-docs/go.sum:github.com/go-ini/ini v1.67.0 h1:z6ZrTEZqSWOTyH2FlglNbNgARyHG8oLW9gMELqKr06A=
./website/hack/generate-cli-docs/go.sum:github.com/go-ini/ini v1.67.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
```
