### PR TITLE
chore(docs): update community call list

### DIFF
--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -30,6 +30,9 @@ For information about joining community calls, see the [OCM Community](https://o
 | 2026-02-04 | <https://zoom.us/rec/share/kgp3G9nWpidW8CGhIFGYqbkuxbCUT5NonY6mqMNvJrHA5b9Q5mfkSUwRuO0Y3o_O.mUL01yhE0MtA8Vqs> |
 | 2026-03-04 | <https://zoom.us/rec/share/aoFnLPOBYxRYZ7XQo7brYj3KkzBAYlO0Ql3Anf5bd1FCz9Sa7Y0L1N77w7aDeNf7.AhYZcg344tkUiScJ> |
 | 2026-04-01 | <https://zoom.us/rec/share/DwfXW8Y69fQ8j7-nHRPCvupqpvDjEnajPIdEmAVRVCdePdLdD2ehIqmdwxvGoFo9.9eOjzaZy1OPXZl23> |
+| 2026-05-06 | <https://zoom.us/rec/share/rBsT6862v1t_Imy4H6fIJd5fbguYkaAUN8SOAXWTGOpdauYR4ZVpS_Z7oLlKHIPG.2HeltyTeIC0cB30o> |
+| 2026-06-03 | <https://zoom.us/rec/share/Qqr0UcINuWsPQ1lv0XqeB7WceJZtIZRC5fCcGtJAU9F2ERBvjCOrDPgmH2ZHlSh1.y1JX4UPjitYhM_oQ> |
+| 2026-07-01 | <https://zoom.us/rec/share/yk-Q0HGYSWFiQIB5Lxh8aVWe6ewmPbMgTaKvMb1zqaC8zRMuSImtxn1YzTuFh4u5.Q8T0G5tC5ymJPB7l> |
 
 ### 2025
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

We forgot adding the links to the video + transcript to our community call listing. 

Since our [calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/open-component-model?view=month) is public by now, we might consider omitting this list that needs to be updated manually. The public calendar contains the meetings as well as the link to the recording in the respective meetings details. However, having a list might be more convenient and easier to find for externals. WDYT?

