### PR TITLE
test: fix flakyness in idle timeout test

### DIFF
--- a/bindings/go/plugin/client/sdk/plugin_test.go
+++ b/bindings/go/plugin/client/sdk/plugin_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -166,9 +167,10 @@ func TestIdleChecker(t *testing.T) {
 			return false
 		}
 
-		r.ErrorContains(err, "dial unix /tmp/test-plugin-idle-plugin.socket: connect: no such file or directory")
+		// The socket may return EOF while it's still shutting down before
+		// being removed. Only consider the test done once the socket is gone.
+		return strings.Contains(err.Error(), "no such file or directory")
 
-		return true
 	}, 5*time.Second, 20*time.Millisecond)
 }
 


### PR DESCRIPTION
#### What this PR does / why we need it
`TestIdleChecker` uses `r.ErrorContains(...)` inside an `r.Eventually` callback. When the plugin's idle timeout fires, there's a brief window where the socket is still present but the server has stopped accepting - the HTTP client gets `EOF` instead of `"no such file or directory"`. Because `r.ErrorContains` is a hard assertion, this immediately fails the test instead of letting `Eventually` retry.

#### Which issue(s) this PR fixes
Replace the hard assertion with `strings.Contains(err.Error(), "no such file or directory")` as the return condition. Transient errors like `EOF` or `connection refused` simply return `false`, and `Eventually` retries until the socket is actually removed.

#### Testing
Since it only happens occasionally as lot of parallel runs are required to reproduce the issue:
```bash
$ go test ./bindings/go/plugin/client/sdk/ -run TestIdleChecker -count=200 -parallel 8 -cpu 1,2,4
...
--- FAIL: TestIdleChecker (5.01s)
    plugin_test.go:169: 
        	Error Trace:	/Users/i538808/SAPDevelop/github.com/flaky_timeout/bindings/go/plugin/client/sdk/plugin_test.go:169
        	            				/Users/i538808/.asdf/installs/golang/1.26.3/packages/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.4.darwin-arm64/src/runtime/asm_arm64.s:1447
        	Error:      	Error "Get \"http://unix/healthz\": EOF" does not contain "dial unix /tmp/test-plugin-idle-plugin.socket: connect: no such file or directory"
        	Test:       	TestIdleChecker
    plugin_test.go:163: 
        	Error Trace:	/Users/i538808/SAPDevelop/github.com/flaky_timeout/bindings/go/plugin/client/sdk/plugin_test.go:163
        	Error:      	Condition never satisfied
        	Test:       	TestIdleChecker
...
2026/07/14 15:14:02 INFO idle check timer expired for plugin id=test-plugin-idle
FAIL
FAIL	ocm.software/open-component-model/bindings/go/plugin/client/sdk	26.365s
FAIL
```

After:
```bash
$ go test ./bindings/go/plugin/client/sdk/ -run TestIdleChecker -count=200 -parallel 8 -cpu 1,2,4
ok  	ocm.software/open-component-model/bindings/go/plugin/client/sdk	16.386s
```

##### Verification

- [x] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
