### PR TITLE
chore(deps): group digest bump prs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -59,6 +59,24 @@
       automerge: true,
     },
     {
+      // Collapse digest-only re-pins (same tag, new SHA) for Actions and
+      // Docker base images into one weekly PR. gomod is excluded so Go
+      // module digests keep their own per-module PRs (no cross-module PR,
+      // go.sum post-upgrade step intact). Placed before the golang digest
+      // rules so their 'Golang versions' groupName wins (last write wins).
+      matchManagers: [
+        'github-actions',
+        'dockerfile',
+        'docker-compose',
+      ],
+      matchUpdateTypes: ['digest', 'pinDigest'],
+      groupName: 'Digest pins',
+      groupSlug: 'digest-pins',
+      schedule: [
+        '* * * * 0' // At every minute on Sunday it is allowed to create branches
+      ],
+    },
+    {
       matchDatasources: ["golang-version"],
       rangeStrategy: "bump",
       groupName: "Golang versions",


### PR DESCRIPTION
Groups digest-only re-pins (same tag, new SHA) for GitHub Actions and Docker base images into one weekly `Digest pins` PR instead of one each - they were ~18% of Renovate PRs. Pinning is unchanged; only the batching is.

`gomod` is excluded on purpose: sweeping it in would span multiple `go.mod` files (cross-module PR) and break the `go.sum` post-upgrade step. Go digests keep their own PRs.

See https://github.com/frewilhelm/open-component-model/pull/808 as an example (contains a lot of bumps because I outdated my `main` branch on purpose).