### PR TITLE
feat(oci): cosign-signable components via normalized descriptor layout

### DIFF
--- a/bindings/go/oci/go.mod
+++ b/bindings/go/oci/go.mod
@@ -15,6 +15,7 @@ require (
 	ocm.software/open-component-model/bindings/go/configuration v0.0.16
 	ocm.software/open-component-model/bindings/go/credentials v0.0.14
 	ocm.software/open-component-model/bindings/go/ctf v0.4.1
+	ocm.software/open-component-model/bindings/go/descriptor/normalisation v0.0.0-20260722011220-30901d85becb
 	ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20260717060357-df059e15a4cb
 	ocm.software/open-component-model/bindings/go/descriptor/v2 v2.0.3-alpha3
 	ocm.software/open-component-model/bindings/go/http v0.0.0-20260717062635-65d9c9c7d7b9

--- a/bindings/go/oci/go.sum
+++ b/bindings/go/oci/go.sum
@@ -57,6 +57,8 @@ ocm.software/open-component-model/bindings/go/ctf v0.4.1 h1:rzSzKGuUkO6ykPLd49Z4
 ocm.software/open-component-model/bindings/go/ctf v0.4.1/go.mod h1:5EoiS3GHkAWBCSyx2i06Prg0sBays8v3tc8Qzq8DguM=
 ocm.software/open-component-model/bindings/go/dag v0.0.6 h1:To76QJAmFD88C101oB/HgYvtomp8mm0270ewDLcVncw=
 ocm.software/open-component-model/bindings/go/dag v0.0.6/go.mod h1:mQbO95zYvX59VXNJGer4+wGsKY0BVI4FKwlR5BlPugM=
+ocm.software/open-component-model/bindings/go/descriptor/normalisation v0.0.0-20260722011220-30901d85becb h1:8gZFbWFmqQVjJSGJljxeeW4BQ0FPaZSPBRfccESyvAk=
+ocm.software/open-component-model/bindings/go/descriptor/normalisation v0.0.0-20260722011220-30901d85becb/go.mod h1:MNd2BPvLrMI0dNsrcpSYgmgavEVRP/HKXefhYrP2kzM=
 ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20260717060357-df059e15a4cb h1:3REIxy7p/tF3GC8aIZvUUB8zOfmKQtYHAwsi/jTH0O0=
 ocm.software/open-component-model/bindings/go/descriptor/runtime v0.0.0-20260717060357-df059e15a4cb/go.mod h1:EzsJGXfl7q6O7FZlbF5rySawZ6oG0K8qexQXkZOehUU=
 ocm.software/open-component-model/bindings/go/descriptor/v2 v2.0.3-alpha3 h1:bTb7LgRFAAuhr5FGkkBVStU4YLtFZz3uhO9V4VFhW64=

--- a/bindings/go/oci/normalized_layout_e2e_test.go
+++ b/bindings/go/oci/normalized_layout_e2e_test.go
@@ -1,0 +1,229 @@
+package oci_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content/memory"
+
+	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+	"ocm.software/open-component-model/bindings/go/oci"
+	ocidescriptor "ocm.software/open-component-model/bindings/go/oci/spec/descriptor"
+	normalizedlayout "ocm.software/open-component-model/bindings/go/oci/spec/layout/normalized/v1"
+	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+// e2eDescriptor returns a minimal, valid component descriptor for e2e tests.
+func e2eDescriptor() *descriptor.Descriptor {
+	d := &descriptor.Descriptor{}
+	d.Component.Name = "example.org/comp"
+	d.Component.Version = "1.0.0"
+	d.Component.Provider = descriptor.Provider{Name: "internal"}
+	return d
+}
+
+// TestNormalized_StableDigestAcrossStores proves the copy-stability property:
+// writing the same descriptor into two independent memory stores produces
+// identical normalized manifest digests — the signable digest is invariant
+// across registry locations.
+func TestNormalized_StableDigestAcrossStores(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme(runtime.WithAllowUnknown())
+	opts := oci.AddDescriptorOptions{Scheme: scheme, Layout: oci.LayoutNormalized}
+
+	storeA := memory.New()
+	storeB := memory.New()
+
+	desc := e2eDescriptor()
+
+	mDescA, err := oci.AddDescriptorToStore(ctx, storeA, desc, opts)
+	require.NoError(t, err, "write to store A must succeed")
+	require.NotNil(t, mDescA)
+
+	mDescB, err := oci.AddDescriptorToStore(ctx, storeB, desc, opts)
+	require.NoError(t, err, "write to store B must succeed")
+	require.NotNil(t, mDescB)
+
+	require.Equal(t, mDescA.Digest, mDescB.Digest,
+		"normalized manifest digest must be identical across independent stores (copy-stability)")
+	require.Equal(t, mDescA.ArtifactType, ocidescriptor.ArtifactTypeNormalizedDescriptor,
+		"returned descriptor must have normalized artifact type")
+	require.True(t, oci.IsNormalizedManifest(*mDescA))
+}
+
+// TestNormalized_DigestIsAnchorCosignSigns proves that the digest returned by
+// AddDescriptorToStore(...LayoutNormalized) is exactly the digest of the manifest
+// that BuildNormalizedManifest constructs from the normalized bytes — i.e. the
+// thing cosign will sign.
+func TestNormalized_DigestIsAnchorCosignSigns(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme(runtime.WithAllowUnknown())
+
+	desc := e2eDescriptor()
+
+	store := memory.New()
+	mDesc, err := oci.AddDescriptorToStore(ctx, store, desc, oci.AddDescriptorOptions{
+		Scheme: scheme,
+		Layout: oci.LayoutNormalized,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, mDesc)
+
+	// Independently compute what the manifest digest should be.
+	normBytes, err := normalizedlayout.Normalize(desc)
+	require.NoError(t, err)
+
+	normLayer := ociImageSpecV1.Descriptor{
+		MediaType: ocidescriptor.MediaTypeComponentDescriptorNormalizedJSON,
+		Digest:    digest.FromBytes(normBytes),
+		Size:      int64(len(normBytes)),
+	}
+	m := normalizedlayout.BuildNormalizedManifest(normLayer, "example.org/comp", "1.0.0")
+	mRaw, err := json.Marshal(m)
+	require.NoError(t, err)
+
+	expectedDigest := digest.FromBytes(mRaw)
+
+	require.Equal(t, expectedDigest.String(), mDesc.Digest.String(),
+		"the tag target digest must equal the digest of the manifest built from normalized bytes")
+}
+
+// TestNormalized_CopyBetweenStoresPreservesDigestAndReadback verifies that
+// after an oras.ExtendedCopyGraph from store A to store B:
+//   - the normalized manifest digest in B is identical to the one in A, and
+//   - GetNormalizedComponentVersion reads back the correct component/version.
+//
+// ExtendedCopyGraph follows predecessors (the access referrer is a predecessor
+// of the normalized manifest), which exactly mirrors a registry-to-registry
+// copy of a signed artifact and its attachments.
+func TestNormalized_CopyBetweenStoresPreservesDigestAndReadback(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme(runtime.WithAllowUnknown())
+
+	desc := e2eDescriptor()
+
+	// Write into store A.
+	storeA := memory.New()
+	mDescA, err := oci.AddDescriptorToStore(ctx, storeA, desc, oci.AddDescriptorOptions{
+		Scheme: scheme,
+		Layout: oci.LayoutNormalized,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, mDescA)
+
+	normalizedDigest := mDescA.Digest
+
+	// Copy the normalized manifest subtree (manifest + config + layer) AND its
+	// access referrer from A into fresh store B using ExtendedCopyGraph.
+	// ExtendedCopyGraph copies the node and all predecessors (referrers) of it,
+	// which is exactly registry-to-registry transport of a signed artifact with
+	// its attached signatures/referrers.
+	storeB := memory.New()
+	err = oras.ExtendedCopyGraph(ctx, storeA, storeB, *mDescA, oras.ExtendedCopyGraphOptions{})
+	require.NoError(t, err, "ExtendedCopyGraph A→B must succeed")
+
+	// Verify that the normalized manifest is present in B with the same digest.
+	mDescInB := *mDescA // same descriptor — blobs are content-addressed
+	exists, err := storeB.Exists(ctx, mDescInB)
+	require.NoError(t, err)
+	require.True(t, exists, "normalized manifest must exist in store B after copy")
+
+	require.Equal(t, normalizedDigest, mDescInB.Digest,
+		"the normalized manifest digest must be identical in both stores — no location info bleeds in")
+
+	// Also re-tag the access fallback tag in B so GetNormalizedComponentVersion
+	// can discover the access manifest via the fallback path (Predecessors already
+	// works because ExtendedCopyGraph tracks the predecessor graph).
+	//
+	// In practice the fallback tag travels separately (it is a registry tag, not
+	// a content blob) so we re-create it: resolve it from A and tag it in B.
+	fallbackTag := normalizedlayout.AccessFallbackTag(normalizedDigest.String())
+	accessDescA, err := storeA.Resolve(ctx, fallbackTag)
+	require.NoError(t, err, "fallback tag must be resolvable in store A")
+	err = storeB.Tag(ctx, accessDescA, fallbackTag)
+	require.NoError(t, err, "tagging access manifest in store B with fallback tag must succeed")
+
+	// Read back the component version from B.
+	got, err := oci.GetNormalizedComponentVersion(ctx, storeB, mDescInB, ocidescriptor.DefaultDescriptorUnmarshalFunc)
+	require.NoError(t, err, "GetNormalizedComponentVersion must succeed after copy")
+	require.Equal(t, "example.org/comp", got.Component.Name, "component name must survive copy")
+	require.Equal(t, "1.0.0", got.Component.Version, "component version must survive copy")
+	require.Equal(t, normalizedDigest, mDescInB.Digest, "the normalized manifest digest must still equal the one from store A")
+}
+
+// TestNormalized_RejectsUndigestedResource verifies that AddDescriptorToStore
+// with LayoutNormalized returns an error containing the resource name when a
+// resource has no digest (RequireAllResourcesDigested enforcement).
+func TestNormalized_RejectsUndigestedResource(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme(runtime.WithAllowUnknown())
+
+	d := e2eDescriptor()
+	r := descriptor.Resource{Type: "ociImage"}
+	r.Name = "img"
+	r.Version = "1.0.0"
+	// r.Digest stays nil — must be rejected
+	d.Component.Resources = []descriptor.Resource{r}
+
+	_, err := oci.AddDescriptorToStore(ctx, memory.New(), d, oci.AddDescriptorOptions{
+		Scheme: scheme,
+		Layout: oci.LayoutNormalized,
+	})
+	require.Error(t, err, "undigested resource must be rejected")
+	require.Contains(t, err.Error(), "img",
+		"error message must mention the offending resource name")
+}
+
+// noneAccess returns a *runtime.Raw that serializes as {"type":"none"}.
+// This is the minimal valid access for resources that have no actual content
+// location (e.g. signed-but-none-access resources). Using "none" allows the
+// v4alpha1 normalizer to handle it without error.
+func noneAccess() *runtime.Raw {
+	return &runtime.Raw{
+		Type: runtime.NewUnversionedType("none"),
+		Data: []byte(`{"type":"none"}`),
+	}
+}
+
+// TestNormalized_AcceptsDigestedResource verifies that a resource with a valid
+// SHA-256 digest is accepted by the normalized layout, and that
+// GetNormalizedComponentVersion round-trips the resource name correctly.
+//
+// The resource uses a "none" access type (the OCI-agnostic sentinel) to satisfy
+// the v2 serialization requirement that every resource must have a non-nil Access.
+func TestNormalized_AcceptsDigestedResource(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme(runtime.WithAllowUnknown())
+
+	d := e2eDescriptor()
+	r := descriptor.Resource{Type: "ociImage"}
+	r.Name = "img"
+	r.Version = "1.0.0"
+	r.Digest = &descriptor.Digest{
+		HashAlgorithm:          "SHA-256",
+		NormalisationAlgorithm: "genericBlobDigest/v1",
+		Value:                  "abc",
+	}
+	// A non-nil access is required by the v2 serialization layer even in the
+	// normalized layout. "none" is the canonical sentinel for no-location access.
+	r.Access = noneAccess()
+	d.Component.Resources = []descriptor.Resource{r}
+
+	store := memory.New()
+	mDesc, err := oci.AddDescriptorToStore(ctx, store, d, oci.AddDescriptorOptions{
+		Scheme: scheme,
+		Layout: oci.LayoutNormalized,
+	})
+	require.NoError(t, err, "resource with valid digest and none-access must be accepted")
+	require.NotNil(t, mDesc)
+
+	got, err := oci.GetNormalizedComponentVersion(ctx, store, *mDesc, ocidescriptor.DefaultDescriptorUnmarshalFunc)
+	require.NoError(t, err, "GetNormalizedComponentVersion must succeed")
+	require.Len(t, got.Component.Resources, 1, "resource must survive round-trip")
+	require.Equal(t, "img", got.Component.Resources[0].Name, "resource name must match")
+}

--- a/bindings/go/oci/repository.go
+++ b/bindings/go/oci/repository.go
@@ -49,9 +49,10 @@ import (
 )
 
 var (
-	_            ComponentVersionRepository          = (*Repository)(nil)
-	_            repository.OwnershipAwareRepository = (*Repository)(nil)
-	versionRegex                                     = regexp.MustCompile(compref.VersionRegex)
+	_            ComponentVersionRepository           = (*Repository)(nil)
+	_            repository.OwnershipAwareRepository  = (*Repository)(nil)
+	_            repository.ComponentSignatureCarrier = (*Repository)(nil)
+	versionRegex                                      = regexp.MustCompile(compref.VersionRegex)
 )
 
 // Repository implements the ComponentVersionRepository interface using OCI registries.
@@ -97,6 +98,9 @@ type Repository struct {
 	// globalAccessPolicy controls whether global access references are added to local blobs.
 	// Default (zero value) is Never, suppressing global access to discourage reliance on it.
 	globalAccessPolicy GlobalAccessPolicy
+
+	// layout selects the OCI storage layout used when adding component versions.
+	layout Layout
 }
 
 // SetGlobalAccessPolicy overrides the global access policy for this repository.
@@ -134,6 +138,7 @@ func (repo *Repository) AddComponentVersion(ctx context.Context, descriptor *des
 		AdditionalLayers:              additionalLayers,
 		ReferrerTrackingPolicy:        repo.referrerTrackingPolicy,
 		DescriptorEncodingMediaType:   repo.descriptorEncodingMediaType,
+		Layout:                        repo.layout,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to add descriptor to store: %w", err)
@@ -204,6 +209,27 @@ func (repo *Repository) GetComponentVersion(ctx context.Context, component, vers
 	reference, store, err := repo.getStore(ctx, component, version)
 	if err != nil {
 		return nil, err
+	}
+
+	resolved, err := store.Resolve(ctx, reference)
+	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return nil, errors.Join(repository.ErrNotFound, fmt.Errorf("component version %s/%s not found: %w", component, version, err))
+		}
+		return nil, err
+	}
+
+	artifactType, err := peekArtifactType(ctx, store, resolved)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine component version layout: %w", err)
+	}
+	if artifactType == descriptor2.ArtifactTypeNormalizedDescriptor {
+		resolved.ArtifactType = descriptor2.ArtifactTypeNormalizedDescriptor
+		desc, err = GetNormalizedComponentVersion(ctx, store, resolved, repo.unmarshalDescriptorFunc)
+		if errors.Is(err, errdef.ErrNotFound) {
+			return desc, errors.Join(repository.ErrNotFound, fmt.Errorf("component version %s/%s not found: %w", component, version, err))
+		}
+		return desc, err
 	}
 
 	desc, _, _, err = getDescriptorFromStore(ctx, store, reference, repo.unmarshalDescriptorFunc)
@@ -518,11 +544,44 @@ func (repo *Repository) localArtifact(ctx context.Context, component, version st
 	if err != nil {
 		return nil, nil, err
 	}
-	desc, manifest, index, err := getDescriptorFromStore(ctx, store, reference, repo.unmarshalDescriptorFunc)
+
+	// Normalized layout: the tag resolves to the access-free normalized manifest, which carries no
+	// component config or descriptor layer. Resolve the full access-bearing descriptor via the access
+	// referrer (with bind check) instead of decoding the tagged manifest. The local blob content is
+	// present in the store as content-addressable blobs, so the shared post-descriptor helper can
+	// fetch it by digest unchanged.
+	resolved, err := store.Resolve(ctx, reference)
+	if err != nil {
+		if errors.Is(err, errdef.ErrNotFound) {
+			return nil, nil, errors.Join(repository.ErrNotFound, fmt.Errorf("component version %s/%s not found: %w", component, version, err))
+		}
+		return nil, nil, err
+	}
+	if at, _ := peekArtifactType(ctx, store, resolved); at == descriptor2.ArtifactTypeNormalizedDescriptor {
+		resolved.ArtifactType = descriptor2.ArtifactTypeNormalizedDescriptor
+		desc, err := GetNormalizedComponentVersion(ctx, store, resolved, repo.unmarshalDescriptorFunc)
+		if err != nil {
+			if errors.Is(err, errdef.ErrNotFound) {
+				return nil, nil, errors.Join(repository.ErrNotFound, fmt.Errorf("component version %s/%s not found: %w", component, version, err))
+			}
+			return nil, nil, err
+		}
+		return repo.localArtifactFromDescriptor(ctx, store, desc, identity, kind)
+	}
+
+	desc, _, _, err := getDescriptorFromStore(ctx, store, reference, repo.unmarshalDescriptorFunc)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get component version: %w", err)
 	}
+	return repo.localArtifactFromDescriptor(ctx, store, desc, identity, kind)
+}
 
+// localArtifactFromDescriptor selects the resource or source in desc that matches identity and kind,
+// then resolves and fetches its local blob from store by the LocalBlob access LocalReference digest.
+// It is layout-agnostic: the descriptor is supplied by the caller (decoded from the v2 manifest for
+// the default layout, or resolved via the access referrer for the normalized layout) and the blob is
+// always resolved by digest, which is present in the store for both layouts.
+func (repo *Repository) localArtifactFromDescriptor(ctx context.Context, store spec.Store, desc *descriptor.Descriptor, identity runtime.Identity, kind annotations.ArtifactKind) (fetch.LocalBlob, descriptor.Artifact, error) {
 	var candidates []descriptor.Artifact
 	switch kind {
 	case annotations.ArtifactKindResource:
@@ -560,55 +619,58 @@ func (repo *Repository) localArtifact(ctx context.Context, component, version st
 
 	switch typed := typed.(type) {
 	case *v2.LocalBlob:
-		b, err := repo.getLocalBlobFromIndexOrManifest(
-			ctx, store, index, manifest, typed.LocalReference,
-			artifact.GetElementMeta().Version,
-		)
+		b, err := repo.getLocalBlobByReference(ctx, store, typed, artifact)
 		return b, artifact, err
 	default:
 		return nil, nil, fmt.Errorf("unsupported resource access type: %T", typed)
 	}
 }
 
-// getLocalBlobFromIndexOrManifest resolves and fetches a blob from either an
-// OCI index or a manifest.
-func (repo *Repository) getLocalBlobFromIndexOrManifest(
-	ctx context.Context,
-	store spec.Store,
-	index *ociImageSpecV1.Index,
-	manifest *ociImageSpecV1.Manifest,
-	ref, version string,
-) (LocalBlob, error) {
-	descriptors := collectDescriptors(index, manifest)
-
-	artifact, err := findDescriptorFromReference(descriptors, ref)
-	if err != nil {
-		return nil, fmt.Errorf("resolve artifact %q: %w", ref, err)
+// getLocalBlobByReference resolves the OCI descriptor for a LocalBlob access by its LocalReference
+// digest and returns the blob content. A nested OCI-compliant manifest is copied as a full OCI layout;
+// a plain layer is fetched directly. This works uniformly for the default and normalized layouts,
+// because both push the local blob as content-addressable content resolvable by digest.
+func (repo *Repository) getLocalBlobByReference(ctx context.Context, store spec.Store, access *v2.LocalBlob, artifact descriptor.Artifact) (LocalBlob, error) {
+	// Resolve the blob descriptor by its digest. A plain blob resolves to the octet-stream media type,
+	// so for non-OCI-compliant media types we resolve against the blob store when available.
+	resolve := store.Resolve
+	if !introspection.IsOCICompliantMediaType(access.MediaType) {
+		if bs, ok := store.(interface{ Blobs() registry.BlobStore }); ok {
+			resolve = bs.Blobs().Resolve
+		}
 	}
 
-	// Nested manifest: copy full OCI layout
-	if index != nil && introspection.IsOCICompliantManifest(artifact) {
+	target, err := resolve(ctx, access.LocalReference)
+	if err != nil {
+		return nil, fmt.Errorf("resolve artifact %q: %w", access.LocalReference, err)
+	}
+	if access.MediaType != "" {
+		target.MediaType = access.MediaType
+	}
+
+	// Nested manifest: copy full OCI layout.
+	if introspection.IsOCICompliantManifest(target) {
 		graph, ok := store.(content.ReadOnlyGraphStorage)
 		if !ok {
 			return nil, fmt.Errorf("store %T does not support predecessor walks", store)
 		}
-		return tar.CopyToOCILayoutInMemory(ctx, graph, artifact, tar.CopyToOCILayoutOptions{
+		return tar.CopyToOCILayoutInMemory(ctx, graph, target, tar.CopyToOCILayoutOptions{
 			ExtendedCopyGraphOptions: oras.ExtendedCopyGraphOptions{
 				CopyGraphOptions: repo.resourceCopyOptions.CopyGraphOptions,
 			},
-			Tags:    []string{version},
+			Tags:    []string{artifact.GetElementMeta().Version},
 			TempDir: repo.tempDir,
 		})
 	}
 
-	data, err := store.Fetch(ctx, artifact)
+	data, err := store.Fetch(ctx, target)
 	if err != nil {
 		return nil, fmt.Errorf("fetch layer: %w", err)
 	}
 	// data cannot be closed, as it is used by the blob
-	b := ociblob.NewDescriptorBlob(data, artifact)
-	if actual, _ := b.Digest(); actual != artifact.Digest.String() {
-		return nil, fmt.Errorf("digest mismatch: expected %q, got %q", artifact.Digest, actual)
+	b := ociblob.NewDescriptorBlob(data, target)
+	if actual, _ := b.Digest(); actual != target.Digest.String() {
+		return nil, fmt.Errorf("digest mismatch: expected %q, got %q", target.Digest, actual)
 	}
 	return b, nil
 }
@@ -619,6 +681,65 @@ func (repo *Repository) getStore(ctx context.Context, component string, version 
 		return "", nil, fmt.Errorf("failed to get store for reference: %w", err)
 	}
 	return reference, store, nil
+}
+
+// CarryComponentSignatures copies non-access referrers (cosign signatures/attestations) of the
+// component version manifest from source into this repository. It is a no-op unless both repos
+// resolve the SAME component-manifest digest — guaranteed by the normalized layout, whose manifest
+// digest is deterministic — because otherwise the referrers would point at a digest absent on the
+// target.
+func (repo *Repository) CarryComponentSignatures(ctx context.Context, source repository.ComponentVersionRepository, component, version string) error {
+	src, ok := source.(*Repository)
+	if !ok {
+		return nil // only OCI→OCI carry is supported
+	}
+	_, srcStore, err := src.getStore(ctx, component, version)
+	if err != nil {
+		return fmt.Errorf("open source store: %w", err)
+	}
+	dstRef, dstStore, err := repo.getStore(ctx, component, version)
+	if err != nil {
+		return fmt.Errorf("open target store: %w", err)
+	}
+	srcRef := src.resolver.ComponentVersionReference(ctx, component, version)
+
+	srcDesc, err := srcStore.Resolve(ctx, srcRef)
+	if err != nil {
+		return fmt.Errorf("resolve source component manifest: %w", err)
+	}
+	dstDesc, err := dstStore.Resolve(ctx, dstRef)
+	if err != nil {
+		return fmt.Errorf("resolve target component manifest: %w", err)
+	}
+	// Only carry when the manifest digest is preserved (normalized layout).
+	if srcDesc.Digest != dstDesc.Digest {
+		return nil
+	}
+
+	predecessors, err := srcStore.Predecessors(ctx, srcDesc)
+	if err != nil {
+		return nil // best-effort; no referrers API means nothing to carry
+	}
+	for _, p := range predecessors {
+		// Classify by the referrer manifest's artifactType (read from the body for reliability).
+		at, err := peekArtifactType(ctx, srcStore, p)
+		if err != nil {
+			continue
+		}
+		if at == descriptor2.ArtifactTypeAccessDescriptor {
+			continue // OCM regenerates the access manifest per registry; never copy it
+		}
+		if exists, _ := dstStore.Exists(ctx, p); exists {
+			continue
+		}
+		// Copy exactly the referrer's own subtree: the referrer manifest plus its config and layer
+		// blobs. The subject it points at (the component manifest) already exists on the target, so
+		// only the referrer graph itself needs to be copied.
+		if err := oras.CopyGraph(ctx, srcStore, dstStore, p, repo.resourceCopyOptions.CopyGraphOptions); err != nil {
+			return fmt.Errorf("failed to carry component referrer %s: %w", p.Digest, err)
+		}
+	}
+	return nil
 }
 
 // UploadResource uploads a [*descriptor.Resource] to the repository.
@@ -919,30 +1040,6 @@ func getDescriptorOCIImageManifest(ctx context.Context, store spec.Store, refere
 	}
 
 	return manifest, index, nil
-}
-
-func collectDescriptors(index *ociImageSpecV1.Index, manifest *ociImageSpecV1.Manifest) []ociImageSpecV1.Descriptor {
-	if index == nil {
-		return manifest.Layers
-	}
-	descs := make([]ociImageSpecV1.Descriptor, 0, len(index.Manifests)+len(manifest.Layers))
-	descs = append(descs, index.Manifests...)
-	descs = append(descs, manifest.Layers...)
-	return descs
-}
-
-func findDescriptorFromReference(descriptors []ociImageSpecV1.Descriptor, reference string) (ociImageSpecV1.Descriptor, error) {
-	asDigest := digest.Digest(reference)
-	if err := asDigest.Validate(); err != nil {
-		return ociImageSpecV1.Descriptor{}, fmt.Errorf("failed to validate reference %q as digest: %w", reference, err)
-	}
-
-	for _, desc := range descriptors {
-		if desc.Digest == asDigest {
-			return desc, nil
-		}
-	}
-	return ociImageSpecV1.Descriptor{}, fmt.Errorf("no matching descriptor found for reference %s", reference)
 }
 
 func (repo *Repository) AddComponentVersionAlias(ctx context.Context, component, versionOrAlias, alias string) (err error) {

--- a/bindings/go/oci/repository/provider/provider.go
+++ b/bindings/go/oci/repository/provider/provider.go
@@ -151,6 +151,10 @@ func (b *CachingComponentVersionRepositoryProvider) GetComponentVersionRepositor
 			return nil, err
 		}
 
+		if obj.ComponentVersionLayout == "normalized" {
+			opts = append(opts, oci.WithComponentVersionLayout(oci.LayoutNormalized))
+		}
+
 		var ociCredentials *v2.OCICredentials
 		if creds != nil {
 			ociCredentials, err = v2.ConvertToOCICredentials(creds)
@@ -168,6 +172,10 @@ func (b *CachingComponentVersionRepositoryProvider) GetComponentVersionRepositor
 			},
 		}, opts...)
 	case *ctfrepospecv1.Repository:
+		if obj.ComponentVersionLayout == "normalized" {
+			opts = append(opts, oci.WithComponentVersionLayout(oci.LayoutNormalized))
+		}
+
 		loadFunc := func(path string) (*ocictf.Store, error) {
 			return ocirepository.NewStoreFromCTFRepoV1(ctx, obj, opts...)
 		}

--- a/bindings/go/oci/repository/provider/provider_test.go
+++ b/bindings/go/oci/repository/provider/provider_test.go
@@ -1,24 +1,167 @@
 package provider_test
 
 import (
+	"bytes"
+	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/opencontainers/go-digest"
+	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
 	"ocm.software/open-component-model/bindings/go/blob/filesystem"
+	"ocm.software/open-component-model/bindings/go/blob/inmemory"
 	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+	v2 "ocm.software/open-component-model/bindings/go/descriptor/v2"
 	httpv1alpha1 "ocm.software/open-component-model/bindings/go/http/spec/config/v1alpha1"
 	"ocm.software/open-component-model/bindings/go/oci/repository/provider"
 	ctfrepospecv1 "ocm.software/open-component-model/bindings/go/oci/spec/repository/v1/ctf"
 	ocirepospecv1 "ocm.software/open-component-model/bindings/go/oci/spec/repository/v1/oci"
+	"ocm.software/open-component-model/bindings/go/repository"
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
+
+// addNonDigestedResourceDescriptor uploads a local blob (so the AddComponentVersion local-blob
+// existence check passes) and returns a component descriptor whose single resource references that
+// blob but carries NO digest. This is the truthful discriminator between the two layouts: the
+// normalized add path requires every resource to be digested and rejects this descriptor, while the
+// default (v2) add path accepts it. See normalizedlayout.RequireAllResourcesDigested, which is only
+// invoked on the normalized add path.
+func addNonDigestedResourceDescriptor(t *testing.T, ctx context.Context, repo repository.ComponentVersionRepository) *descriptor.Descriptor {
+	t.Helper()
+	content := []byte("discriminator blob content")
+	resource := &descriptor.Resource{
+		Relation: descriptor.LocalRelation,
+		ElementMeta: descriptor.ElementMeta{
+			ObjectMeta: descriptor.ObjectMeta{Name: "test-resource", Version: "1.0.0"},
+		},
+		Type: "ociImageLayer",
+		Access: &v2.LocalBlob{
+			LocalReference: digest.FromBytes(content).String(),
+			MediaType:      ociImageSpecV1.MediaTypeImageLayer,
+		},
+	}
+	newRes, err := repo.AddLocalResource(ctx, "example.org/comp", "1.0.0", resource, inmemory.New(bytes.NewReader(content)))
+	require.NoError(t, err)
+
+	// Drop the digest that AddLocalResource populated so the resource is undigested at add time.
+	newRes.Digest = nil
+
+	desc := &descriptor.Descriptor{}
+	desc.Component.Name = "example.org/comp"
+	desc.Component.Version = "1.0.0"
+	desc.Component.Provider = descriptor.Provider{Name: "x"}
+	desc.Component.Resources = append(desc.Component.Resources, *newRes)
+	return desc
+}
+
+// TestProvider_ComponentVersionLayout_Normalized verifies end-to-end that a repository
+// spec requesting the "normalized" layout is honored by the provider: the constructed
+// repository stores component versions using the cosign-signable normalized layout.
+//
+// The provider does not expose the underlying store, so we prove the layout is active via two
+// truthful, store-free signals:
+//  1. A local resource round-trips through GetLocalResource on the normalized layout.
+//  2. Adding a component whose resource lacks a digest is rejected with the normalized-layout
+//     digest requirement — a check performed only on the normalized add path. The default layout
+//     accepts the same descriptor (asserted by the negative control below).
+func TestProvider_ComponentVersionLayout_Normalized(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	fs, err := filesystem.NewFS(t.TempDir(), os.O_RDWR)
+	require.NoError(t, err)
+
+	prov := provider.NewComponentVersionRepositoryProvider()
+
+	repoSpec := &ctfrepospecv1.Repository{
+		FilePath:               fs.String(),
+		AccessMode:             ctfrepospecv1.AccessModeReadWrite,
+		ComponentVersionLayout: "normalized",
+	}
+
+	repo, err := prov.GetComponentVersionRepository(ctx, repoSpec, nil)
+	require.NoError(t, err)
+
+	// Signal 2: the normalized add path enforces the resource-digest requirement.
+	require.ErrorContains(t, repo.AddComponentVersion(ctx, addNonDigestedResourceDescriptor(t, ctx, repo)),
+		"normalized layout requires every resource to be digested",
+		"expected the normalized-layout digest requirement, proving the layout was honored")
+
+	// Signal 1: a properly digested local resource round-trips via the normalized read path.
+	desc := &descriptor.Descriptor{}
+	desc.Component.Name = "example.org/comp"
+	desc.Component.Version = "1.0.0"
+	desc.Component.Provider = descriptor.Provider{Name: "x"}
+
+	content := []byte("normalized provider local resource")
+	resource := &descriptor.Resource{
+		Relation: descriptor.LocalRelation,
+		ElementMeta: descriptor.ElementMeta{
+			ObjectMeta: descriptor.ObjectMeta{Name: "test-resource", Version: "1.0.0"},
+		},
+		Type: "ociImageLayer",
+		Access: &v2.LocalBlob{
+			LocalReference: digest.FromBytes(content).String(),
+			MediaType:      ociImageSpecV1.MediaTypeImageLayer,
+		},
+	}
+	newRes, err := repo.AddLocalResource(ctx, desc.Component.Name, desc.Component.Version, resource, inmemory.New(bytes.NewReader(content)))
+	require.NoError(t, err)
+	desc.Component.Resources = append(desc.Component.Resources, *newRes)
+
+	require.NoError(t, repo.AddComponentVersion(ctx, desc))
+
+	// Round-trips through the normalized read path.
+	got, err := repo.GetComponentVersion(ctx, desc.Component.Name, desc.Component.Version)
+	require.NoError(t, err)
+	require.Equal(t, "example.org/comp", got.Component.Name)
+	require.Equal(t, "1.0.0", got.Component.Version)
+
+	blb, gotRes, err := repo.GetLocalResource(ctx, desc.Component.Name, desc.Component.Version, runtime.Identity{"name": "test-resource"})
+	require.NoError(t, err)
+	require.NotNil(t, gotRes)
+	require.Equal(t, "test-resource", gotRes.Name)
+	reader, err := blb.ReadCloser()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reader.Close()) })
+	roundTripped, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, content, roundTripped)
+}
+
+// TestProvider_ComponentVersionLayout_DefaultIsNotNormalized is the negative control for
+// TestProvider_ComponentVersionLayout_Normalized: a spec without ComponentVersionLayout must use
+// the default layout, which does NOT enforce the normalized resource-digest requirement. Adding a
+// non-digested resource therefore succeeds, proving the default layout is not the normalized one.
+func TestProvider_ComponentVersionLayout_DefaultIsNotNormalized(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	fs, err := filesystem.NewFS(t.TempDir(), os.O_RDWR)
+	require.NoError(t, err)
+
+	prov := provider.NewComponentVersionRepositoryProvider()
+
+	repoSpec := &ctfrepospecv1.Repository{
+		FilePath:   fs.String(),
+		AccessMode: ctfrepospecv1.AccessModeReadWrite,
+	}
+
+	repo, err := prov.GetComponentVersionRepository(ctx, repoSpec, nil)
+	require.NoError(t, err)
+
+	// The default layout does not enforce the normalized digest requirement, so the same
+	// descriptor that the normalized layout rejects is accepted here.
+	require.NoError(t, repo.AddComponentVersion(ctx, addNonDigestedResourceDescriptor(t, ctx, repo)))
+}
 
 func Test_Provider_Smoke(t *testing.T) {
 	t.Parallel()

--- a/bindings/go/oci/repository_normalized_test.go
+++ b/bindings/go/oci/repository_normalized_test.go
@@ -1,0 +1,368 @@
+package oci_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go"
+	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+
+	"ocm.software/open-component-model/bindings/go/blob/filesystem"
+	"ocm.software/open-component-model/bindings/go/blob/inmemory"
+	"ocm.software/open-component-model/bindings/go/ctf"
+	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+	v2 "ocm.software/open-component-model/bindings/go/descriptor/v2"
+	"ocm.software/open-component-model/bindings/go/oci"
+	ocictf "ocm.software/open-component-model/bindings/go/oci/ctf"
+	"ocm.software/open-component-model/bindings/go/oci/spec"
+	ocidescriptor "ocm.software/open-component-model/bindings/go/oci/spec/descriptor"
+	"ocm.software/open-component-model/bindings/go/repository"
+)
+
+// newNormalizedRepo creates an *oci.Repository backed by an in-memory CTF store,
+// matching the setup used by the existing repository tests.
+func newNormalizedRepo(t *testing.T, opts ...oci.RepositoryOption) *oci.Repository {
+	t.Helper()
+	fs, err := filesystem.NewFS(t.TempDir(), os.O_RDWR)
+	require.NoError(t, err)
+	ctfStore := ocictf.NewFromCTF(ctf.NewFileSystemCTF(fs))
+	// Repository() helper (defined in repository_test.go) prepends WithTempDir, so
+	// replicate that here with the same helper to keep setup consistent.
+	return Repository(t, append([]oci.RepositoryOption{ocictf.WithCTF(ctfStore)}, opts...)...)
+}
+
+func simpleDescriptor(name, version string) *descriptor.Descriptor {
+	return &descriptor.Descriptor{
+		Meta: descriptor.Meta{Version: "v2"},
+		Component: descriptor.Component{
+			Provider: descriptor.Provider{Name: "internal"},
+			ComponentMeta: descriptor.ComponentMeta{
+				ObjectMeta: descriptor.ObjectMeta{
+					Name:    name,
+					Version: version,
+				},
+			},
+		},
+	}
+}
+
+// TestRepository_NormalizedLayout_RoundTrip checks that a repository created
+// with WithComponentVersionLayout(LayoutNormalized) can add and retrieve a
+// component version via the normalized layout path.
+func TestRepository_NormalizedLayout_RoundTrip(t *testing.T) {
+	r := require.New(t)
+	ctx := context.Background()
+
+	repo := newNormalizedRepo(t, oci.WithComponentVersionLayout(oci.LayoutNormalized))
+
+	desc := simpleDescriptor("example.org/comp", "1.0.0")
+
+	// Should not exist yet.
+	_, err := repo.GetComponentVersion(ctx, desc.Component.Name, desc.Component.Version)
+	r.Error(err)
+	r.ErrorIs(err, repository.ErrNotFound)
+
+	// Add the component version using the normalized layout.
+	r.NoError(repo.AddComponentVersion(ctx, desc))
+
+	// Retrieve it — the read path must detect the normalized manifest and delegate
+	// to GetNormalizedComponentVersion.
+	got, err := repo.GetComponentVersion(ctx, desc.Component.Name, desc.Component.Version)
+	r.NoError(err)
+	r.NotNil(got)
+	r.Equal("example.org/comp", got.Component.Name)
+	r.Equal("1.0.0", got.Component.Version)
+}
+
+// TestRepository_NormalizedLayout_GetLocalResource_RoundTrip verifies that a local resource
+// uploaded to a normalized-layout repository can be read back via GetLocalResource. Under the
+// normalized layout the tag resolves to the access-free manifest; the read path must resolve the
+// full access-bearing descriptor via the access referrer and then fetch the local blob content by
+// digest (the content is pushed as a content-addressable blob during AddLocalResource).
+func TestRepository_NormalizedLayout_GetLocalResource_RoundTrip(t *testing.T) {
+	r := require.New(t)
+	ctx := context.Background()
+
+	repo := newNormalizedRepo(t, oci.WithComponentVersionLayout(oci.LayoutNormalized))
+
+	desc := simpleDescriptor("example.org/comp", "1.0.0")
+
+	content := []byte("normalized local resource content")
+	resource := &descriptor.Resource{
+		Relation: descriptor.LocalRelation,
+		ElementMeta: descriptor.ElementMeta{
+			ObjectMeta: descriptor.ObjectMeta{
+				Name:    "test-resource",
+				Version: "1.0.0",
+			},
+		},
+		Type: "ociImageLayer",
+		Access: &v2.LocalBlob{
+			LocalReference: digest.FromBytes(content).String(),
+			MediaType:      ociImageSpecV1.MediaTypeImageLayer,
+		},
+	}
+
+	// Upload the blob; AddLocalResource populates the resource digest from the blob, which the
+	// normalized layout requires for every resource.
+	b := inmemory.New(bytes.NewReader(content))
+	newRes, err := repo.AddLocalResource(ctx, desc.Component.Name, desc.Component.Version, resource, b)
+	r.NoError(err)
+	r.NotNil(newRes)
+	r.NotNil(newRes.Digest, "AddLocalResource should populate the resource digest")
+
+	desc.Component.Resources = append(desc.Component.Resources, *newRes)
+	r.NoError(repo.AddComponentVersion(ctx, desc))
+
+	// Read the local resource back via the normalized read path.
+	blb, gotRes, err := repo.GetLocalResource(ctx, desc.Component.Name, desc.Component.Version, map[string]string{
+		"name":    "test-resource",
+		"version": "1.0.0",
+	})
+	r.NoError(err)
+	r.NotNil(blb)
+	r.NotNil(gotRes)
+	r.Equal("test-resource", gotRes.Name)
+	r.Equal("1.0.0", gotRes.Version)
+
+	reader, err := blb.ReadCloser()
+	r.NoError(err)
+	t.Cleanup(func() { r.NoError(reader.Close()) })
+	got, err := io.ReadAll(reader)
+	r.NoError(err)
+	r.Equal(content, got, "round-tripped blob content must equal what was uploaded")
+}
+
+// TestRepository_NormalizedLayout_GetLocalSource_RoundTrip is the source-side counterpart to the
+// resource round-trip test above, exercising GetLocalSource under the normalized layout.
+func TestRepository_NormalizedLayout_GetLocalSource_RoundTrip(t *testing.T) {
+	r := require.New(t)
+	ctx := context.Background()
+
+	repo := newNormalizedRepo(t, oci.WithComponentVersionLayout(oci.LayoutNormalized))
+
+	desc := simpleDescriptor("example.org/comp", "1.0.0")
+
+	content := []byte("normalized local source content")
+	source := &descriptor.Source{
+		ElementMeta: descriptor.ElementMeta{
+			ObjectMeta: descriptor.ObjectMeta{
+				Name:    "test-source",
+				Version: "1.0.0",
+			},
+		},
+		Type: "ociImageLayer",
+		Access: &v2.LocalBlob{
+			LocalReference: digest.FromBytes(content).String(),
+			MediaType:      ociImageSpecV1.MediaTypeImageLayer,
+		},
+	}
+
+	b := inmemory.New(bytes.NewReader(content))
+	newSrc, err := repo.AddLocalSource(ctx, desc.Component.Name, desc.Component.Version, source, b)
+	r.NoError(err)
+	r.NotNil(newSrc)
+
+	desc.Component.Sources = append(desc.Component.Sources, *newSrc)
+	r.NoError(repo.AddComponentVersion(ctx, desc))
+
+	blb, gotSrc, err := repo.GetLocalSource(ctx, desc.Component.Name, desc.Component.Version, map[string]string{
+		"name":    "test-source",
+		"version": "1.0.0",
+	})
+	r.NoError(err)
+	r.NotNil(blb)
+	r.NotNil(gotSrc)
+	r.Equal("test-source", gotSrc.Name)
+
+	reader, err := blb.ReadCloser()
+	r.NoError(err)
+	t.Cleanup(func() { r.NoError(reader.Close()) })
+	got, err := io.ReadAll(reader)
+	r.NoError(err)
+	r.Equal(content, got, "round-tripped source blob content must equal what was uploaded")
+}
+
+// pushReferrer pushes an OCI image manifest that references subject as its Subject,
+// with the given artifactType, into store. It returns the referrer manifest descriptor.
+// The config and a single tiny layer are pushed as content-addressable blobs so the
+// whole referrer graph is present in the source store and can be carried.
+func pushReferrer(t *testing.T, ctx context.Context, store spec.Store, subject ociImageSpecV1.Descriptor, artifactType string) ociImageSpecV1.Descriptor {
+	t.Helper()
+	r := require.New(t)
+
+	configRaw := []byte("{}")
+	configDesc := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageConfig,
+		Digest:    digest.FromBytes(configRaw),
+		Size:      int64(len(configRaw)),
+	}
+	r.NoError(store.Push(ctx, configDesc, bytes.NewReader(configRaw)))
+
+	layerRaw := []byte("referrer-payload-" + artifactType)
+	layerDesc := ociImageSpecV1.Descriptor{
+		MediaType: ociImageSpecV1.MediaTypeImageLayer,
+		Digest:    digest.FromBytes(layerRaw),
+		Size:      int64(len(layerRaw)),
+	}
+	r.NoError(store.Push(ctx, layerDesc, bytes.NewReader(layerRaw)))
+
+	subjectCopy := subject
+	manifest := ociImageSpecV1.Manifest{
+		Versioned:    specs.Versioned{SchemaVersion: 2},
+		MediaType:    ociImageSpecV1.MediaTypeImageManifest,
+		ArtifactType: artifactType,
+		Config:       configDesc,
+		Layers:       []ociImageSpecV1.Descriptor{layerDesc},
+		Subject:      &subjectCopy,
+	}
+	manifestRaw, err := json.Marshal(manifest)
+	r.NoError(err)
+	manifestDesc := ociImageSpecV1.Descriptor{
+		MediaType:    ociImageSpecV1.MediaTypeImageManifest,
+		ArtifactType: artifactType,
+		Digest:       digest.FromBytes(manifestRaw),
+		Size:         int64(len(manifestRaw)),
+	}
+	r.NoError(store.Push(ctx, manifestDesc, bytes.NewReader(manifestRaw)))
+	return manifestDesc
+}
+
+// TestRepository_CarryComponentSignatures verifies that CarryComponentSignatures copies a
+// non-access referrer (e.g. a cosign signature) of the normalized component manifest from a
+// source repository into a target repository, while skipping the OCM-managed access referrer.
+// Both repos use the normalized layout so the component-manifest digest is identical, which is
+// the precondition for the referrers to point at content that exists on the target.
+func TestRepository_CarryComponentSignatures(t *testing.T) {
+	r := require.New(t)
+	ctx := context.Background()
+
+	// Two independent CTF stores, each fronted by an *oci.Repository using the normalized layout.
+	srcFS, err := filesystem.NewFS(t.TempDir(), os.O_RDWR)
+	r.NoError(err)
+	srcCTF := ocictf.NewFromCTF(ctf.NewFileSystemCTF(srcFS))
+	src := Repository(t, ocictf.WithCTF(srcCTF), oci.WithComponentVersionLayout(oci.LayoutNormalized))
+
+	dstFS, err := filesystem.NewFS(t.TempDir(), os.O_RDWR)
+	r.NoError(err)
+	dstCTF := ocictf.NewFromCTF(ctf.NewFileSystemCTF(dstFS))
+	dst := Repository(t, ocictf.WithCTF(dstCTF), oci.WithComponentVersionLayout(oci.LayoutNormalized))
+
+	const compName, compVersion = "example.org/comp", "1.0.0"
+
+	// Add the SAME component to BOTH repos → identical normalized manifest digest.
+	r.NoError(src.AddComponentVersion(ctx, simpleDescriptor(compName, compVersion)))
+	r.NoError(dst.AddComponentVersion(ctx, simpleDescriptor(compName, compVersion)))
+
+	// Grab the source store handle to push fake referrers of the component manifest.
+	srcRef := srcCTF.ComponentVersionReference(ctx, compName, compVersion)
+	srcStore, err := srcCTF.StoreForReference(ctx, srcRef)
+	r.NoError(err)
+	srcManifest, err := srcStore.Resolve(ctx, srcRef)
+	r.NoError(err)
+
+	dstRef := dstCTF.ComponentVersionReference(ctx, compName, compVersion)
+	dstStore, err := dstCTF.StoreForReference(ctx, dstRef)
+	r.NoError(err)
+	dstManifest, err := dstStore.Resolve(ctx, dstRef)
+	r.NoError(err)
+
+	// Precondition: identical component-manifest digest across the two repos.
+	r.Equal(srcManifest.Digest, dstManifest.Digest, "normalized manifest digests must match across stores")
+
+	// Push a cosign-type (non-access) referrer and an access-type referrer into the source.
+	cosignReferrer := pushReferrer(t, ctx, srcStore, srcManifest, "application/vnd.dev.cosign.simplesigning.v1+json")
+	accessReferrer := pushReferrer(t, ctx, srcStore, srcManifest, ocidescriptor.ArtifactTypeAccessDescriptor)
+
+	// Sanity: the fake access referrer does not exist in dst before carry.
+	existsBefore, err := dstStore.Exists(ctx, accessReferrer)
+	r.NoError(err)
+	r.False(existsBefore, "the fake access referrer must not pre-exist in dst")
+
+	// Carry.
+	r.NoError(dst.CarryComponentSignatures(ctx, src, compName, compVersion))
+
+	// The cosign referrer (and its blobs) must now exist in dst.
+	existsCosign, err := dstStore.Exists(ctx, cosignReferrer)
+	r.NoError(err)
+	r.True(existsCosign, "the cosign referrer must be carried into dst")
+
+	// The specific fake access referrer from src must NOT have been copied (it was skipped).
+	existsAccess, err := dstStore.Exists(ctx, accessReferrer)
+	r.NoError(err)
+	r.False(existsAccess, "the fake access referrer from src must be skipped, not carried")
+}
+
+// TestRepository_CarryComponentSignatures_NoOpWhenDigestsDiffer verifies that no referrers are
+// carried when the source and target component manifests resolve to different digests (i.e. the
+// normalized-layout digest-preservation precondition does not hold).
+func TestRepository_CarryComponentSignatures_NoOpWhenDigestsDiffer(t *testing.T) {
+	r := require.New(t)
+	ctx := context.Background()
+
+	srcFS, err := filesystem.NewFS(t.TempDir(), os.O_RDWR)
+	r.NoError(err)
+	srcCTF := ocictf.NewFromCTF(ctf.NewFileSystemCTF(srcFS))
+	src := Repository(t, ocictf.WithCTF(srcCTF), oci.WithComponentVersionLayout(oci.LayoutNormalized))
+
+	dstFS, err := filesystem.NewFS(t.TempDir(), os.O_RDWR)
+	r.NoError(err)
+	dstCTF := ocictf.NewFromCTF(ctf.NewFileSystemCTF(dstFS))
+	dst := Repository(t, ocictf.WithCTF(dstCTF), oci.WithComponentVersionLayout(oci.LayoutNormalized))
+
+	const compName, compVersion = "example.org/comp", "1.0.0"
+
+	// DIFFERENT provider → different normalized bytes → different manifest digest.
+	srcDesc := simpleDescriptor(compName, compVersion)
+	srcDesc.Component.Provider = descriptor.Provider{Name: "source-provider"}
+	r.NoError(src.AddComponentVersion(ctx, srcDesc))
+
+	dstDesc := simpleDescriptor(compName, compVersion)
+	dstDesc.Component.Provider = descriptor.Provider{Name: "target-provider"}
+	r.NoError(dst.AddComponentVersion(ctx, dstDesc))
+
+	srcRef := srcCTF.ComponentVersionReference(ctx, compName, compVersion)
+	srcStore, err := srcCTF.StoreForReference(ctx, srcRef)
+	r.NoError(err)
+	srcManifest, err := srcStore.Resolve(ctx, srcRef)
+	r.NoError(err)
+
+	cosignReferrer := pushReferrer(t, ctx, srcStore, srcManifest, "application/vnd.dev.cosign.simplesigning.v1+json")
+
+	// Carry must be a no-op because the digests differ.
+	r.NoError(dst.CarryComponentSignatures(ctx, src, compName, compVersion))
+
+	dstRef := dstCTF.ComponentVersionReference(ctx, compName, compVersion)
+	dstStore, err := dstCTF.StoreForReference(ctx, dstRef)
+	r.NoError(err)
+	existsCosign, err := dstStore.Exists(ctx, cosignReferrer)
+	r.NoError(err)
+	r.False(existsCosign, "no referrer must be carried when component manifest digests differ")
+}
+
+// TestRepository_DefaultLayout_RoundTrip is a regression guard that confirms the
+// default (LayoutV2) repository still round-trips a component version correctly
+// after the normalized-layout detection changes.
+func TestRepository_DefaultLayout_RoundTrip(t *testing.T) {
+	r := require.New(t)
+	ctx := context.Background()
+
+	// No WithComponentVersionLayout option → default LayoutV2.
+	repo := newNormalizedRepo(t)
+
+	desc := simpleDescriptor("example.org/v2comp", "2.0.0")
+
+	r.NoError(repo.AddComponentVersion(ctx, desc))
+
+	got, err := repo.GetComponentVersion(ctx, desc.Component.Name, desc.Component.Version)
+	r.NoError(err)
+	r.NotNil(got)
+	r.Equal("example.org/v2comp", got.Component.Name)
+	r.Equal("2.0.0", got.Component.Version)
+}

--- a/bindings/go/oci/repository_options.go
+++ b/bindings/go/oci/repository_options.go
@@ -53,6 +53,12 @@ type RepositoryOptions struct {
 	// DescriptorEncodingMediaType is the media type of the descriptor encoding used for component versions.
 	DescriptorEncodingMediaType string
 
+	// Layout selects the OCI storage layout used when adding component versions.
+	// The default (LayoutV2) is the access-bearing v2 descriptor manifest as the tag target.
+	// LayoutNormalized produces the cosign-signable normalized layout (a stable, access-free
+	// normalized manifest as the tag target, with the access-bearing descriptor as a referrer).
+	Layout Layout
+
 	// DescriptorUnmarshalFunc is used to unmarshal descriptors from OCI stores.
 	// If not provided, DefaultDescriptorUnmarshalFunc will be used.
 	DescriptorUnmarshalFunc descriptor.UnmarshalFunc
@@ -167,6 +173,11 @@ func WithGlobalAccessPolicy(policy GlobalAccessPolicy) RepositoryOption {
 	}
 }
 
+// WithComponentVersionLayout selects the OCI storage layout used when adding component versions.
+func WithComponentVersionLayout(l Layout) RepositoryOption {
+	return func(o *RepositoryOptions) { o.Layout = l }
+}
+
 // NewRepository creates a new Repository instance with the given options.
 func NewRepository(opts ...RepositoryOption) (*Repository, error) {
 	options := &RepositoryOptions{}
@@ -229,5 +240,6 @@ func NewRepository(opts ...RepositoryOption) (*Repository, error) {
 		unmarshalDescriptorFunc:     options.DescriptorUnmarshalFunc,
 		tempDir:                     options.TempDir,
 		globalAccessPolicy:          options.GlobalAccessPolicy,
+		layout:                      options.Layout,
 	}, nil
 }

--- a/bindings/go/oci/spec/descriptor/media_type.go
+++ b/bindings/go/oci/spec/descriptor/media_type.go
@@ -34,3 +34,16 @@ const (
 	MediaTypeComponentDescriptorYAML       = MediaTypeComponentDescriptorV2 + "+yaml"
 	MediaTypeLegacyComponentDescriptorYAML = "application/vnd.gardener.cloud.cnudie.component-descriptor.v2+yaml"
 )
+
+// Media types and artifact types for the normalized (cosign-signable) layout (layout version v1).
+const (
+	// ArtifactTypeNormalizedDescriptor is the artifactType of the normalized (access-free)
+	// descriptor manifest. This manifest is the stable primary entry point a tag resolves to
+	// in the normalized layout, and is the manifest cosign signs.
+	ArtifactTypeNormalizedDescriptor = MediaTypeComponentDescriptor + ".normalized.v1"
+	// MediaTypeComponentDescriptorNormalizedJSON is the media type of the normalized descriptor layer.
+	MediaTypeComponentDescriptorNormalizedJSON = ArtifactTypeNormalizedDescriptor + "+json"
+	// ArtifactTypeAccessDescriptor is the artifactType of the access-bearing descriptor manifest,
+	// stored as a referrer (subject) of the normalized manifest. Regenerated per registry; unsigned.
+	ArtifactTypeAccessDescriptor = MediaTypeComponentDescriptor + ".access.v1"
+)

--- a/bindings/go/oci/spec/layout/normalized/v1/bind.go
+++ b/bindings/go/oci/spec/layout/normalized/v1/bind.go
@@ -1,0 +1,35 @@
+package v1
+
+import (
+	"bytes"
+	"fmt"
+
+	"ocm.software/open-component-model/bindings/go/descriptor/normalisation"
+	v4alpha1 "ocm.software/open-component-model/bindings/go/descriptor/normalisation/json/v4alpha1"
+	descruntime "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+)
+
+// NormalisationAlgorithm is the algorithm used to derive the normalized descriptor layer, and the
+// value stored in the AnnotationNormalisationAlgo annotation.
+const NormalisationAlgorithm = v4alpha1.Algorithm
+
+// Normalize returns the normalized (access-free, JCS-canonical) descriptor bytes for cd. These
+// bytes are the normalized manifest's single layer and the payload cosign's signature covers
+// (via the manifest digest).
+func Normalize(cd *descruntime.Descriptor) ([]byte, error) {
+	return normalisation.Normalise(cd, NormalisationAlgorithm)
+}
+
+// VerifyNormalizedMatchesAccess proves that the access-bearing descriptor `access` re-normalizes
+// to exactly `normalized` (the signed, access-free bytes). This is the sole trust gate for an
+// access referrer: the accesses it carries may only be trusted once this passes.
+func VerifyNormalizedMatchesAccess(normalized []byte, access *descruntime.Descriptor) error {
+	recomputed, err := Normalize(access)
+	if err != nil {
+		return fmt.Errorf("failed to normalize access descriptor: %w", err)
+	}
+	if !bytes.Equal(recomputed, normalized) {
+		return fmt.Errorf("access descriptor does not match signed normalized descriptor (possible tampering or mismatched referrer)")
+	}
+	return nil
+}

--- a/bindings/go/oci/spec/layout/normalized/v1/bind_test.go
+++ b/bindings/go/oci/spec/layout/normalized/v1/bind_test.go
@@ -1,0 +1,50 @@
+package v1_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"ocm.software/open-component-model/bindings/go/descriptor/normalisation"
+	v4alpha1 "ocm.software/open-component-model/bindings/go/descriptor/normalisation/json/v4alpha1"
+	descruntime "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+	layout "ocm.software/open-component-model/bindings/go/oci/spec/layout/normalized/v1"
+)
+
+func bindTestDescriptor() *descruntime.Descriptor {
+	d := &descruntime.Descriptor{}
+	d.Component.Name = "example.org/comp"
+	d.Component.Version = "1.0.0"
+	d.Component.Provider = descruntime.Provider{Name: "internal"}
+	return d
+}
+
+func TestNormalize_MatchesNormalisationPackage(t *testing.T) {
+	d := bindTestDescriptor()
+	want, err := normalisation.Normalise(d, v4alpha1.Algorithm)
+	require.NoError(t, err)
+	got, err := layout.Normalize(d)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestVerifyNormalizedMatchesAccess_OK(t *testing.T) {
+	f := bindTestDescriptor()
+	n, err := layout.Normalize(f)
+	require.NoError(t, err)
+	require.NoError(t, layout.VerifyNormalizedMatchesAccess(n, f))
+}
+
+func TestVerifyNormalizedMatchesAccess_Mismatch(t *testing.T) {
+	f := bindTestDescriptor()
+	n, err := layout.Normalize(f)
+	require.NoError(t, err)
+
+	tampered := bindTestDescriptor()
+	tampered.Component.Name = "example.org/evil"
+
+	err = layout.VerifyNormalizedMatchesAccess(n, tampered)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match")
+}

--- a/bindings/go/oci/spec/layout/normalized/v1/layout.go
+++ b/bindings/go/oci/spec/layout/normalized/v1/layout.go
@@ -1,0 +1,28 @@
+// Package v1 defines constants and helpers for the normalized (cosign-signable) OCM OCI layout.
+//
+// In this layout the tag resolves to a normalized, access-free descriptor manifest whose digest
+// is stable across registry-to-registry copies (it contains no access/location information). The
+// access-bearing descriptor and local blobs are stored as a referrer of that manifest and are
+// regenerated per registry.
+package v1
+
+import "strings"
+
+// LayoutVersion is the version of the normalized layout implemented by this package.
+const LayoutVersion = "v1"
+
+const (
+	// AnnotationLayoutVersion records the layout version on the normalized manifest.
+	AnnotationLayoutVersion = "software.ocm.component-model/layout-version"
+	// AnnotationNormalisationAlgo records the normalisation algorithm used to produce the
+	// normalized descriptor layer, so the bind check is unambiguous and reproducible.
+	AnnotationNormalisationAlgo = "software.ocm.component-model/normalisation-algo"
+)
+
+// AccessFallbackTag returns the predictable tag used to discover the access referrer on registries
+// that do not implement the OCI referrers API. It mirrors cosign's `sha256-<hex>.sig` convention
+// with an `.acc` suffix, derived from the normalized manifest digest (e.g. "sha256:abc" ->
+// "sha256-abc.acc").
+func AccessFallbackTag(normalizedManifestDigest string) string {
+	return strings.Replace(normalizedManifestDigest, ":", "-", 1) + ".acc"
+}

--- a/bindings/go/oci/spec/layout/normalized/v1/layout_test.go
+++ b/bindings/go/oci/spec/layout/normalized/v1/layout_test.go
@@ -1,0 +1,20 @@
+package v1_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	layout "ocm.software/open-component-model/bindings/go/oci/spec/layout/normalized/v1"
+)
+
+func TestLayoutConstants(t *testing.T) {
+	assert.Equal(t, "v1", layout.LayoutVersion)
+	assert.Equal(t, "software.ocm.component-model/layout-version", layout.AnnotationLayoutVersion)
+	assert.Equal(t, "software.ocm.component-model/normalisation-algo", layout.AnnotationNormalisationAlgo)
+}
+
+func TestAccessFallbackTag(t *testing.T) {
+	got := layout.AccessFallbackTag("sha256:abcdef0123456789")
+	assert.Equal(t, "sha256-abcdef0123456789.acc", got)
+}

--- a/bindings/go/oci/spec/layout/normalized/v1/manifest.go
+++ b/bindings/go/oci/spec/layout/normalized/v1/manifest.go
@@ -1,0 +1,50 @@
+package v1
+
+import (
+	"fmt"
+
+	"github.com/opencontainers/image-spec/specs-go"
+	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
+
+	ocidescriptor "ocm.software/open-component-model/bindings/go/oci/spec/descriptor"
+)
+
+// BuildNormalizedManifest builds the normalized (access-free) manifest M. Its config is the OCI
+// empty descriptor and its single layer is the normalized descriptor blob. It is the tag target
+// and the subject other referrers (access descriptor, cosign signatures) attach to. Its content
+// is fully determined by the normalized layer digest, so its own digest is stable across copies.
+func BuildNormalizedManifest(normalizedLayer ociImageSpecV1.Descriptor, component, version string) ociImageSpecV1.Manifest {
+	return ociImageSpecV1.Manifest{
+		Versioned:    specs.Versioned{SchemaVersion: 2},
+		MediaType:    ociImageSpecV1.MediaTypeImageManifest,
+		ArtifactType: ocidescriptor.ArtifactTypeNormalizedDescriptor,
+		Config:       ociImageSpecV1.DescriptorEmptyJSON,
+		Layers:       []ociImageSpecV1.Descriptor{normalizedLayer},
+		Annotations: map[string]string{
+			AnnotationLayoutVersion:          LayoutVersion,
+			AnnotationNormalisationAlgo:      NormalisationAlgorithm,
+			ociImageSpecV1.AnnotationVersion: version,
+			ociImageSpecV1.AnnotationTitle:   fmt.Sprintf("OCM Normalized Component Descriptor for %s in version %s", component, version),
+		},
+	}
+}
+
+// BuildAccessManifest builds the access-bearing manifest A as a referrer (subject) of the
+// normalized manifest. It carries the full v2 descriptor layer plus any local-blob layers and the
+// component config. It is regenerated per registry and is never signed.
+func BuildAccessManifest(subject, config, descriptorLayer ociImageSpecV1.Descriptor, localBlobLayers []ociImageSpecV1.Descriptor, component, version string) ociImageSpecV1.Manifest {
+	subjectCopy := subject
+	return ociImageSpecV1.Manifest{
+		Versioned:    specs.Versioned{SchemaVersion: 2},
+		MediaType:    ociImageSpecV1.MediaTypeImageManifest,
+		ArtifactType: ocidescriptor.ArtifactTypeAccessDescriptor,
+		Config:       config,
+		Subject:      &subjectCopy,
+		Layers:       append([]ociImageSpecV1.Descriptor{descriptorLayer}, localBlobLayers...),
+		Annotations: map[string]string{
+			AnnotationLayoutVersion:          LayoutVersion,
+			ociImageSpecV1.AnnotationVersion: version,
+			ociImageSpecV1.AnnotationTitle:   fmt.Sprintf("OCM Access Component Descriptor for %s in version %s", component, version),
+		},
+	}
+}

--- a/bindings/go/oci/spec/layout/normalized/v1/manifest_test.go
+++ b/bindings/go/oci/spec/layout/normalized/v1/manifest_test.go
@@ -1,0 +1,47 @@
+package v1_test
+
+import (
+	"testing"
+
+	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+
+	ocidescriptor "ocm.software/open-component-model/bindings/go/oci/spec/descriptor"
+	layout "ocm.software/open-component-model/bindings/go/oci/spec/layout/normalized/v1"
+)
+
+func TestBuildNormalizedManifest(t *testing.T) {
+	normLayer := ociImageSpecV1.Descriptor{
+		MediaType: ocidescriptor.MediaTypeComponentDescriptorNormalizedJSON,
+		Digest:    "sha256:1111",
+		Size:      10,
+	}
+	m := layout.BuildNormalizedManifest(normLayer, "example.org/comp", "1.0.0")
+
+	assert.Equal(t, ociImageSpecV1.MediaTypeImageManifest, m.MediaType)
+	assert.Equal(t, ocidescriptor.ArtifactTypeNormalizedDescriptor, m.ArtifactType)
+	assert.Equal(t, ociImageSpecV1.DescriptorEmptyJSON, m.Config)
+	assert.Equal(t, []ociImageSpecV1.Descriptor{normLayer}, m.Layers)
+	assert.Nil(t, m.Subject)
+	assert.Equal(t, layout.LayoutVersion, m.Annotations[layout.AnnotationLayoutVersion])
+	assert.Equal(t, layout.NormalisationAlgorithm, m.Annotations[layout.AnnotationNormalisationAlgo])
+	assert.Equal(t, 2, m.SchemaVersion)
+}
+
+func TestBuildAccessManifest(t *testing.T) {
+	subject := ociImageSpecV1.Descriptor{Digest: "sha256:1111"}
+	config := ociImageSpecV1.Descriptor{MediaType: "application/vnd.ocm.software.component.config.v1+json", Digest: "sha256:2222"}
+	descLayer := ociImageSpecV1.Descriptor{MediaType: ocidescriptor.MediaTypeComponentDescriptorJSON, Digest: "sha256:3333"}
+	blob := ociImageSpecV1.Descriptor{MediaType: "application/octet-stream", Digest: "sha256:4444"}
+
+	a := layout.BuildAccessManifest(subject, config, descLayer, []ociImageSpecV1.Descriptor{blob}, "example.org/comp", "1.0.0")
+
+	assert.Equal(t, ociImageSpecV1.MediaTypeImageManifest, a.MediaType)
+	assert.Equal(t, ocidescriptor.ArtifactTypeAccessDescriptor, a.ArtifactType)
+	require := assert.New(t)
+	require.NotNil(a.Subject)
+	assert.Equal(t, subject, *a.Subject)
+	assert.Equal(t, config, a.Config)
+	assert.Equal(t, []ociImageSpecV1.Descriptor{descLayer, blob}, a.Layers)
+	assert.Equal(t, layout.LayoutVersion, a.Annotations[layout.AnnotationLayoutVersion])
+}

--- a/bindings/go/oci/spec/layout/normalized/v1/validate.go
+++ b/bindings/go/oci/spec/layout/normalized/v1/validate.go
@@ -1,0 +1,51 @@
+package v1
+
+import (
+	"fmt"
+	"strings"
+
+	descruntime "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+)
+
+// acceptedHashAlgorithms are the digest hash algorithms strong enough for the normalized layout.
+var acceptedHashAlgorithms = map[string]bool{
+	"SHA-256": true,
+	"SHA-384": true,
+	"SHA-512": true,
+}
+
+// RequireAllResourcesDigested returns an error unless every resource carries a digest with an
+// accepted (sha256+) hash algorithm. Resources explicitly excluded from the signature via the OCM
+// sentinel (HashAlgorithm == NoDigest) are allowed, matching jsonNormalisation/v4alpha1 behavior
+// for none-access resources. Sources are intentionally not enforced. This guarantees no unbound
+// resource content in the normalized (cosign-signable) layout.
+func RequireAllResourcesDigested(cd *descruntime.Descriptor) error {
+	var problems []string
+	for _, r := range cd.Component.Resources {
+		if err := checkResourceDigest(r.Digest); err != nil {
+			problems = append(problems, fmt.Sprintf("resource %q: %v", r.Name, err))
+		}
+	}
+	if len(problems) > 0 {
+		return fmt.Errorf("normalized layout requires every resource to be digested: %s",
+			strings.Join(problems, "; "))
+	}
+	return nil
+}
+
+func checkResourceDigest(d *descruntime.Digest) error {
+	if d == nil {
+		return fmt.Errorf("missing digest")
+	}
+	// Explicitly excluded-from-signature resources (e.g. none-access) are allowed.
+	if d.HashAlgorithm == descruntime.NoDigest {
+		return nil
+	}
+	if d.Value == "" {
+		return fmt.Errorf("missing digest value")
+	}
+	if !acceptedHashAlgorithms[d.HashAlgorithm] {
+		return fmt.Errorf("hash algorithm %q is not accepted (need SHA-256 or stronger)", d.HashAlgorithm)
+	}
+	return nil
+}

--- a/bindings/go/oci/spec/layout/normalized/v1/validate_test.go
+++ b/bindings/go/oci/spec/layout/normalized/v1/validate_test.go
@@ -1,0 +1,54 @@
+package v1_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	descruntime "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+	layout "ocm.software/open-component-model/bindings/go/oci/spec/layout/normalized/v1"
+)
+
+func descriptorWithResourceDigest(d *descruntime.Digest) *descruntime.Descriptor {
+	desc := &descruntime.Descriptor{}
+	desc.Component.Name = "example.org/comp"
+	desc.Component.Version = "1.0.0"
+	r := descruntime.Resource{Type: "ociImage"}
+	r.Name = "img"
+	r.Version = "1.0.0"
+	r.Digest = d
+	desc.Component.Resources = []descruntime.Resource{r}
+	return desc
+}
+
+func TestRequireAllResourcesDigested_OK(t *testing.T) {
+	desc := descriptorWithResourceDigest(&descruntime.Digest{
+		HashAlgorithm:          "SHA-256",
+		NormalisationAlgorithm: "genericBlobDigest/v1",
+		Value:                  "abc",
+	})
+	require.NoError(t, layout.RequireAllResourcesDigested(desc))
+}
+
+func TestRequireAllResourcesDigested_MissingDigest(t *testing.T) {
+	desc := descriptorWithResourceDigest(nil)
+	err := layout.RequireAllResourcesDigested(desc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "img")
+}
+
+func TestRequireAllResourcesDigested_WeakHash(t *testing.T) {
+	desc := descriptorWithResourceDigest(&descruntime.Digest{HashAlgorithm: "SHA-1", Value: "abc"})
+	err := layout.RequireAllResourcesDigested(desc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SHA-1")
+}
+
+func TestRequireAllResourcesDigested_ExcludedSentinelAllowed(t *testing.T) {
+	desc := descriptorWithResourceDigest(&descruntime.Digest{
+		HashAlgorithm:          descruntime.NoDigest,
+		NormalisationAlgorithm: descruntime.ExcludeFromSignature,
+	})
+	require.NoError(t, layout.RequireAllResourcesDigested(desc))
+}

--- a/bindings/go/oci/spec/repository/v1/ctf/repository.go
+++ b/bindings/go/oci/spec/repository/v1/ctf/repository.go
@@ -43,6 +43,11 @@ type Repository struct {
 	// If not specified, the AccessMode will be interpreted as AccessModeReadOnly for read-based operations
 	// and as AccessModeReadWrite for write-based operations.
 	AccessMode AccessMode `json:"accessMode,omitempty"`
+
+	// ComponentVersionLayout selects the storage layout used when adding component versions
+	// to this repository. "" or "v2" = the default access-bearing manifest; "normalized" = the
+	// cosign-signable normalized layout (a stable, access-free manifest as the tag target).
+	ComponentVersionLayout string `json:"componentVersionLayout,omitempty"`
 }
 
 func (spec *Repository) String() string {

--- a/bindings/go/oci/spec/repository/v1/ctf/repository_test.go
+++ b/bindings/go/oci/spec/repository/v1/ctf/repository_test.go
@@ -4,8 +4,46 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"ocm.software/open-component-model/bindings/go/ctf"
+	"ocm.software/open-component-model/bindings/go/runtime"
 )
+
+func TestRepository_ComponentVersionLayout_JSON(t *testing.T) {
+	r := Repository{
+		Type:                   runtime.NewVersionedType(Type, "v1"),
+		FilePath:               "/tmp/archive.ctf",
+		ComponentVersionLayout: "normalized",
+	}
+	b, err := json.Marshal(&r)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"componentVersionLayout":"normalized"`)
+
+	var back Repository
+	require.NoError(t, json.Unmarshal(b, &back))
+	assert.Equal(t, "normalized", back.ComponentVersionLayout)
+}
+
+// TestRepository_ComponentVersionLayout_SchemaAccepts ensures the generated JSON Schema
+// declares the componentVersionLayout property. The schema sets additionalProperties:false,
+// so without this property a spec carrying componentVersionLayout would be rejected during
+// validation. Asserting the property exists in the schema guarantees acceptance.
+func TestRepository_ComponentVersionLayout_SchemaAccepts(t *testing.T) {
+	schema := Repository{}.JSONSchema()
+	require.NotEmpty(t, schema)
+
+	var parsed struct {
+		Properties           map[string]json.RawMessage `json:"properties"`
+		AdditionalProperties bool                       `json:"additionalProperties"`
+	}
+	require.NoError(t, json.Unmarshal(schema, &parsed))
+	require.False(t, parsed.AdditionalProperties,
+		"schema is expected to forbid additional properties, making the property declaration load-bearing")
+	require.Contains(t, parsed.Properties, "componentVersionLayout",
+		"generated schema must declare componentVersionLayout so specs setting it pass validation")
+}
 
 func TestRepository_String(t *testing.T) {
 	tests := []struct {

--- a/bindings/go/oci/spec/repository/v1/ctf/schemas/Repository.schema.json
+++ b/bindings/go/oci/spec/repository/v1/ctf/schemas/Repository.schema.json
@@ -10,6 +10,10 @@
       "$ref": "#/$defs/ocm.software.open-component-model.bindings.go.oci.spec.repository.v1.ctf.AccessMode",
       "description": "AccessMode can be set to request readonly access or creation\nThe format of the path is determined by the access mode bitmask aggregated with |.\nIf not specified, the AccessMode will be interpreted as AccessModeReadOnly for read-based operations\nand as AccessModeReadWrite for write-based operations."
     },
+    "componentVersionLayout": {
+      "type": "string",
+      "description": "ComponentVersionLayout selects the storage layout used when adding component versions\nto this repository. \"\" or \"v2\" = the default access-bearing manifest; \"normalized\" = the\ncosign-signable normalized layout (a stable, access-free manifest as the tag target)."
+    },
     "filePath": {
       "type": "string",
       "description": "Path is the path of the CTF Archive on the filesystem.\n\nExamples\n- ./relative/path/to/archive.tgz\n- relative/path/to/archive.tar\n- /absolute/path/to/archive-folder"

--- a/bindings/go/oci/spec/repository/v1/oci/repository.go
+++ b/bindings/go/oci/spec/repository/v1/oci/repository.go
@@ -57,6 +57,10 @@ type Repository struct {
 	//     BaseUrl="ghcr.io/open-component-model/ocm" + SubPath=""
 	//     → Auto-extracts to: BaseUrl="ghcr.io", SubPath="open-component-model/ocm"
 	SubPath string `json:"subPath,omitempty"`
+	// ComponentVersionLayout selects the storage layout used when adding component versions
+	// to this repository. "" or "v2" = the default access-bearing manifest; "normalized" = the
+	// cosign-signable normalized layout (a stable, access-free manifest as the tag target).
+	ComponentVersionLayout string `json:"componentVersionLayout,omitempty"`
 }
 
 func (spec *Repository) String() string {

--- a/bindings/go/oci/spec/repository/v1/oci/repository_test.go
+++ b/bindings/go/oci/spec/repository/v1/oci/repository_test.go
@@ -1,0 +1,45 @@
+package oci
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+func TestRepository_ComponentVersionLayout_JSON(t *testing.T) {
+	r := Repository{
+		Type:                   runtime.NewVersionedType(Type, "v1"),
+		BaseUrl:                "localhost:5001",
+		ComponentVersionLayout: "normalized",
+	}
+	b, err := json.Marshal(&r)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"componentVersionLayout":"normalized"`)
+
+	var back Repository
+	require.NoError(t, json.Unmarshal(b, &back))
+	assert.Equal(t, "normalized", back.ComponentVersionLayout)
+}
+
+// TestRepository_ComponentVersionLayout_SchemaAccepts ensures the generated JSON Schema
+// declares the componentVersionLayout property. The schema sets additionalProperties:false,
+// so without this property a spec carrying componentVersionLayout would be rejected during
+// validation. Asserting the property exists in the schema guarantees acceptance.
+func TestRepository_ComponentVersionLayout_SchemaAccepts(t *testing.T) {
+	schema := Repository{}.JSONSchema()
+	require.NotEmpty(t, schema)
+
+	var parsed struct {
+		Properties           map[string]json.RawMessage `json:"properties"`
+		AdditionalProperties bool                       `json:"additionalProperties"`
+	}
+	require.NoError(t, json.Unmarshal(schema, &parsed))
+	require.False(t, parsed.AdditionalProperties,
+		"schema is expected to forbid additional properties, making the property declaration load-bearing")
+	require.Contains(t, parsed.Properties, "componentVersionLayout",
+		"generated schema must declare componentVersionLayout so specs setting it pass validation")
+}

--- a/bindings/go/oci/spec/repository/v1/oci/schemas/Repository.schema.json
+++ b/bindings/go/oci/spec/repository/v1/oci/schemas/Repository.schema.json
@@ -10,6 +10,10 @@
       "type": "string",
       "description": "BaseURL is the base url of the OCI registry (host + optional port).\nShould not include repository paths - use SubPath for that.\n\nExamples:\n- \"https://registry.example.com\"\n- \"https://registry.example.com:5000\"\n- \"oci://registry.example.com:5000\"\n- \"docker.io\"\n- \"ghcr.io\"\n\nIf BaseUrl contains a path (e.g., \"ghcr.io/org/repo\"),\nthe path will be auto-extracted and used as SubPath."
     },
+    "componentVersionLayout": {
+      "type": "string",
+      "description": "ComponentVersionLayout selects the storage layout used when adding component versions\nto this repository. \"\" or \"v2\" = the default access-bearing manifest; \"normalized\" = the\ncosign-signable normalized layout (a stable, access-free manifest as the tag target)."
+    },
     "subPath": {
       "type": "string",
       "description": "SubPath is an optional repository prefix path used for the OCM repository.\nThe OCM-based artifacts will use this path as a repository prefix.\nAn OCI registry may host many OCM repositories with different repository prefixes.\n\nAuto-extraction: If not specified and BaseUrl contains a path component,\nthe path will be automatically extracted and used as SubPath.\n\nExamples:\nExplicit separation:\nBaseUrl=\"ghcr.io\" + SubPath=\"open-component-model/ocm\"\n→ Registry: ghcr.io, Repository prefix: open-component-model/ocm\n\nEmbedded path:\nBaseUrl=\"ghcr.io/open-component-model/ocm\" + SubPath=\"\"\n→ Auto-extracts to: BaseUrl=\"ghcr.io\", SubPath=\"open-component-model/ocm\""

--- a/bindings/go/oci/spec/transformation/v1alpha1/ctf_add_component_version.go
+++ b/bindings/go/oci/spec/transformation/v1alpha1/ctf_add_component_version.go
@@ -35,4 +35,11 @@ type CTFAddComponentVersionOutput struct{}
 type CTFAddComponentVersionSpec struct {
 	Repository ctf.Repository `json:"repository"`
 	Descriptor *v2.Descriptor `json:"descriptor"`
+	// SourceRepository is the optional specification of the repository the
+	// component version originates from. When set, it enables carrying
+	// component-level signature referrers (e.g. cosign signatures) from the
+	// source into the target repository after the component version has been
+	// added. It is a no-op for repositories that do not implement signature
+	// carrying or when source and target do not resolve the same manifest.
+	SourceRepository *runtime.Raw `json:"sourceRepository,omitempty"`
 }

--- a/bindings/go/oci/spec/transformation/v1alpha1/oci_add_component_version.go
+++ b/bindings/go/oci/spec/transformation/v1alpha1/oci_add_component_version.go
@@ -35,4 +35,11 @@ type OCIAddComponentVersionOutput struct{}
 type OCIAddComponentVersionSpec struct {
 	Repository oci.Repository `json:"repository"`
 	Descriptor *v2.Descriptor `json:"descriptor"`
+	// SourceRepository is the optional specification of the repository the
+	// component version originates from. When set, it enables carrying
+	// component-level signature referrers (e.g. cosign signatures) from the
+	// source into the target repository after the component version has been
+	// added. It is a no-op for repositories that do not implement signature
+	// carrying or when source and target do not resolve the same manifest.
+	SourceRepository *runtime.Raw `json:"sourceRepository,omitempty"`
 }

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFAddComponentVersion.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFAddComponentVersion.schema.json
@@ -761,6 +761,10 @@
           "$ref": "#/$defs/ocm.software.open-component-model.bindings.go.oci.spec.repository.v1.ctf.AccessMode",
           "description": "AccessMode can be set to request readonly access or creation\nThe format of the path is determined by the access mode bitmask aggregated with |.\nIf not specified, the AccessMode will be interpreted as AccessModeReadOnly for read-based operations\nand as AccessModeReadWrite for write-based operations."
         },
+        "componentVersionLayout": {
+          "type": "string",
+          "description": "ComponentVersionLayout selects the storage layout used when adding component versions\nto this repository. \"\" or \"v2\" = the default access-bearing manifest; \"normalized\" = the\ncosign-signable normalized layout (a stable, access-free manifest as the tag target)."
+        },
         "filePath": {
           "type": "string",
           "description": "Path is the path of the CTF Archive on the filesystem.\n\nExamples\n- ./relative/path/to/archive.tgz\n- relative/path/to/archive.tar\n- /absolute/path/to/archive-folder"
@@ -818,6 +822,19 @@
         },
         "repository": {
           "$ref": "#/$defs/ocm.software.open-component-model.bindings.go.oci.spec.repository.v1.ctf.Repository"
+        },
+        "sourceRepository": {
+          "type": "object",
+          "description": "SourceRepository is the optional specification of the repository the component version originates from, used to carry component-level signature referrers into the target.",
+          "properties": {
+            "type": {
+              "$ref": "#/$defs/ocm.software.open-component-model.bindings.go.runtime.Type"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": true
         }
       },
       "required": [

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFAddComponentVersionSpec.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFAddComponentVersionSpec.schema.json
@@ -11,6 +11,19 @@
     },
     "repository": {
       "$ref": "#/$defs/ocm.software.open-component-model.bindings.go.oci.spec.repository.v1.ctf.Repository"
+    },
+    "sourceRepository": {
+      "type": "object",
+      "description": "SourceRepository is the optional specification of the repository the component version originates from, used to carry component-level signature referrers into the target.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ocm.software.open-component-model.bindings.go.runtime.Type"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": true
     }
   },
   "required": [
@@ -749,6 +762,10 @@
         "accessMode": {
           "$ref": "#/$defs/ocm.software.open-component-model.bindings.go.oci.spec.repository.v1.ctf.AccessMode",
           "description": "AccessMode can be set to request readonly access or creation\nThe format of the path is determined by the access mode bitmask aggregated with |.\nIf not specified, the AccessMode will be interpreted as AccessModeReadOnly for read-based operations\nand as AccessModeReadWrite for write-based operations."
+        },
+        "componentVersionLayout": {
+          "type": "string",
+          "description": "ComponentVersionLayout selects the storage layout used when adding component versions\nto this repository. \"\" or \"v2\" = the default access-bearing manifest; \"normalized\" = the\ncosign-signable normalized layout (a stable, access-free manifest as the tag target)."
         },
         "filePath": {
           "type": "string",

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFAddLocalResource.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFAddLocalResource.schema.json
@@ -311,6 +311,10 @@
           "$ref": "#/$defs/ocm.software.open-component-model.bindings.go.oci.spec.repository.v1.ctf.AccessMode",
           "description": "AccessMode can be set to request readonly access or creation\nThe format of the path is determined by the access mode bitmask aggregated with |.\nIf not specified, the AccessMode will be interpreted as AccessModeReadOnly for read-based operations\nand as AccessModeReadWrite for write-based operations."
         },
+        "componentVersionLayout": {
+          "type": "string",
+          "description": "ComponentVersionLayout selects the storage layout used when adding component versions\nto this repository. \"\" or \"v2\" = the default access-bearing manifest; \"normalized\" = the\ncosign-signable normalized layout (a stable, access-free manifest as the tag target)."
+        },
         "filePath": {
           "type": "string",
           "description": "Path is the path of the CTF Archive on the filesystem.\n\nExamples\n- ./relative/path/to/archive.tgz\n- relative/path/to/archive.tar\n- /absolute/path/to/archive-folder"

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFAddLocalResourceSpec.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFAddLocalResourceSpec.schema.json
@@ -316,6 +316,10 @@
           "$ref": "#/$defs/ocm.software.open-component-model.bindings.go.oci.spec.repository.v1.ctf.AccessMode",
           "description": "AccessMode can be set to request readonly access or creation\nThe format of the path is determined by the access mode bitmask aggregated with |.\nIf not specified, the AccessMode will be interpreted as AccessModeReadOnly for read-based operations\nand as AccessModeReadWrite for write-based operations."
         },
+        "componentVersionLayout": {
+          "type": "string",
+          "description": "ComponentVersionLayout selects the storage layout used when adding component versions\nto this repository. \"\" or \"v2\" = the default access-bearing manifest; \"normalized\" = the\ncosign-signable normalized layout (a stable, access-free manifest as the tag target)."
+        },
         "filePath": {
           "type": "string",
           "description": "Path is the path of the CTF Archive on the filesystem.\n\nExamples\n- ./relative/path/to/archive.tgz\n- relative/path/to/archive.tar\n- /absolute/path/to/archive-folder"

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFGetComponentVersion.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFGetComponentVersion.schema.json
@@ -761,6 +761,10 @@
           "$ref": "#/$defs/ocm.software.open-component-model.bindings.go.oci.spec.repository.v1.ctf.AccessMode",
           "description": "AccessMode can be set to request readonly access or creation\nThe format of the path is determined by the access mode bitmask aggregated with |.\nIf not specified, the AccessMode will be interpreted as AccessModeReadOnly for read-based operations\nand as AccessModeReadWrite for write-based operations."
         },
+        "componentVersionLayout": {
+          "type": "string",
+          "description": "ComponentVersionLayout selects the storage layout used when adding component versions\nto this repository. \"\" or \"v2\" = the default access-bearing manifest; \"normalized\" = the\ncosign-signable normalized layout (a stable, access-free manifest as the tag target)."
+        },
         "filePath": {
           "type": "string",
           "description": "Path is the path of the CTF Archive on the filesystem.\n\nExamples\n- ./relative/path/to/archive.tgz\n- relative/path/to/archive.tar\n- /absolute/path/to/archive-folder"

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFGetComponentVersionSpec.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFGetComponentVersionSpec.schema.json
@@ -40,6 +40,10 @@
           "$ref": "#/$defs/ocm.software.open-component-model.bindings.go.oci.spec.repository.v1.ctf.AccessMode",
           "description": "AccessMode can be set to request readonly access or creation\nThe format of the path is determined by the access mode bitmask aggregated with |.\nIf not specified, the AccessMode will be interpreted as AccessModeReadOnly for read-based operations\nand as AccessModeReadWrite for write-based operations."
         },
+        "componentVersionLayout": {
+          "type": "string",
+          "description": "ComponentVersionLayout selects the storage layout used when adding component versions\nto this repository. \"\" or \"v2\" = the default access-bearing manifest; \"normalized\" = the\ncosign-signable normalized layout (a stable, access-free manifest as the tag target)."
+        },
         "filePath": {
           "type": "string",
           "description": "Path is the path of the CTF Archive on the filesystem.\n\nExamples\n- ./relative/path/to/archive.tgz\n- relative/path/to/archive.tar\n- /absolute/path/to/archive-folder"

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFGetLocalResource.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFGetLocalResource.schema.json
@@ -311,6 +311,10 @@
           "$ref": "#/$defs/ocm.software.open-component-model.bindings.go.oci.spec.repository.v1.ctf.AccessMode",
           "description": "AccessMode can be set to request readonly access or creation\nThe format of the path is determined by the access mode bitmask aggregated with |.\nIf not specified, the AccessMode will be interpreted as AccessModeReadOnly for read-based operations\nand as AccessModeReadWrite for write-based operations."
         },
+        "componentVersionLayout": {
+          "type": "string",
+          "description": "ComponentVersionLayout selects the storage layout used when adding component versions\nto this repository. \"\" or \"v2\" = the default access-bearing manifest; \"normalized\" = the\ncosign-signable normalized layout (a stable, access-free manifest as the tag target)."
+        },
         "filePath": {
           "type": "string",
           "description": "Path is the path of the CTF Archive on the filesystem.\n\nExamples\n- ./relative/path/to/archive.tgz\n- relative/path/to/archive.tar\n- /absolute/path/to/archive-folder"

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFGetLocalResourceSpec.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/CTFGetLocalResourceSpec.schema.json
@@ -52,6 +52,10 @@
           "$ref": "#/$defs/ocm.software.open-component-model.bindings.go.oci.spec.repository.v1.ctf.AccessMode",
           "description": "AccessMode can be set to request readonly access or creation\nThe format of the path is determined by the access mode bitmask aggregated with |.\nIf not specified, the AccessMode will be interpreted as AccessModeReadOnly for read-based operations\nand as AccessModeReadWrite for write-based operations."
         },
+        "componentVersionLayout": {
+          "type": "string",
+          "description": "ComponentVersionLayout selects the storage layout used when adding component versions\nto this repository. \"\" or \"v2\" = the default access-bearing manifest; \"normalized\" = the\ncosign-signable normalized layout (a stable, access-free manifest as the tag target)."
+        },
         "filePath": {
           "type": "string",
           "description": "Path is the path of the CTF Archive on the filesystem.\n\nExamples\n- ./relative/path/to/archive.tgz\n- relative/path/to/archive.tar\n- /absolute/path/to/archive-folder"

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIAddComponentVersion.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIAddComponentVersion.schema.json
@@ -755,6 +755,10 @@
           "type": "string",
           "description": "BaseURL is the base url of the OCI registry (host + optional port).\nShould not include repository paths - use SubPath for that.\n\nExamples:\n- \"https://registry.example.com\"\n- \"https://registry.example.com:5000\"\n- \"oci://registry.example.com:5000\"\n- \"docker.io\"\n- \"ghcr.io\"\n\nIf BaseUrl contains a path (e.g., \"ghcr.io/org/repo\"),\nthe path will be auto-extracted and used as SubPath."
         },
+        "componentVersionLayout": {
+          "type": "string",
+          "description": "ComponentVersionLayout selects the storage layout used when adding component versions\nto this repository. \"\" or \"v2\" = the default access-bearing manifest; \"normalized\" = the\ncosign-signable normalized layout (a stable, access-free manifest as the tag target)."
+        },
         "subPath": {
           "type": "string",
           "description": "SubPath is an optional repository prefix path used for the OCM repository.\nThe OCM-based artifacts will use this path as a repository prefix.\nAn OCI registry may host many OCM repositories with different repository prefixes.\n\nAuto-extraction: If not specified and BaseUrl contains a path component,\nthe path will be automatically extracted and used as SubPath.\n\nExamples:\nExplicit separation:\nBaseUrl=\"ghcr.io\" + SubPath=\"open-component-model/ocm\"\n→ Registry: ghcr.io, Repository prefix: open-component-model/ocm\n\nEmbedded path:\nBaseUrl=\"ghcr.io/open-component-model/ocm\" + SubPath=\"\"\n→ Auto-extracts to: BaseUrl=\"ghcr.io\", SubPath=\"open-component-model/ocm\""
@@ -826,6 +830,19 @@
         },
         "repository": {
           "$ref": "#/$defs/ocm.software.open-component-model.bindings.go.oci.spec.repository.v1.oci.Repository"
+        },
+        "sourceRepository": {
+          "type": "object",
+          "description": "SourceRepository is the optional specification of the repository the component version originates from, used to carry component-level signature referrers into the target.",
+          "properties": {
+            "type": {
+              "$ref": "#/$defs/ocm.software.open-component-model.bindings.go.runtime.Type"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": true
         }
       },
       "required": [

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIAddComponentVersionSpec.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIAddComponentVersionSpec.schema.json
@@ -11,6 +11,19 @@
     },
     "repository": {
       "$ref": "#/$defs/ocm.software.open-component-model.bindings.go.oci.spec.repository.v1.oci.Repository"
+    },
+    "sourceRepository": {
+      "type": "object",
+      "description": "SourceRepository is the optional specification of the repository the component version originates from, used to carry component-level signature referrers into the target.",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/ocm.software.open-component-model.bindings.go.runtime.Type"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "additionalProperties": true
     }
   },
   "required": [
@@ -743,6 +756,10 @@
         "baseUrl": {
           "type": "string",
           "description": "BaseURL is the base url of the OCI registry (host + optional port).\nShould not include repository paths - use SubPath for that.\n\nExamples:\n- \"https://registry.example.com\"\n- \"https://registry.example.com:5000\"\n- \"oci://registry.example.com:5000\"\n- \"docker.io\"\n- \"ghcr.io\"\n\nIf BaseUrl contains a path (e.g., \"ghcr.io/org/repo\"),\nthe path will be auto-extracted and used as SubPath."
+        },
+        "componentVersionLayout": {
+          "type": "string",
+          "description": "ComponentVersionLayout selects the storage layout used when adding component versions\nto this repository. \"\" or \"v2\" = the default access-bearing manifest; \"normalized\" = the\ncosign-signable normalized layout (a stable, access-free manifest as the tag target)."
         },
         "subPath": {
           "type": "string",

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIAddLocalResource.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIAddLocalResource.schema.json
@@ -322,6 +322,10 @@
           "type": "string",
           "description": "BaseURL is the base url of the OCI registry (host + optional port).\nShould not include repository paths - use SubPath for that.\n\nExamples:\n- \"https://registry.example.com\"\n- \"https://registry.example.com:5000\"\n- \"oci://registry.example.com:5000\"\n- \"docker.io\"\n- \"ghcr.io\"\n\nIf BaseUrl contains a path (e.g., \"ghcr.io/org/repo\"),\nthe path will be auto-extracted and used as SubPath."
         },
+        "componentVersionLayout": {
+          "type": "string",
+          "description": "ComponentVersionLayout selects the storage layout used when adding component versions\nto this repository. \"\" or \"v2\" = the default access-bearing manifest; \"normalized\" = the\ncosign-signable normalized layout (a stable, access-free manifest as the tag target)."
+        },
         "subPath": {
           "type": "string",
           "description": "SubPath is an optional repository prefix path used for the OCM repository.\nThe OCM-based artifacts will use this path as a repository prefix.\nAn OCI registry may host many OCM repositories with different repository prefixes.\n\nAuto-extraction: If not specified and BaseUrl contains a path component,\nthe path will be automatically extracted and used as SubPath.\n\nExamples:\nExplicit separation:\nBaseUrl=\"ghcr.io\" + SubPath=\"open-component-model/ocm\"\n→ Registry: ghcr.io, Repository prefix: open-component-model/ocm\n\nEmbedded path:\nBaseUrl=\"ghcr.io/open-component-model/ocm\" + SubPath=\"\"\n→ Auto-extracts to: BaseUrl=\"ghcr.io\", SubPath=\"open-component-model/ocm\""

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIAddLocalResourceSpec.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIAddLocalResourceSpec.schema.json
@@ -331,6 +331,10 @@
           "type": "string",
           "description": "BaseURL is the base url of the OCI registry (host + optional port).\nShould not include repository paths - use SubPath for that.\n\nExamples:\n- \"https://registry.example.com\"\n- \"https://registry.example.com:5000\"\n- \"oci://registry.example.com:5000\"\n- \"docker.io\"\n- \"ghcr.io\"\n\nIf BaseUrl contains a path (e.g., \"ghcr.io/org/repo\"),\nthe path will be auto-extracted and used as SubPath."
         },
+        "componentVersionLayout": {
+          "type": "string",
+          "description": "ComponentVersionLayout selects the storage layout used when adding component versions\nto this repository. \"\" or \"v2\" = the default access-bearing manifest; \"normalized\" = the\ncosign-signable normalized layout (a stable, access-free manifest as the tag target)."
+        },
         "subPath": {
           "type": "string",
           "description": "SubPath is an optional repository prefix path used for the OCM repository.\nThe OCM-based artifacts will use this path as a repository prefix.\nAn OCI registry may host many OCM repositories with different repository prefixes.\n\nAuto-extraction: If not specified and BaseUrl contains a path component,\nthe path will be automatically extracted and used as SubPath.\n\nExamples:\nExplicit separation:\nBaseUrl=\"ghcr.io\" + SubPath=\"open-component-model/ocm\"\n→ Registry: ghcr.io, Repository prefix: open-component-model/ocm\n\nEmbedded path:\nBaseUrl=\"ghcr.io/open-component-model/ocm\" + SubPath=\"\"\n→ Auto-extracts to: BaseUrl=\"ghcr.io\", SubPath=\"open-component-model/ocm\""

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIGetComponentVersion.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIGetComponentVersion.schema.json
@@ -755,6 +755,10 @@
           "type": "string",
           "description": "BaseURL is the base url of the OCI registry (host + optional port).\nShould not include repository paths - use SubPath for that.\n\nExamples:\n- \"https://registry.example.com\"\n- \"https://registry.example.com:5000\"\n- \"oci://registry.example.com:5000\"\n- \"docker.io\"\n- \"ghcr.io\"\n\nIf BaseUrl contains a path (e.g., \"ghcr.io/org/repo\"),\nthe path will be auto-extracted and used as SubPath."
         },
+        "componentVersionLayout": {
+          "type": "string",
+          "description": "ComponentVersionLayout selects the storage layout used when adding component versions\nto this repository. \"\" or \"v2\" = the default access-bearing manifest; \"normalized\" = the\ncosign-signable normalized layout (a stable, access-free manifest as the tag target)."
+        },
         "subPath": {
           "type": "string",
           "description": "SubPath is an optional repository prefix path used for the OCM repository.\nThe OCM-based artifacts will use this path as a repository prefix.\nAn OCI registry may host many OCM repositories with different repository prefixes.\n\nAuto-extraction: If not specified and BaseUrl contains a path component,\nthe path will be automatically extracted and used as SubPath.\n\nExamples:\nExplicit separation:\nBaseUrl=\"ghcr.io\" + SubPath=\"open-component-model/ocm\"\n→ Registry: ghcr.io, Repository prefix: open-component-model/ocm\n\nEmbedded path:\nBaseUrl=\"ghcr.io/open-component-model/ocm\" + SubPath=\"\"\n→ Auto-extracts to: BaseUrl=\"ghcr.io\", SubPath=\"open-component-model/ocm\""

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIGetComponentVersionSpec.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIGetComponentVersionSpec.schema.json
@@ -34,6 +34,10 @@
           "type": "string",
           "description": "BaseURL is the base url of the OCI registry (host + optional port).\nShould not include repository paths - use SubPath for that.\n\nExamples:\n- \"https://registry.example.com\"\n- \"https://registry.example.com:5000\"\n- \"oci://registry.example.com:5000\"\n- \"docker.io\"\n- \"ghcr.io\"\n\nIf BaseUrl contains a path (e.g., \"ghcr.io/org/repo\"),\nthe path will be auto-extracted and used as SubPath."
         },
+        "componentVersionLayout": {
+          "type": "string",
+          "description": "ComponentVersionLayout selects the storage layout used when adding component versions\nto this repository. \"\" or \"v2\" = the default access-bearing manifest; \"normalized\" = the\ncosign-signable normalized layout (a stable, access-free manifest as the tag target)."
+        },
         "subPath": {
           "type": "string",
           "description": "SubPath is an optional repository prefix path used for the OCM repository.\nThe OCM-based artifacts will use this path as a repository prefix.\nAn OCI registry may host many OCM repositories with different repository prefixes.\n\nAuto-extraction: If not specified and BaseUrl contains a path component,\nthe path will be automatically extracted and used as SubPath.\n\nExamples:\nExplicit separation:\nBaseUrl=\"ghcr.io\" + SubPath=\"open-component-model/ocm\"\n→ Registry: ghcr.io, Repository prefix: open-component-model/ocm\n\nEmbedded path:\nBaseUrl=\"ghcr.io/open-component-model/ocm\" + SubPath=\"\"\n→ Auto-extracts to: BaseUrl=\"ghcr.io\", SubPath=\"open-component-model/ocm\""

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIGetLocalResource.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIGetLocalResource.schema.json
@@ -305,6 +305,10 @@
           "type": "string",
           "description": "BaseURL is the base url of the OCI registry (host + optional port).\nShould not include repository paths - use SubPath for that.\n\nExamples:\n- \"https://registry.example.com\"\n- \"https://registry.example.com:5000\"\n- \"oci://registry.example.com:5000\"\n- \"docker.io\"\n- \"ghcr.io\"\n\nIf BaseUrl contains a path (e.g., \"ghcr.io/org/repo\"),\nthe path will be auto-extracted and used as SubPath."
         },
+        "componentVersionLayout": {
+          "type": "string",
+          "description": "ComponentVersionLayout selects the storage layout used when adding component versions\nto this repository. \"\" or \"v2\" = the default access-bearing manifest; \"normalized\" = the\ncosign-signable normalized layout (a stable, access-free manifest as the tag target)."
+        },
         "subPath": {
           "type": "string",
           "description": "SubPath is an optional repository prefix path used for the OCM repository.\nThe OCM-based artifacts will use this path as a repository prefix.\nAn OCI registry may host many OCM repositories with different repository prefixes.\n\nAuto-extraction: If not specified and BaseUrl contains a path component,\nthe path will be automatically extracted and used as SubPath.\n\nExamples:\nExplicit separation:\nBaseUrl=\"ghcr.io\" + SubPath=\"open-component-model/ocm\"\n→ Registry: ghcr.io, Repository prefix: open-component-model/ocm\n\nEmbedded path:\nBaseUrl=\"ghcr.io/open-component-model/ocm\" + SubPath=\"\"\n→ Auto-extracts to: BaseUrl=\"ghcr.io\", SubPath=\"open-component-model/ocm\""

--- a/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIGetLocalResourceSpec.schema.json
+++ b/bindings/go/oci/spec/transformation/v1alpha1/schemas/OCIGetLocalResourceSpec.schema.json
@@ -46,6 +46,10 @@
           "type": "string",
           "description": "BaseURL is the base url of the OCI registry (host + optional port).\nShould not include repository paths - use SubPath for that.\n\nExamples:\n- \"https://registry.example.com\"\n- \"https://registry.example.com:5000\"\n- \"oci://registry.example.com:5000\"\n- \"docker.io\"\n- \"ghcr.io\"\n\nIf BaseUrl contains a path (e.g., \"ghcr.io/org/repo\"),\nthe path will be auto-extracted and used as SubPath."
         },
+        "componentVersionLayout": {
+          "type": "string",
+          "description": "ComponentVersionLayout selects the storage layout used when adding component versions\nto this repository. \"\" or \"v2\" = the default access-bearing manifest; \"normalized\" = the\ncosign-signable normalized layout (a stable, access-free manifest as the tag target)."
+        },
         "subPath": {
           "type": "string",
           "description": "SubPath is an optional repository prefix path used for the OCM repository.\nThe OCM-based artifacts will use this path as a repository prefix.\nAn OCI registry may host many OCM repositories with different repository prefixes.\n\nAuto-extraction: If not specified and BaseUrl contains a path component,\nthe path will be automatically extracted and used as SubPath.\n\nExamples:\nExplicit separation:\nBaseUrl=\"ghcr.io\" + SubPath=\"open-component-model/ocm\"\n→ Registry: ghcr.io, Repository prefix: open-component-model/ocm\n\nEmbedded path:\nBaseUrl=\"ghcr.io/open-component-model/ocm\" + SubPath=\"\"\n→ Auto-extracts to: BaseUrl=\"ghcr.io\", SubPath=\"open-component-model/ocm\""

--- a/bindings/go/oci/spec/transformation/v1alpha1/zz_generated.deepcopy.go
+++ b/bindings/go/oci/spec/transformation/v1alpha1/zz_generated.deepcopy.go
@@ -148,6 +148,11 @@ func (in *CTFAddComponentVersionSpec) DeepCopyInto(out *CTFAddComponentVersionSp
 		*out = new(v2.Descriptor)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.SourceRepository != nil {
+		in, out := &in.SourceRepository, &out.SourceRepository
+		*out = new(runtime.Raw)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 
@@ -530,6 +535,11 @@ func (in *OCIAddComponentVersionSpec) DeepCopyInto(out *OCIAddComponentVersionSp
 	if in.Descriptor != nil {
 		in, out := &in.Descriptor, &out.Descriptor
 		*out = new(v2.Descriptor)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.SourceRepository != nil {
+		in, out := &in.SourceRepository, &out.SourceRepository
+		*out = new(runtime.Raw)
 		(*in).DeepCopyInto(*out)
 	}
 	return

--- a/bindings/go/oci/store_descriptor.go
+++ b/bindings/go/oci/store_descriptor.go
@@ -22,7 +22,19 @@ import (
 	componentConfig "ocm.software/open-component-model/bindings/go/oci/spec/config/component"
 	ocidescriptor "ocm.software/open-component-model/bindings/go/oci/spec/descriptor"
 	indexv1 "ocm.software/open-component-model/bindings/go/oci/spec/index/component/v1"
+	normalizedlayout "ocm.software/open-component-model/bindings/go/oci/spec/layout/normalized/v1"
 	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+// Layout selects the OCI storage layout for a component version.
+type Layout int
+
+const (
+	// LayoutV2 is the default: the tag resolves to the access-bearing v2 descriptor manifest.
+	LayoutV2 Layout = iota
+	// LayoutNormalized is the cosign-signable layout: the tag resolves to a stable, access-free
+	// normalized descriptor manifest, with the access-bearing descriptor stored as a referrer.
+	LayoutNormalized
 )
 
 // AddDescriptorOptions defines the options for adding a component descriptor to a Store.
@@ -33,6 +45,7 @@ type AddDescriptorOptions struct {
 	AdditionalLayers              []ociImageSpecV1.Descriptor
 	ReferrerTrackingPolicy        ReferrerTrackingPolicy
 	DescriptorEncodingMediaType   string
+	Layout                        Layout
 }
 
 // AddDescriptorToStore uploads a component descriptor to any given Store.
@@ -40,6 +53,10 @@ type AddDescriptorOptions struct {
 // It can be used to retrieve the component descriptor later.
 // To persist the descriptor, the manifest still has to be tagged.
 func AddDescriptorToStore(ctx context.Context, store spec.Store, descriptor *descriptor.Descriptor, opts AddDescriptorOptions) (*ociImageSpecV1.Descriptor, error) {
+	if opts.Layout == LayoutNormalized {
+		return addNormalizedLayout(ctx, store, descriptor, opts)
+	}
+
 	component, version := descriptor.Component.Name, descriptor.Component.Version
 
 	// we can concurrently upload certain parts of the descriptor!
@@ -196,11 +213,137 @@ It is used to store the component descriptor manifest and other related blob man
 	return &idxDescriptor, nil
 }
 
+// addNormalizedLayout uploads a component descriptor using the cosign-signable normalized layout.
+//
+// The tag target is a stable, access-free normalized manifest M whose single layer is the
+// normalized (JCS-canonical) descriptor bytes. The full access-bearing descriptor and any
+// additional local-blob layers are stored in an access manifest A that references M as its subject
+// (a referrer). A is additionally tagged with a predictable fallback tag so it can be discovered on
+// registries without the OCI referrers API.
+//
+// The returned descriptor is the normalized manifest descriptor M (untagged); the caller tags it as
+// the component reference, mirroring AddDescriptorToStore.
+func addNormalizedLayout(ctx context.Context, store spec.Store, desc *descriptor.Descriptor, opts AddDescriptorOptions) (*ociImageSpecV1.Descriptor, error) {
+	if err := normalizedlayout.RequireAllResourcesDigested(desc); err != nil {
+		return nil, err
+	}
+
+	if len(opts.AdditionalDescriptorManifests) > 0 {
+		return nil, fmt.Errorf("normalized layout stores additional local blobs as manifest layers and does not support additional descriptor manifests (nested local-blob manifests)")
+	}
+
+	component, version := desc.Component.Name, desc.Component.Version
+
+	// Build the normalized (access-free) layer that cosign signs (via the manifest digest).
+	normBytes, err := normalizedlayout.Normalize(desc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to normalize descriptor: %w", err)
+	}
+	normLayer := ociImageSpecV1.Descriptor{
+		MediaType: ocidescriptor.MediaTypeComponentDescriptorNormalizedJSON,
+		Digest:    digest.FromBytes(normBytes),
+		Size:      int64(len(normBytes)),
+	}
+
+	descriptorMediaType := opts.DescriptorEncodingMediaType
+	if descriptorMediaType == "" {
+		descriptorMediaType = ocidescriptor.MediaTypeComponentDescriptorJSON
+	}
+
+	// Encode the full, access-bearing descriptor as the access manifest layer.
+	descBuf, err := ocidescriptor.SingleFileEncodeDescriptor(opts.Scheme, desc, descriptorMediaType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode descriptor: %w", err)
+	}
+	descBytes := descBuf.Bytes()
+	descLayer := ociImageSpecV1.Descriptor{
+		MediaType: descriptorMediaType,
+		Digest:    digest.FromBytes(descBytes),
+		Size:      int64(len(descBytes)),
+	}
+
+	configRaw, configDesc, err := componentConfig.New(descLayer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal component config: %w", err)
+	}
+
+	// Push the empty config blob for the normalized manifest, tolerating pre-existence.
+	emptyConfig := ociImageSpecV1.DescriptorEmptyJSON
+	if exists, err := store.Exists(ctx, emptyConfig); err != nil {
+		return nil, fmt.Errorf("failed to check empty config existence: %w", err)
+	} else if !exists {
+		if err := store.Push(ctx, emptyConfig, bytes.NewReader(emptyConfig.Data)); err != nil {
+			return nil, fmt.Errorf("unable to push empty config: %w", err)
+		}
+	}
+
+	// Push the content blobs.
+	if err := store.Push(ctx, normLayer, bytes.NewReader(normBytes)); err != nil {
+		return nil, fmt.Errorf("unable to push normalized descriptor layer: %w", err)
+	}
+	if err := store.Push(ctx, descLayer, bytes.NewReader(descBytes)); err != nil {
+		return nil, fmt.Errorf("unable to push descriptor layer: %w", err)
+	}
+	if err := store.Push(ctx, configDesc, bytes.NewReader(configRaw)); err != nil {
+		return nil, fmt.Errorf("unable to push component config: %w", err)
+	}
+
+	// Build and push the normalized manifest (the tag target).
+	m := normalizedlayout.BuildNormalizedManifest(normLayer, component, version)
+	mRaw, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal normalized manifest: %w", err)
+	}
+	mDesc := ociImageSpecV1.Descriptor{
+		MediaType:    m.MediaType,
+		ArtifactType: m.ArtifactType,
+		Digest:       digest.FromBytes(mRaw),
+		Size:         int64(len(mRaw)),
+		Annotations:  m.Annotations,
+	}
+	slogcontext.Log(ctx, slog.LevelDebug, "pushing normalized descriptor manifest", log.DescriptorLogAttr(mDesc))
+	if err := store.Push(ctx, mDesc, bytes.NewReader(mRaw)); err != nil {
+		return nil, fmt.Errorf("unable to push normalized manifest: %w", err)
+	}
+
+	// Build and push the access manifest as a referrer of the normalized manifest.
+	a := normalizedlayout.BuildAccessManifest(mDesc, configDesc, descLayer, opts.AdditionalLayers, component, version)
+	aRaw, err := json.Marshal(a)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal access manifest: %w", err)
+	}
+	aDesc := ociImageSpecV1.Descriptor{
+		MediaType:    a.MediaType,
+		ArtifactType: a.ArtifactType,
+		Digest:       digest.FromBytes(aRaw),
+		Size:         int64(len(aRaw)),
+		Annotations:  a.Annotations,
+	}
+	slogcontext.Log(ctx, slog.LevelDebug, "pushing access descriptor manifest", log.DescriptorLogAttr(aDesc))
+	if err := store.Push(ctx, aDesc, bytes.NewReader(aRaw)); err != nil {
+		return nil, fmt.Errorf("unable to push access manifest: %w", err)
+	}
+
+	// Tag the access manifest with the predictable fallback tag for referrer-less registries.
+	if err := store.Tag(ctx, aDesc, normalizedlayout.AccessFallbackTag(mDesc.Digest.String())); err != nil {
+		return nil, fmt.Errorf("unable to tag access manifest with fallback tag: %w", err)
+	}
+
+	return &mDesc, nil
+}
+
 // getDescriptorFromStore retrieves a component descriptor from a given Store using the provided reference.
 func getDescriptorFromStore(ctx context.Context, store spec.Store, reference string, unmarshal ocidescriptor.UnmarshalFunc) (desc *descriptor.Descriptor, manifestRef *ociImageSpecV1.Manifest, index *ociImageSpecV1.Index, err error) {
 	manifest, index, err := getDescriptorOCIImageManifest(ctx, store, reference)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to get manifest: %w", err)
+	}
+
+	// This function decodes the access-bearing manifest by following its config to the component
+	// descriptor layer. A normalized-layout manifest has an empty config and no descriptor layer, so
+	// it cannot be decoded here; it must be read via the normalized read path instead.
+	if manifest.ArtifactType == ocidescriptor.ArtifactTypeNormalizedDescriptor {
+		return nil, nil, nil, fmt.Errorf("cannot decode a normalized-layout manifest here: it has no component descriptor layer; resolve it via the normalized read path")
 	}
 
 	componentConfigRaw, err := store.Fetch(ctx, manifest.Config)
@@ -214,6 +357,12 @@ func getDescriptorFromStore(ctx context.Context, store spec.Store, reference str
 
 	if closeErr := componentConfigRaw.Close(); closeErr != nil {
 		return nil, nil, nil, fmt.Errorf("failed to close component config reader: %w", closeErr)
+	}
+
+	// Defensive equivalent of the check above for when ArtifactType is absent (e.g. an intermediate
+	// proxy strips it): an empty config carries no descriptor layer.
+	if cfg.ComponentDescriptorLayer == nil {
+		return nil, nil, nil, fmt.Errorf("cannot decode a normalized-layout manifest here: it has no component descriptor layer; resolve it via the normalized read path")
 	}
 
 	// Read component descriptor

--- a/bindings/go/oci/store_normalized_read.go
+++ b/bindings/go/oci/store_normalized_read.go
@@ -1,0 +1,155 @@
+package oci
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content"
+
+	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+	"ocm.software/open-component-model/bindings/go/oci/spec"
+	ocidescriptor "ocm.software/open-component-model/bindings/go/oci/spec/descriptor"
+	normalizedlayout "ocm.software/open-component-model/bindings/go/oci/spec/layout/normalized/v1"
+)
+
+// IsNormalizedManifest reports whether a resolved manifest descriptor is the normalized-layout tag target.
+func IsNormalizedManifest(target ociImageSpecV1.Descriptor) bool {
+	return target.ArtifactType == ocidescriptor.ArtifactTypeNormalizedDescriptor
+}
+
+// GetNormalizedComponentVersion resolves the full access-bearing descriptor for a normalized
+// manifest and returns it only after the bind check passes. Selection is safety-first: only
+// bind-check survivors are trusted; survivors are ordered by their own manifest digest; resolution
+// falls through to the next survivor on any failure.
+func GetNormalizedComponentVersion(ctx context.Context, store spec.Store, normalized ociImageSpecV1.Descriptor, unmarshal ocidescriptor.UnmarshalFunc) (*descriptor.Descriptor, error) {
+	// Fetch the normalized (signed) manifest and extract its single layer bytes.
+	normManifestRaw, err := content.FetchAll(ctx, store, normalized)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch normalized manifest: %w", err)
+	}
+	var normManifest ociImageSpecV1.Manifest
+	if err := json.Unmarshal(normManifestRaw, &normManifest); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal normalized manifest: %w", err)
+	}
+	if len(normManifest.Layers) != 1 {
+		return nil, fmt.Errorf("normalized manifest %s must have exactly one layer, got %d", normalized.Digest, len(normManifest.Layers))
+	}
+	signedNormalized, err := content.FetchAll(ctx, store, normManifest.Layers[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch normalized descriptor layer: %w", err)
+	}
+
+	// Gather candidate access manifests from referrers and the predictable fallback tag, deduped.
+	seen := make(map[string]bool)
+	var candidates []ociImageSpecV1.Descriptor
+	var discoveryErr error
+
+	if predecessors, predecessorsErr := store.Predecessors(ctx, normalized); predecessorsErr != nil {
+		discoveryErr = predecessorsErr
+	} else {
+		for _, p := range predecessors {
+			key := p.Digest.String()
+			if !seen[key] {
+				seen[key] = true
+				candidates = append(candidates, p)
+			}
+		}
+	}
+
+	if fallback, resolveErr := store.Resolve(ctx, normalizedlayout.AccessFallbackTag(normalized.Digest.String())); resolveErr != nil {
+		// Preserve the fallback error only if we haven't already recorded a discovery error;
+		// both are non-fatal as long as the other source yields candidates.
+		if discoveryErr == nil {
+			discoveryErr = resolveErr
+		}
+	} else {
+		key := fallback.Digest.String()
+		if !seen[key] {
+			seen[key] = true
+			candidates = append(candidates, fallback)
+		}
+	}
+
+	// Keep only genuine access.v1 referrers whose subject is exactly the normalized manifest.
+	type keptCandidate struct {
+		desc     ociImageSpecV1.Descriptor
+		manifest ociImageSpecV1.Manifest
+	}
+	var kept []keptCandidate
+	for _, c := range candidates {
+		raw, err := content.FetchAll(ctx, store, c)
+		if err != nil {
+			continue
+		}
+		var man ociImageSpecV1.Manifest
+		if err := json.Unmarshal(raw, &man); err != nil {
+			continue
+		}
+		if man.ArtifactType != ocidescriptor.ArtifactTypeAccessDescriptor {
+			continue
+		}
+		if man.Subject == nil || man.Subject.Digest != normalized.Digest {
+			continue
+		}
+		kept = append(kept, keptCandidate{desc: c, manifest: man})
+	}
+
+	if len(kept) == 0 {
+		if discoveryErr != nil {
+			return nil, fmt.Errorf("no access.v1 referrer found for normalized manifest %s: %w", normalized.Digest, discoveryErr)
+		}
+		return nil, fmt.Errorf("no access.v1 referrer found for normalized manifest %s", normalized.Digest)
+	}
+
+	// Deterministic, attacker-proof ordering by the referrer's own manifest digest.
+	sort.Slice(kept, func(i, j int) bool {
+		return kept[i].desc.Digest.String() < kept[j].desc.Digest.String()
+	})
+
+	var lastErr error
+	for _, k := range kept {
+		if len(k.manifest.Layers) < 1 {
+			lastErr = fmt.Errorf("access manifest %s has no layers", k.desc.Digest)
+			continue
+		}
+		layer := k.manifest.Layers[0]
+		layerBytes, err := content.FetchAll(ctx, store, layer)
+		if err != nil {
+			lastErr = fmt.Errorf("failed to fetch access descriptor layer for %s: %w", k.desc.Digest, err)
+			continue
+		}
+		full, err := ocidescriptor.SingleFileDecodeDescriptor(bytes.NewReader(layerBytes), layer.MediaType, unmarshal)
+		if err != nil {
+			lastErr = fmt.Errorf("failed to decode access descriptor for %s: %w", k.desc.Digest, err)
+			continue
+		}
+		if err := normalizedlayout.VerifyNormalizedMatchesAccess(signedNormalized, full); err != nil {
+			lastErr = fmt.Errorf("bind check failed for access manifest %s: %w", k.desc.Digest, err)
+			continue
+		}
+		return full, nil
+	}
+
+	return nil, fmt.Errorf("no valid access.v1 referrer for normalized manifest %s: %w", normalized.Digest, lastErr)
+}
+
+// peekArtifactType fetches a manifest/index and returns its artifactType from the body. This is
+// needed because registries do not populate Descriptor.ArtifactType when resolving a tag; the value
+// lives inside the manifest JSON.
+func peekArtifactType(ctx context.Context, store spec.Store, target ociImageSpecV1.Descriptor) (string, error) {
+	raw, err := content.FetchAll(ctx, store, target)
+	if err != nil {
+		return "", err
+	}
+	var peek struct {
+		ArtifactType string `json:"artifactType"`
+	}
+	if err := json.Unmarshal(raw, &peek); err != nil {
+		return "", err
+	}
+	return peek.ArtifactType, nil
+}

--- a/bindings/go/oci/store_normalized_test.go
+++ b/bindings/go/oci/store_normalized_test.go
@@ -1,0 +1,182 @@
+package oci_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ociImageSpecV1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/content/memory"
+
+	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+	"ocm.software/open-component-model/bindings/go/oci"
+	componentConfig "ocm.software/open-component-model/bindings/go/oci/spec/config/component"
+	ocidescriptor "ocm.software/open-component-model/bindings/go/oci/spec/descriptor"
+	normalizedlayout "ocm.software/open-component-model/bindings/go/oci/spec/layout/normalized/v1"
+	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+func newNormalizedTestDescriptor() *descriptor.Descriptor {
+	desc := &descriptor.Descriptor{}
+	desc.Component.Name = "example.org/comp"
+	desc.Component.Version = "1.0.0"
+	desc.Component.Provider = descriptor.Provider{Name: "internal"}
+	return desc
+}
+
+func TestNormalized_RejectsAdditionalDescriptorManifests(t *testing.T) {
+	ctx := context.Background()
+	store := memory.New()
+
+	desc := newNormalizedTestDescriptor()
+
+	_, err := oci.AddDescriptorToStore(ctx, store, desc, oci.AddDescriptorOptions{
+		Scheme:  runtime.NewScheme(runtime.WithAllowUnknown()),
+		Layout:  oci.LayoutNormalized,
+		AdditionalDescriptorManifests: []ociImageSpecV1.Descriptor{
+			{
+				Digest:    "sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+				MediaType: ociImageSpecV1.MediaTypeImageManifest,
+			},
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "additional descriptor manifests")
+}
+
+func TestNormalizedLayoutRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := memory.New()
+
+	desc := newNormalizedTestDescriptor()
+
+	mDesc, err := oci.AddDescriptorToStore(ctx, store, desc, oci.AddDescriptorOptions{
+		Scheme: runtime.NewScheme(runtime.WithAllowUnknown()),
+		Layout: oci.LayoutNormalized,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, mDesc)
+	require.Equal(t, ocidescriptor.ArtifactTypeNormalizedDescriptor, mDesc.ArtifactType)
+	require.True(t, oci.IsNormalizedManifest(*mDesc))
+
+	got, err := oci.GetNormalizedComponentVersion(ctx, store, *mDesc, ocidescriptor.DefaultDescriptorUnmarshalFunc)
+	require.NoError(t, err)
+	require.Equal(t, "example.org/comp", got.Component.Name)
+	require.Equal(t, "1.0.0", got.Component.Version)
+}
+
+// TestNormalizedLayoutSkipsTamperedReferrer verifies that GetNormalizedComponentVersion
+// rejects a tampered access manifest (whose descriptor does not re-normalise to the signed
+// bytes) and falls through to the legitimate one.
+//
+// The test is written so that the TAMPERED access manifest's digest sorts LEXICOGRAPHICALLY
+// BEFORE the valid one. The read path processes candidates in ascending-digest order, so the
+// tampered manifest is tried first. The test can only pass if the bind check fires and the
+// code falls through — it is NOT sufficient for the valid manifest to simply sort first.
+func TestNormalizedLayoutSkipsTamperedReferrer(t *testing.T) {
+	ctx := context.Background()
+	store := memory.New()
+	scheme := runtime.NewScheme(runtime.WithAllowUnknown())
+
+	desc := newNormalizedTestDescriptor()
+
+	mDesc, err := oci.AddDescriptorToStore(ctx, store, desc, oci.AddDescriptorOptions{
+		Scheme: scheme,
+		Layout: oci.LayoutNormalized,
+	})
+	require.NoError(t, err)
+
+	// Determine the digest of the valid access manifest that was just written so we know
+	// what we need to beat lexicographically.
+	predecessors, err := store.Predecessors(ctx, *mDesc)
+	require.NoError(t, err)
+	var validAccessDesc ociImageSpecV1.Descriptor
+	for _, p := range predecessors {
+		// The access manifest is the one referrer with ArtifactTypeAccessDescriptor.
+		if p.ArtifactType == ocidescriptor.ArtifactTypeAccessDescriptor {
+			validAccessDesc = p
+			break
+		}
+	}
+	require.NotEmpty(t, validAccessDesc.Digest, "could not find valid access manifest among predecessors")
+
+	// Build a TAMPERED access manifest whose descriptor digest sorts BEFORE the valid one.
+	// We iterate over candidate tampered component names until the tampered manifest's digest
+	// compares less than the valid manifest's digest string. This is robust: we never hardcode
+	// a lucky value — the loop finds one deterministically within very few iterations.
+	const maxAttempts = 1000
+	var (
+		tamperedAccessDesc ociImageSpecV1.Descriptor
+		tamperedAccessRaw  []byte
+		tamperedLayer      ociImageSpecV1.Descriptor
+		tamperedLayerBytes []byte
+		tamperedConfigRaw  []byte
+		tamperedConfigDesc ociImageSpecV1.Descriptor
+		tamperedName       string
+	)
+	found := false
+	for i := 0; i < maxAttempts; i++ {
+		tamperedName = fmt.Sprintf("example.org/evil-%d", i)
+		evil := newNormalizedTestDescriptor()
+		evil.Component.Name = tamperedName // differs from valid in a signed field → bind check fails
+
+		evilBuf, err := ocidescriptor.SingleFileEncodeDescriptor(scheme, evil, ocidescriptor.MediaTypeComponentDescriptorJSON)
+		require.NoError(t, err)
+		evilBytes := evilBuf.Bytes()
+		evilLayerDesc := ociImageSpecV1.Descriptor{
+			MediaType: ocidescriptor.MediaTypeComponentDescriptorJSON,
+			Digest:    digest.FromBytes(evilBytes),
+			Size:      int64(len(evilBytes)),
+		}
+
+		cfgRaw, cfgDesc, err := componentConfig.New(evilLayerDesc)
+		require.NoError(t, err)
+
+		evilManifest := normalizedlayout.BuildAccessManifest(*mDesc, cfgDesc, evilLayerDesc, nil, tamperedName, evil.Component.Version)
+		evilRaw, err := json.Marshal(evilManifest)
+		require.NoError(t, err)
+		evilDesc := ociImageSpecV1.Descriptor{
+			MediaType:    evilManifest.MediaType,
+			ArtifactType: evilManifest.ArtifactType,
+			Digest:       digest.FromBytes(evilRaw),
+			Size:         int64(len(evilRaw)),
+			Annotations:  evilManifest.Annotations,
+		}
+
+		if evilDesc.Digest.String() < validAccessDesc.Digest.String() {
+			// Found a tampered descriptor that will be tried FIRST by the read path.
+			tamperedAccessDesc = evilDesc
+			tamperedAccessRaw = evilRaw
+			tamperedLayer = evilLayerDesc
+			tamperedLayerBytes = evilBytes
+			tamperedConfigRaw = cfgRaw
+			tamperedConfigDesc = cfgDesc
+			found = true
+			break
+		}
+	}
+	require.True(t, found,
+		"could not find a tampered access manifest digest that sorts before the valid one in %d attempts; "+
+			"the test logic needs revisiting", maxAttempts)
+
+	// Push all blobs for the winning tampered manifest.
+	require.NoError(t, store.Push(ctx, tamperedLayer, bytes.NewReader(tamperedLayerBytes)))
+	require.NoError(t, store.Push(ctx, tamperedConfigDesc, bytes.NewReader(tamperedConfigRaw)))
+	require.NoError(t, store.Push(ctx, tamperedAccessDesc, bytes.NewReader(tamperedAccessRaw)))
+
+	// The tampered access manifest now sorts BEFORE the valid one. GetNormalizedComponentVersion
+	// MUST run the bind check (which rejects it) and fall through to the valid manifest.
+	// If the bind check were removed, this assertion would fail because the tampered name
+	// "example.org/evil-*" would be returned instead of "example.org/comp".
+	got, err := oci.GetNormalizedComponentVersion(ctx, store, *mDesc, ocidescriptor.DefaultDescriptorUnmarshalFunc)
+	require.NoError(t, err)
+	require.Equal(t, "example.org/comp", got.Component.Name,
+		"bind check must reject the tampered referrer (digest %s, sorts before valid %s) "+
+			"and fall through to the legitimate one",
+		tamperedAccessDesc.Digest, validAccessDesc.Digest)
+	require.Equal(t, "1.0.0", got.Component.Version)
+}

--- a/bindings/go/oci/transformer/add_component_version.go
+++ b/bindings/go/oci/transformer/add_component_version.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"ocm.software/open-component-model/bindings/go/credentials"
 	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
@@ -28,14 +29,21 @@ func (t *AddComponentVersion) Transform(ctx context.Context, step runtime.Typed)
 		return nil, fmt.Errorf("failed converting generic transformation to download component transformation: %w", err)
 	}
 	var repoSpec runtime.Typed
+	var sourceRepoSpec runtime.Typed
 	var v2desc *v2.Descriptor
 	switch tr := transformation.(type) {
 	case *v1alpha1.OCIAddComponentVersion:
 		repoSpec = &tr.Spec.Repository
 		v2desc = tr.Spec.Descriptor
+		if tr.Spec.SourceRepository != nil {
+			sourceRepoSpec = tr.Spec.SourceRepository
+		}
 	case *v1alpha1.CTFAddComponentVersion:
 		repoSpec = &tr.Spec.Repository
 		v2desc = tr.Spec.Descriptor
+		if tr.Spec.SourceRepository != nil {
+			sourceRepoSpec = tr.Spec.SourceRepository
+		}
 	default:
 		return nil, fmt.Errorf("unexpected transformation type: %T", transformation)
 	}
@@ -66,5 +74,50 @@ func (t *AddComponentVersion) Transform(ctx context.Context, step runtime.Typed)
 			desc.Component.Name, desc.Component.Version, err)
 	}
 
+	// If a source repository was threaded into the step, attempt to carry
+	// component-level signature referrers (e.g. cosign signatures) from the
+	// source into the target. This is an OPTIONAL enhancement: the component
+	// version has already been transferred successfully above, so a failure to
+	// carry signatures must NOT fail the transfer. It is a genuine no-op for
+	// targets that do not implement signature carrying, for non-OCI sources,
+	// and whenever source and target do not resolve the same component-manifest
+	// digest (only the normalized layout preserves it).
+	if sourceRepoSpec != nil {
+		if err := t.carrySignatures(ctx, repo, sourceRepoSpec, desc); err != nil {
+			slog.WarnContext(ctx, "component transferred, but carrying signature referrers failed",
+				slog.String("component", desc.Component.Name),
+				slog.String("version", desc.Component.Version),
+				slog.Any("error", err))
+		}
+	}
+
 	return transformation, nil
+}
+
+// carrySignatures copies component-manifest signature referrers from the source repository (built
+// from sourceRepoSpec) into the target repo, when the target supports it. Returns an error so the
+// caller can log it; callers MUST treat the error as non-fatal (the transfer already succeeded).
+func (t *AddComponentVersion) carrySignatures(ctx context.Context, target repository.ComponentVersionRepository, sourceRepoSpec runtime.Typed, desc *descriptor.Descriptor) error {
+	carrier, ok := target.(repository.ComponentSignatureCarrier)
+	if !ok {
+		return nil // target cannot carry signatures; nothing to do
+	}
+	var srcCreds runtime.Typed
+	if t.CredentialProvider != nil {
+		if consumerId, err := t.RepoProvider.GetComponentVersionRepositoryCredentialConsumerIdentity(ctx, sourceRepoSpec); err == nil {
+			if srcCreds, err = t.CredentialProvider.Resolve(ctx, consumerId); err != nil {
+				if !errors.Is(err, credentials.ErrNotFound) {
+					return fmt.Errorf("resolve source credentials for signature carry: %w", err)
+				}
+			}
+		}
+	}
+	srcRepo, err := t.RepoProvider.GetComponentVersionRepository(ctx, sourceRepoSpec, srcCreds)
+	if err != nil {
+		return fmt.Errorf("open source repository for signature carry: %w", err)
+	}
+	if err := carrier.CarryComponentSignatures(ctx, srcRepo, desc.Component.Name, desc.Component.Version); err != nil {
+		return fmt.Errorf("carry component signatures: %w", err)
+	}
+	return nil
 }

--- a/bindings/go/oci/transformer/add_component_version_test.go
+++ b/bindings/go/oci/transformer/add_component_version_test.go
@@ -1,0 +1,186 @@
+package transformer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+	v2 "ocm.software/open-component-model/bindings/go/descriptor/v2"
+	ocispec "ocm.software/open-component-model/bindings/go/oci/spec/repository/v1/oci"
+	"ocm.software/open-component-model/bindings/go/oci/spec/transformation/v1alpha1"
+	"ocm.software/open-component-model/bindings/go/repository"
+	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+// carrierTargetRepo implements both ComponentVersionRepository and
+// repository.ComponentSignatureCarrier. It records whether AddComponentVersion
+// and CarryComponentSignatures were invoked and with which arguments.
+type carrierTargetRepo struct {
+	repository.ComponentVersionRepository
+
+	addedDescriptor *descriptor.Descriptor
+
+	carryCalled    bool
+	carrySource    repository.ComponentVersionRepository
+	carryComponent string
+	carryVersion   string
+}
+
+func (m *carrierTargetRepo) AddComponentVersion(ctx context.Context, desc *descriptor.Descriptor) error {
+	m.addedDescriptor = desc
+	return nil
+}
+
+func (m *carrierTargetRepo) CarryComponentSignatures(ctx context.Context, source repository.ComponentVersionRepository, component, version string) error {
+	m.carryCalled = true
+	m.carrySource = source
+	m.carryComponent = component
+	m.carryVersion = version
+	return nil
+}
+
+// sourceStubRepo is a minimal source repository stub returned by the provider
+// when opening the source spec for signature carrying.
+type sourceStubRepo struct {
+	repository.ComponentVersionRepository
+}
+
+// carrierRepoProvider returns the target repo for the target spec and the source
+// stub for the source spec, distinguishing them by BaseUrl.
+type carrierRepoProvider struct {
+	target        *carrierTargetRepo
+	source        *sourceStubRepo
+	sourceBaseURL string
+}
+
+func (m *carrierRepoProvider) GetComponentVersionRepositoryCredentialConsumerIdentity(ctx context.Context, repositorySpecification runtime.Typed) (runtime.Identity, error) {
+	return nil, nil
+}
+
+func (m *carrierRepoProvider) GetComponentVersionRepository(ctx context.Context, repositorySpecification runtime.Typed, credentials runtime.Typed) (repository.ComponentVersionRepository, error) {
+	// The source spec is threaded as a *runtime.Raw; the target spec is a concrete
+	// *oci.Repository. Route based on type to return the appropriate stub.
+	if raw, ok := repositorySpecification.(*runtime.Raw); ok {
+		_ = raw
+		return m.source, nil
+	}
+	return m.target, nil
+}
+
+func (m *carrierRepoProvider) GetJSONSchemaForRepositorySpecification(typ runtime.Type) ([]byte, error) {
+	return nil, nil
+}
+
+func newAddComponentVersionScheme() *runtime.Scheme {
+	combinedScheme := runtime.NewScheme()
+	v2.MustAddToScheme(combinedScheme)
+	combinedScheme.MustRegisterWithAlias(&v1alpha1.OCIAddComponentVersion{}, v1alpha1.OCIAddComponentVersionV1alpha1)
+	combinedScheme.MustRegisterWithAlias(&v1alpha1.CTFAddComponentVersion{}, v1alpha1.CTFAddComponentVersionV1alpha1)
+	return combinedScheme
+}
+
+func newTestV2Descriptor(name, version string) *v2.Descriptor {
+	return &v2.Descriptor{
+		Meta: v2.Meta{Version: "v2"},
+		Component: v2.Component{
+			ComponentMeta: v2.ComponentMeta{
+				ObjectMeta: v2.ObjectMeta{
+					Name:    name,
+					Version: version,
+				},
+			},
+			Provider: "ocm.software",
+		},
+	}
+}
+
+// TestAddComponentVersion_Transform_CarriesSignaturesWhenSourceSet verifies that
+// when the upload step carries a SourceRepository spec, the transformer invokes
+// CarryComponentSignatures on the target (which implements
+// repository.ComponentSignatureCarrier) with the correct component/version and a
+// non-nil source repository.
+func TestAddComponentVersion_Transform_CarriesSignaturesWhenSourceSet(t *testing.T) {
+	ctx := context.Background()
+
+	target := &carrierTargetRepo{}
+	source := &sourceStubRepo{}
+	provider := &carrierRepoProvider{target: target, source: source, sourceBaseURL: "ghcr.io/source"}
+
+	transformer := &AddComponentVersion{
+		Scheme:       newAddComponentVersionScheme(),
+		RepoProvider: provider,
+	}
+
+	sourceSpec := &runtime.Raw{
+		Type: runtime.NewVersionedType(ocispec.Type, "v1"),
+		Data: []byte(`{"type":"OCIRepository/v1","baseUrl":"ghcr.io/source"}`),
+	}
+
+	step := &v1alpha1.OCIAddComponentVersion{
+		Type: runtime.NewVersionedType(v1alpha1.OCIAddComponentVersionType, v1alpha1.Version),
+		ID:   "test-upload",
+		Spec: &v1alpha1.OCIAddComponentVersionSpec{
+			Repository: ocispec.Repository{
+				Type:    runtime.NewVersionedType(ocispec.Type, "v1"),
+				BaseUrl: "ghcr.io/target",
+			},
+			Descriptor:       newTestV2Descriptor("ocm.software/test-component", "1.0.0"),
+			SourceRepository: sourceSpec,
+		},
+	}
+
+	result, err := transformer.Transform(ctx, step)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// The component version must have been added to the target.
+	require.NotNil(t, target.addedDescriptor)
+	assert.Equal(t, "ocm.software/test-component", target.addedDescriptor.Component.Name)
+	assert.Equal(t, "1.0.0", target.addedDescriptor.Component.Version)
+
+	// The carrier must have been invoked with the correct component/version and a
+	// non-nil source repository.
+	assert.True(t, target.carryCalled, "CarryComponentSignatures should have been called")
+	assert.Equal(t, "ocm.software/test-component", target.carryComponent)
+	assert.Equal(t, "1.0.0", target.carryVersion)
+	require.NotNil(t, target.carrySource, "carry source repository must be non-nil")
+	assert.Same(t, source, target.carrySource, "carry source must be the source stub returned by the provider")
+}
+
+// TestAddComponentVersion_Transform_NoCarryWhenSourceNil verifies that when the
+// upload step does NOT carry a SourceRepository spec, the carrier is not invoked.
+func TestAddComponentVersion_Transform_NoCarryWhenSourceNil(t *testing.T) {
+	ctx := context.Background()
+
+	target := &carrierTargetRepo{}
+	source := &sourceStubRepo{}
+	provider := &carrierRepoProvider{target: target, source: source}
+
+	transformer := &AddComponentVersion{
+		Scheme:       newAddComponentVersionScheme(),
+		RepoProvider: provider,
+	}
+
+	step := &v1alpha1.OCIAddComponentVersion{
+		Type: runtime.NewVersionedType(v1alpha1.OCIAddComponentVersionType, v1alpha1.Version),
+		ID:   "test-upload",
+		Spec: &v1alpha1.OCIAddComponentVersionSpec{
+			Repository: ocispec.Repository{
+				Type:    runtime.NewVersionedType(ocispec.Type, "v1"),
+				BaseUrl: "ghcr.io/target",
+			},
+			Descriptor: newTestV2Descriptor("ocm.software/test-component", "1.0.0"),
+			// SourceRepository intentionally left nil.
+		},
+	}
+
+	result, err := transformer.Transform(ctx, step)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	require.NotNil(t, target.addedDescriptor)
+	assert.False(t, target.carryCalled, "CarryComponentSignatures must NOT be called when SourceRepository is nil")
+}

--- a/bindings/go/oci/transformer_carry_signatures_test.go
+++ b/bindings/go/oci/transformer_carry_signatures_test.go
@@ -1,0 +1,151 @@
+package oci_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"ocm.software/open-component-model/bindings/go/ctf"
+	descruntime "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+	"ocm.software/open-component-model/bindings/go/oci"
+	ocictf "ocm.software/open-component-model/bindings/go/oci/ctf"
+	ocidescriptor "ocm.software/open-component-model/bindings/go/oci/spec/descriptor"
+	ocispec "ocm.software/open-component-model/bindings/go/oci/spec/repository/v1/oci"
+	transformerv1alpha1 "ocm.software/open-component-model/bindings/go/oci/spec/transformation/v1alpha1"
+	"ocm.software/open-component-model/bindings/go/oci/transformer"
+	"ocm.software/open-component-model/bindings/go/repository"
+	"ocm.software/open-component-model/bindings/go/runtime"
+
+	"ocm.software/open-component-model/bindings/go/blob/filesystem"
+	v2 "ocm.software/open-component-model/bindings/go/descriptor/v2"
+)
+
+// staticRepoProvider returns pre-built source and target repositories, routing on
+// the runtime type of the requested spec: the concrete *oci.Repository spec maps
+// to the target, and the raw source spec maps to the source. This lets the real
+// AddComponentVersion transformer drive the true carry path against real
+// normalized-layout OCI repositories.
+type staticRepoProvider struct {
+	target repository.ComponentVersionRepository
+	source repository.ComponentVersionRepository
+}
+
+func (p *staticRepoProvider) GetComponentVersionRepositoryCredentialConsumerIdentity(ctx context.Context, repositorySpecification runtime.Typed) (runtime.Identity, error) {
+	return nil, nil
+}
+
+func (p *staticRepoProvider) GetComponentVersionRepository(ctx context.Context, repositorySpecification runtime.Typed, credentials runtime.Typed) (repository.ComponentVersionRepository, error) {
+	// The source spec is threaded into the step as a *runtime.Raw; the target spec
+	// is the concrete *oci.Repository.
+	if _, ok := repositorySpecification.(*runtime.Raw); ok {
+		return p.source, nil
+	}
+	return p.target, nil
+}
+
+func (p *staticRepoProvider) GetJSONSchemaForRepositorySpecification(typ runtime.Type) ([]byte, error) {
+	return nil, nil
+}
+
+// TestTransfer_AddComponentVersion_CarriesReferrerEndToEnd exercises the true carry
+// path through the AddComponentVersion transformer: it adds the component version
+// to a real normalized-layout target OCI repository and then carries a cosign-type
+// referrer from a real normalized-layout source, while the OCM-managed access
+// referrer is skipped.
+//
+// Approach: rather than build and execute a full transfer graph (which requires a
+// broad harness), this test drives the AddComponentVersion transformer directly
+// with a step whose spec carries the source repository, using real source+target
+// OCI repositories. This still exercises the genuine end-to-end carry path
+// (Transform -> repo.AddComponentVersion -> CarryComponentSignatures).
+func TestTransfer_AddComponentVersion_CarriesReferrerEndToEnd(t *testing.T) {
+	r := require.New(t)
+	ctx := context.Background()
+
+	// Real source repository (normalized layout) backed by an in-memory CTF store.
+	srcFS, err := filesystem.NewFS(t.TempDir(), os.O_RDWR)
+	r.NoError(err)
+	srcCTF := ocictf.NewFromCTF(ctf.NewFileSystemCTF(srcFS))
+	src := Repository(t, ocictf.WithCTF(srcCTF), oci.WithComponentVersionLayout(oci.LayoutNormalized))
+
+	// Real target repository (normalized layout) backed by an in-memory CTF store.
+	dstFS, err := filesystem.NewFS(t.TempDir(), os.O_RDWR)
+	r.NoError(err)
+	dstCTF := ocictf.NewFromCTF(ctf.NewFileSystemCTF(dstFS))
+	dst := Repository(t, ocictf.WithCTF(dstCTF), oci.WithComponentVersionLayout(oci.LayoutNormalized))
+
+	const compName, compVersion = "example.org/comp", "1.0.0"
+
+	// Seed the SOURCE with the component version so that its normalized manifest and
+	// referrers exist to be carried.
+	desc := simpleDescriptor(compName, compVersion)
+	r.NoError(src.AddComponentVersion(ctx, desc))
+
+	// Push a cosign-type (non-access) referrer and an OCM access referrer onto the
+	// source component manifest.
+	srcRef := srcCTF.ComponentVersionReference(ctx, compName, compVersion)
+	srcStore, err := srcCTF.StoreForReference(ctx, srcRef)
+	r.NoError(err)
+	srcManifest, err := srcStore.Resolve(ctx, srcRef)
+	r.NoError(err)
+	cosignReferrer := pushReferrer(t, ctx, srcStore, srcManifest, "application/vnd.dev.cosign.simplesigning.v1+json")
+	accessReferrer := pushReferrer(t, ctx, srcStore, srcManifest, ocidescriptor.ArtifactTypeAccessDescriptor)
+
+	// Build the v2 descriptor for the upload step.
+	v2desc, err := descruntime.ConvertToV2(runtime.NewScheme(runtime.WithAllowUnknown()), desc)
+	r.NoError(err)
+
+	// Wire the real transformer with a provider returning the real repos.
+	scheme := runtime.NewScheme()
+	v2.MustAddToScheme(scheme)
+	scheme.MustRegisterWithAlias(&transformerv1alpha1.OCIAddComponentVersion{}, transformerv1alpha1.OCIAddComponentVersionV1alpha1)
+	scheme.MustRegisterWithAlias(&transformerv1alpha1.CTFAddComponentVersion{}, transformerv1alpha1.CTFAddComponentVersionV1alpha1)
+
+	provider := &staticRepoProvider{target: dst, source: src}
+	tr := &transformer.AddComponentVersion{
+		Scheme:       scheme,
+		RepoProvider: provider,
+	}
+
+	// The step carries the source repository so the carry runs after the add.
+	sourceSpec := &runtime.Raw{
+		Type: runtime.NewVersionedType(ocispec.Type, "v1"),
+		Data: []byte(`{"type":"OCIRepository/v1","baseUrl":"source"}`),
+	}
+	step := &transformerv1alpha1.OCIAddComponentVersion{
+		Type: runtime.NewVersionedType(transformerv1alpha1.OCIAddComponentVersionType, transformerv1alpha1.Version),
+		ID:   "upload",
+		Spec: &transformerv1alpha1.OCIAddComponentVersionSpec{
+			Repository: ocispec.Repository{
+				Type:    runtime.NewVersionedType(ocispec.Type, "v1"),
+				BaseUrl: "target",
+			},
+			Descriptor:       v2desc,
+			SourceRepository: sourceSpec,
+		},
+	}
+
+	_, err = tr.Transform(ctx, step)
+	r.NoError(err)
+
+	// Resolve the target component manifest and confirm the digest matches the source
+	// (normalized layout preserves the component-manifest digest).
+	dstRef := dstCTF.ComponentVersionReference(ctx, compName, compVersion)
+	dstStore, err := dstCTF.StoreForReference(ctx, dstRef)
+	r.NoError(err)
+	dstManifest, err := dstStore.Resolve(ctx, dstRef)
+	r.NoError(err)
+	r.Equal(srcManifest.Digest, dstManifest.Digest, "target normalized manifest digest must match source")
+
+	// The cosign referrer must have been carried into the target.
+	existsCosign, err := dstStore.Exists(ctx, cosignReferrer)
+	r.NoError(err)
+	r.True(existsCosign, "the cosign referrer must be carried into the target through the transfer path")
+
+	// The OCM access referrer from the source must NOT have been copied.
+	existsAccess, err := dstStore.Exists(ctx, accessReferrer)
+	r.NoError(err)
+	r.False(existsAccess, "the source access referrer must be skipped, not carried")
+}

--- a/bindings/go/repository/interface.go
+++ b/bindings/go/repository/interface.go
@@ -65,6 +65,15 @@ type ComponentVersionRepository interface {
 	LocalSourceRepository
 }
 
+// ComponentSignatureCarrier is an optional capability implemented by repositories that can copy a
+// component version manifest's external referrers (e.g. cosign signatures/attestations) from a
+// source repository into themselves. Implementations MUST skip OCM-managed referrers (the access
+// descriptor) and only carry referrers that remain valid because the component manifest digest is
+// preserved across the copy (the normalized layout).
+type ComponentSignatureCarrier interface {
+	CarryComponentSignatures(ctx context.Context, source ComponentVersionRepository, component, version string) error
+}
+
 // LocalResourceRepository defines the interface for managing local resources within a component version repository.
 // Local resources are artifacts that are stored directly in the repository rather than referenced externally.
 type LocalResourceRepository interface {

--- a/bindings/go/transfer/internal/graph.go
+++ b/bindings/go/transfer/internal/graph.go
@@ -213,7 +213,7 @@ func fillGraphDefinitionWithPrefetchedComponents(
 			}
 			allFileRefs = append(allFileRefs, fileRefs...)
 
-			if err := addUploadTransformation(v2desc, id, baseID, target, tgd, resourceTransformIDs); err != nil {
+			if err := addUploadTransformation(v2desc, id, baseID, target, val.SourceRepository, tgd, resourceTransformIDs); err != nil {
 				return err
 			}
 		}
@@ -353,7 +353,7 @@ func addDescriptorToEnvironment(v2desc *descriptorv2.Descriptor, id string, tgd 
 // addUploadTransformation creates the final upload (AddComponentVersion) transformation
 // for a component, reconstructing the descriptor with CEL references to modified resources.
 // envID is the base ID used to reference the descriptor in the environment (without target suffix).
-func addUploadTransformation(v2desc *descriptorv2.Descriptor, id string, envID string, toSpec runtime.Typed, tgd *transformv1alpha1.TransformationGraphDefinition, resourceTransformIDs map[int]string) error {
+func addUploadTransformation(v2desc *descriptorv2.Descriptor, id string, envID string, toSpec runtime.Typed, fromSpec runtime.Typed, tgd *transformv1alpha1.TransformationGraphDefinition, resourceTransformIDs map[int]string) error {
 	descriptorSpec := buildDescriptorSpec(v2desc, envID, resourceTransformIDs)
 
 	addType, err := chooseAddType(toSpec)
@@ -366,15 +366,30 @@ func addUploadTransformation(v2desc *descriptorv2.Descriptor, id string, envID s
 		return fmt.Errorf("cannot convert target spec to unstructured: %w", err)
 	}
 
+	specData := map[string]any{
+		"repository": toRepo.Data,
+		"descriptor": descriptorSpec,
+	}
+
+	// Thread the source repository spec into the upload step so the add
+	// transformer can carry component-level signature referrers (e.g. cosign
+	// signatures) from the source into the target. This is a no-op for targets
+	// that do not implement signature carrying or when source and target do not
+	// resolve the same manifest digest.
+	if fromSpec != nil {
+		fromRepo, err := asUnstructured(fromSpec)
+		if err != nil {
+			return fmt.Errorf("cannot convert source spec to unstructured: %w", err)
+		}
+		specData["sourceRepository"] = fromRepo.Data
+	}
+
 	upload := transformv1alpha1.GenericTransformation{
 		TransformationMeta: meta.TransformationMeta{
 			Type: addType,
 			ID:   id + "Upload",
 		},
-		Spec: &runtime.Unstructured{Data: map[string]any{
-			"repository": toRepo.Data,
-			"descriptor": descriptorSpec,
-		}},
+		Spec: &runtime.Unstructured{Data: specData},
 	}
 
 	tgd.Transformations = append(tgd.Transformations, upload)

--- a/cli/cmd/add/component-version/cmd.go
+++ b/cli/cmd/add/component-version/cmd.go
@@ -35,6 +35,7 @@ import (
 	"ocm.software/open-component-model/cli/internal/flags/enum"
 	"ocm.software/open-component-model/cli/internal/flags/file"
 	"ocm.software/open-component-model/cli/internal/flags/log"
+	"ocm.software/open-component-model/cli/internal/layout"
 	"ocm.software/open-component-model/cli/internal/render"
 	"ocm.software/open-component-model/cli/internal/render/graph/list"
 	"ocm.software/open-component-model/cli/internal/render/graph/tree"
@@ -52,6 +53,7 @@ const (
 	FlagSkipReferenceDigestProcessing      = "skip-reference-digest-processing"
 	FlagOutput                             = "output"
 	FlagDisplayMode                        = "display-mode"
+	FlagLayout                             = "layout"
 
 	DefaultComponentConstructorBaseName = "component-constructor"
 	LegacyDefaultArchiveName            = "transport-archive"
@@ -225,6 +227,7 @@ add component-version --%[1]s ./archive --%[2]s %[3]s.yaml
 	enum.Var(cmd.Flags(), FlagComponentVersionConflictPolicy, ComponentVersionConflictPolicies(), "policy to apply when a component version already exists in the repository")
 	enum.Var(cmd.Flags(), FlagExternalComponentVersionCopyPolicy, ExternalComponentVersionCopyPolicies(), "policy to apply when a component reference to a component version outside of the constructor or target repository is encountered")
 	cmd.Flags().Bool(FlagSkipReferenceDigestProcessing, false, "skip digest processing for resources and sources. Any resource referenced via access type will not have their digest updated.")
+	cmd.Flags().String(FlagLayout, "v2", "component version storage layout: v2 (default) or normalized (cosign-signable, stable digest)")
 	enum.VarP(cmd.Flags(), FlagOutput, "o", []string{render.OutputFormatTable.String(), render.OutputFormatYAML.String(), render.OutputFormatJSON.String(), render.OutputFormatNDJSON.String(), render.OutputFormatTree.String()}, "output format of the component descriptors")
 	enum.VarP(cmd.Flags(), FlagDisplayMode, "", []string{render.StaticRenderMode, render.LiveRenderMode}, `static: print the output once the complete component graph is discovered
   live (experimental): continuously updates the output to represent the current construction state of the component graph`)
@@ -299,6 +302,14 @@ func AddComponentVersion(cmd *cobra.Command, _ []string) error {
 	repoSpec, err := GetRepositorySpec(cmd)
 	if err != nil {
 		return fmt.Errorf("getting repository spec failed: %w", err)
+	}
+
+	layoutValue, err := cmd.Flags().GetString(FlagLayout)
+	if err != nil {
+		return fmt.Errorf("getting layout flag failed: %w", err)
+	}
+	if err := layout.Apply(repoSpec, layoutValue); err != nil {
+		return err
 	}
 
 	cacheDir, err := cmd.Flags().GetString(FlagBlobCacheDirectory)

--- a/cli/cmd/transfer/component-version/cmd.go
+++ b/cli/cmd/transfer/component-version/cmd.go
@@ -24,6 +24,7 @@ import (
 	transformv1alpha1 "ocm.software/open-component-model/bindings/go/transform/spec/v1alpha1"
 	ocmctx "ocm.software/open-component-model/cli/internal/context"
 	"ocm.software/open-component-model/cli/internal/flags/enum"
+	"ocm.software/open-component-model/cli/internal/layout"
 	"ocm.software/open-component-model/cli/internal/render"
 	"ocm.software/open-component-model/cli/internal/render/progress"
 	"ocm.software/open-component-model/cli/internal/render/progress/bar"
@@ -39,6 +40,7 @@ const (
 	FlagTransferSpec     = "transfer-spec"
 	FlagSemverConstraint = "semver-constraint"
 	FlagLatest           = "latest"
+	FlagLayout           = "layout"
 
 	// Each node emits 2 events (Running + Completed/Failed) and since the tracker consumes
 	// them faster than the transfer produces, 16 is enough to avoid blocking with room to grow.
@@ -155,6 +157,7 @@ transfer component-version --transfer-spec spec.yaml
 	cmd.Flags().String(FlagTransferSpec, "", "path to a transfer specification file (use \"-\" for stdin)")
 	cmd.Flags().String(FlagSemverConstraint, "", "semantic version constraint restricting which versions to transfer (e.g. \">= 1.0.0, < 2.0.0\"); only used when no version is specified in the reference")
 	cmd.Flags().Bool(FlagLatest, false, "if set, only the latest version of the component is transferred; only used when no version is specified in the reference")
+	cmd.Flags().String(FlagLayout, "v2", "component version storage layout: v2 (default) or normalized (cosign-signable, stable digest)")
 
 	return cmd
 }
@@ -169,7 +172,7 @@ func transferArgs(cmd *cobra.Command, args []string) error {
 		if len(args) > 0 {
 			return fmt.Errorf("positional arguments are not allowed when --%s is set", FlagTransferSpec)
 		}
-		ignoredFlags := []string{FlagRecursive, FlagCopyResources, FlagUploadAs}
+		ignoredFlags := []string{FlagRecursive, FlagCopyResources, FlagUploadAs, FlagLayout}
 		for _, name := range ignoredFlags {
 			if cmd.Flags().Changed(name) {
 				slog.Warn(fmt.Sprintf("--%s has no effect when --%s is set", name, FlagTransferSpec))
@@ -349,6 +352,14 @@ func buildGraphDefinitionFromArgs(
 	)
 	if err != nil {
 		return nil, fmt.Errorf("invalid target repository spec: %w", err)
+	}
+
+	layoutValue, err := cmd.Flags().GetString(FlagLayout)
+	if err != nil {
+		return nil, fmt.Errorf("getting layout flag failed: %w", err)
+	}
+	if err := layout.Apply(toSpec, layoutValue); err != nil {
+		return nil, err
 	}
 
 	transferCfg, err := transferv1alpha1.LookupConfig(cfg)

--- a/cli/internal/layout/layout.go
+++ b/cli/internal/layout/layout.go
@@ -1,0 +1,29 @@
+package layout
+
+import (
+	"fmt"
+
+	ctfrepospec "ocm.software/open-component-model/bindings/go/oci/spec/repository/v1/ctf"
+	ocirepospec "ocm.software/open-component-model/bindings/go/oci/spec/repository/v1/oci"
+	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+// Apply sets componentVersionLayout on a target repository spec (OCI or CTF) from a --layout flag
+// value. "" and "v2" leave the spec unchanged (default). "normalized" sets the field. Any other
+// value is an error. Specs of other types are left unchanged (the layout only applies to OCI/CTF).
+func Apply(spec runtime.Typed, layout string) error {
+	switch layout {
+	case "", "v2":
+		return nil
+	case "normalized":
+		switch s := spec.(type) {
+		case *ocirepospec.Repository:
+			s.ComponentVersionLayout = "normalized"
+		case *ctfrepospec.Repository:
+			s.ComponentVersionLayout = "normalized"
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown --layout %q (want v2 or normalized)", layout)
+	}
+}

--- a/cli/internal/layout/layout_test.go
+++ b/cli/internal/layout/layout_test.go
@@ -1,0 +1,52 @@
+package layout
+
+import (
+	"testing"
+
+	ctfrepospec "ocm.software/open-component-model/bindings/go/oci/spec/repository/v1/ctf"
+	ocirepospec "ocm.software/open-component-model/bindings/go/oci/spec/repository/v1/oci"
+)
+
+func TestApply(t *testing.T) {
+	tests := []struct {
+		name    string
+		layout  string
+		want    string
+		wantErr bool
+	}{
+		{name: "normalized", layout: "normalized", want: "normalized"},
+		{name: "v2 leaves empty", layout: "v2", want: ""},
+		{name: "empty leaves empty", layout: "", want: ""},
+		{name: "bogus errors", layout: "bogus", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oci := &ocirepospec.Repository{BaseUrl: "ghcr.io"}
+			ctf := &ctfrepospec.Repository{FilePath: "./archive"}
+
+			ociErr := Apply(oci, tt.layout)
+			ctfErr := Apply(ctf, tt.layout)
+
+			if tt.wantErr {
+				if ociErr == nil || ctfErr == nil {
+					t.Fatalf("expected error for layout %q, got oci=%v ctf=%v", tt.layout, ociErr, ctfErr)
+				}
+				return
+			}
+
+			if ociErr != nil {
+				t.Fatalf("unexpected error on oci spec: %v", ociErr)
+			}
+			if ctfErr != nil {
+				t.Fatalf("unexpected error on ctf spec: %v", ctfErr)
+			}
+			if oci.ComponentVersionLayout != tt.want {
+				t.Errorf("oci ComponentVersionLayout = %q, want %q", oci.ComponentVersionLayout, tt.want)
+			}
+			if ctf.ComponentVersionLayout != tt.want {
+				t.Errorf("ctf ComponentVersionLayout = %q, want %q", ctf.ComponentVersionLayout, tt.want)
+			}
+		})
+	}
+}

--- a/demo/.gitignore
+++ b/demo/.gitignore
@@ -1,0 +1,4 @@
+transport/
+cosign.key
+cosign.pub
+tmp/

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,203 @@
+# Cosign-signable OCM components (normalized layout) — end-to-end demo
+
+**What this proves:** an OCM component published in the *normalized* layout has a stable OCI
+manifest digest that does **not** change when the component is copied between registries.
+So you can `cosign sign` it exactly like a Docker image, and the signature stays valid after
+`ocm transfer` moves the component across registries — here `zot1 → CTF → zot2`, verified on zot2
+without re-signing.
+
+Why it works: the normalized manifest is *access-free* and carries **no** per-registry annotations
+(no `creator`/`authors`), and its single layer is the JCS-canonical descriptor. Re-materializing the
+component on another registry therefore yields a **bit-identical** manifest digest. The default
+(`v2`) layout embeds `software.ocm.creator` in the manifest, so its digest changes per registry and
+a signature would not survive — which is exactly why the normalized layout exists.
+
+## Prerequisites
+
+Put these tools on your `PATH`:
+
+- `docker` — runs the two local registries
+- `cosign` (v3.x) — signs and verifies the component
+- `curl` and `jq` — inspect the registry in the walkthrough
+- `skopeo` — optional, for the manifest-digest inspections
+- `go` — only needed to build the `ocm` CLI from source (next step)
+
+Build the `ocm` CLI from this checkout. The bindings live in sibling modules, so a Go workspace
+file lets the CLI build against the in-repo code:
+
+```bash
+# from the repo root
+go work init ./cli ./bindings/go/oci ./bindings/go/transfer 2>/dev/null \
+  || go work use ./cli ./bindings/go/oci ./bindings/go/transfer
+(cd cli && go build -o ./tmp/ocm .)
+OCM=./cli/tmp/ocm
+```
+
+The `--layout` flag is added by this change, so the demo requires the `ocm` binary built above.
+
+## 1. Start two local registries (zot1, zot2)
+
+```bash
+docker run -d --rm --name zot1 -p 5001:5000 -v "$PWD/demo/zot-config.json:/etc/zot/config.json" ghcr.io/project-zot/zot-linux-amd64:latest
+docker run -d --rm --name zot2 -p 5002:5000 -v "$PWD/demo/zot-config.json:/etc/zot/config.json" ghcr.io/project-zot/zot-linux-amd64:latest
+curl -sf http://localhost:5001/v2/ && echo " zot1 up"
+curl -sf http://localhost:5002/v2/ && echo " zot2 up"
+```
+
+## 2. Publish the component in the normalized layout to zot1
+
+`demo/component-constructor.yaml` defines a component with one local (`utf8`) resource.
+
+```bash
+$OCM add component-version --layout normalized -r oci::http://localhost:5001/ocm -c demo/component-constructor.yaml
+```
+
+The tag `1.0.0` now resolves to the normalized manifest — `artifactType`
+`application/vnd.ocm.software.component-descriptor.normalized.v1`, an empty OCI config, one
+normalized-descriptor layer, and layout annotations, with **no** creator/author fields:
+
+```console
+$ curl -s http://localhost:5001/v2/ocm/component-descriptors/ocm.software/demo/cosign-normalized/manifests/1.0.0 \
+    -H 'Accept: application/vnd.oci.image.manifest.v1+json' | jq '{artifactType, annotations}'
+{
+  "artifactType": "application/vnd.ocm.software.component-descriptor.normalized.v1",
+  "annotations": {
+    "org.opencontainers.image.title": "OCM Normalized Component Descriptor for ocm.software/demo/cosign-normalized in version 1.0.0",
+    "org.opencontainers.image.version": "1.0.0",
+    "software.ocm.component-model/layout-version": "v1",
+    "software.ocm.component-model/normalisation-algo": "jsonNormalisation/v4alpha1"
+  }
+}
+```
+
+Its digest — the thing cosign will sign — is stable:
+
+```console
+$ curl -sI http://localhost:5001/v2/ocm/component-descriptors/ocm.software/demo/cosign-normalized/manifests/1.0.0 \
+    -H 'Accept: application/vnd.oci.image.manifest.v1+json' | grep -i docker-content-digest
+Docker-Content-Digest: sha256:133c3c751f0d3dc699d33de182f7cefe960a721b9e08ad01f29dd510e32ef795
+```
+
+(The access-bearing descriptor + local blobs live in an `access.v1` referrer of this manifest,
+discoverable via the referrers API and a `sha256-<manifest-digest>.acc` fallback tag.)
+
+## 3. Sign it with cosign — exactly like a Docker image
+
+```bash
+cd demo
+export COSIGN_PASSWORD=""
+cosign generate-key-pair
+REF=localhost:5001/ocm/component-descriptors/ocm.software/demo/cosign-normalized:1.0.0
+cosign sign   --key cosign.key --use-signing-config=false --tlog-upload=false --allow-insecure-registry --allow-http-registry --yes $REF
+cosign verify --key cosign.pub --insecure-ignore-tlog=true --allow-insecure-registry --allow-http-registry $REF
+cd ..
+```
+
+`cosign sign` targets the tag like any image (it resolves to the normalized manifest digest) and
+attaches the signature as an **OCI referrer** of that manifest. `cosign verify` on zot1 succeeds; the
+payload binds `docker-manifest-digest: sha256:133c3c75…` (the normalized manifest digest).
+
+Flag notes for a local, offline registry with cosign 3.x:
+`--use-signing-config=false --tlog-upload=false` (no transparency log), `--allow-insecure-registry
+--allow-http-registry` (plain-HTTP zot), `--insecure-ignore-tlog=true` on verify. Use a key pair to
+stay offline; keyless/Fulcio is a drop-in variation with a reachable Sigstore.
+
+Both referrers of the normalized manifest are now present on zot1:
+
+```console
+$ curl -s "http://localhost:5001/v2/ocm/component-descriptors/ocm.software/demo/cosign-normalized/referrers/sha256:133c3c751f0d3dc699d33de182f7cefe960a721b9e08ad01f29dd510e32ef795" \
+    | jq -r '.manifests[] | "\(.artifactType)  \(.digest)"'
+application/vnd.ocm.software.component-descriptor.access.v1   sha256:5107b20d716abb414ed9b0ba97945b3c5247dd4c880520f671735053b50e5271
+application/vnd.dev.sigstore.bundle.v0.3+json                 sha256:08736c7f4705f7f84322d99efce8447c7893e92c49dc96d949efc067505e7d4e
+```
+
+## 4. Other OCM commands still work on the normalized component
+
+```console
+$ $OCM get component-version oci::http://localhost:5001/ocm//ocm.software/demo/cosign-normalized:1.0.0 -o yaml
+- component:
+    name: ocm.software/demo/cosign-normalized
+    provider: ocm.software
+    resources:
+    - access: { localReference: sha256:9355..., mediaType: text/plain, type: LocalBlob/v1 }
+      digest: { hashAlgorithm: SHA-256, normalisationAlgorithm: genericBlobDigest/v1, value: 9355... }
+      name: greeting
+      type: plainText
+      version: 1.0.0
+    version: 1.0.0
+  meta: { schemaVersion: v2 }
+
+$ $OCM download resource oci::http://localhost:5001/ocm//ocm.software/demo/cosign-normalized:1.0.0 \
+      --identity name=greeting --output demo/tmp/greeting.txt
+level=INFO msg="resource downloaded successfully" output=demo/tmp/greeting.txt
+$ cat demo/tmp/greeting.txt
+hello from the normalized, cosign-signed component
+```
+
+`get` resolves the descriptor via the signed normalized manifest + its access referrer (with the
+bind check), and `download resource` reads the local blob from the access referrer.
+
+## 5. Transfer zot1 → CTF → zot2 (carries the signature)
+
+```bash
+$OCM transfer component-version --layout normalized \
+    oci::http://localhost:5001/ocm//ocm.software/demo/cosign-normalized:1.0.0 \
+    ctf::./demo/transport
+$OCM transfer component-version --layout normalized \
+    ctf::./demo/transport//ocm.software/demo/cosign-normalized:1.0.0 \
+    oci::http://localhost:5002/ocm
+```
+
+`ocm transfer` re-materializes the component on each hop. Because the normalized manifest is
+deterministic, its digest on zot2 is **identical** to zot1, and transfer carries the component
+manifest's non-access referrers (the cosign signature) along:
+
+```console
+$ curl -sI http://localhost:5002/v2/ocm/component-descriptors/ocm.software/demo/cosign-normalized/manifests/1.0.0 \
+    -H 'Accept: application/vnd.oci.image.manifest.v1+json' | grep -i docker-content-digest
+Docker-Content-Digest: sha256:133c3c751f0d3dc699d33de182f7cefe960a721b9e08ad01f29dd510e32ef795   # same as zot1
+
+$ curl -s "http://localhost:5002/v2/ocm/component-descriptors/ocm.software/demo/cosign-normalized/referrers/sha256:133c3c751f0d3dc699d33de182f7cefe960a721b9e08ad01f29dd510e32ef795" \
+    | jq -r '.manifests[] | "\(.artifactType)  \(.digest)"'
+application/vnd.ocm.software.component-descriptor.access.v1   sha256:5107b20d716abb414ed9b0ba97945b3c5247dd4c880520f671735053b50e5271
+application/vnd.dev.sigstore.bundle.v0.3+json                 sha256:08736c7f4705f7f84322d99efce8447c7893e92c49dc96d949efc067505e7d4e   # the SAME signature digest
+```
+
+## 6. Verify on zot2 — the proof
+
+```console
+$ cosign verify --key demo/cosign.pub --insecure-ignore-tlog=true --allow-insecure-registry --allow-http-registry \
+    localhost:5002/ocm/component-descriptors/ocm.software/demo/cosign-normalized:1.0.0
+Verification for localhost:5002/...cosign-normalized:1.0.0 --
+  - The cosign claims were validated
+  - The signatures were verified against the specified public key
+[{"critical":{...,"image":{"docker-manifest-digest":"sha256:133c3c751f0d3dc699d33de182f7cefe960a721b9e08ad01f29dd510e32ef795"},...}}]
+```
+
+The signature made on **zot1** verifies on **zot2** with no re-signing and no manual copy — because
+the normalized manifest digest survived the transfer and `ocm transfer` carried the signature referrer.
+
+## Contrast: the default (v2) layout
+
+Publishing the same component with the default layout produces a manifest that embeds per-registry
+identity, so its digest is **not** stable across registries:
+
+```console
+$ $OCM add component-version -r oci::http://localhost:5001/v2demo -c demo/component-constructor.yaml
+$ curl -s .../v2demo/.../manifests/1.0.0 -H 'Accept: application/vnd.oci.image.manifest.v1+json' | jq '.annotations'
+{
+  "org.opencontainers.image.authors": "Builtin OCI Repository Plugin",
+  "software.ocm.creator": "Builtin OCI Repository Plugin",
+  ...
+}
+```
+
+Those annotations change the manifest bytes (hence the digest) per repository, so a cosign signature
+over a v2 component would break on transfer. The normalized layout removes exactly this.
+
+## Cleanup
+
+```bash
+docker rm -f zot1 zot2
+rm -rf demo/transport demo/tmp demo/cosign.key demo/cosign.pub
+```

--- a/demo/component-constructor.yaml
+++ b/demo/component-constructor.yaml
@@ -1,0 +1,12 @@
+components:
+  - name: ocm.software/demo/cosign-normalized
+    version: 1.0.0
+    provider:
+      name: ocm.software
+    resources:
+      - name: greeting
+        type: plainText
+        version: 1.0.0
+        input:
+          type: utf8
+          text: "hello from the normalized, cosign-signed component"

--- a/demo/zot-config.json
+++ b/demo/zot-config.json
@@ -1,0 +1,5 @@
+{
+  "storage": { "rootDirectory": "/var/lib/registry" },
+  "http": { "address": "0.0.0.0", "port": "5000" },
+  "log": { "level": "warn" }
+}


### PR DESCRIPTION
**DONE FOR HACKATHON, DO NOT MERGE AS IS, JUST AS A PREVIEW**

## Description

Introduce an opt-in OCI storage layout in which a component version's tag resolves to a stable, access-free "normalized" descriptor manifest whose digest (D_norm) is invariant across registry-to-registry copies. This makes an OCM component signable with standard cosign — exactly like a Docker image — and the signature survives transport.

Library (bindings/go/oci):
- New layout package oci/spec/layout/normalized/v1: layout constants, the publish-time resource-digest invariant, the normalize + bind check (normalize(access_descriptor) == signed_normalized_bytes), and the normalized and access manifest builders. The normalized layer is the jsonNormalisation/ v4alpha1 canonical descriptor (access stripped); the access-bearing descriptor and local blobs live in an unsigned access.v1 referrer of the normalized manifest, regenerated per registry.
- Write path (addNormalizedLayout) and read path: discover the access referrer via Predecessors + a sha256-<D_norm>.acc fallback tag, gate trust on the bind check (deterministic, content-derived ordering, fall-through), and detect the layout on read from the manifest artifactType. Local resources/sources read via the access referrer.
- CarryComponentSignatures: copy the component manifest's non-access referrers (cosign signatures/attestations) from a source repo, gated on a preserved manifest digest (normalized layout only), skipping the access manifest.

Selection & versioning:
- componentVersionLayout field on the OCI and CTF repository specs; the provider maps it to oci.WithComponentVersionLayout. Default layout is unchanged.
- ocm add/transfer component-version gain a --layout v2|normalized flag.

Transfer:
- ocm transfer re-materializes the normalized manifest identically (D_norm preserved) and carries the cosign signature referrer to the target, so a signature made on one registry verifies on another with no re-signing. The carry is non-fatal (never breaks a transfer) and a no-op for the v2 layout.

demo/: a runnable, verified end-to-end walkthrough — publish normalized to a local zot, cosign sign, verify, transfer zot1 -> CTF -> zot2, and cosign verify on zot2 (the signature is carried by ocm transfer).

Backwards compatible and opt-in; all new behavior is versioned.


## Original Spec: Normalized Descriptor as Primary OCI Entry Point (cosign-signable layout)

### 1. Problem

An OCM component version is stored as **one OCI manifest** (an image manifest, wrapped in
an OCI index when multiple sub-manifests are involved) in an OCI registry. Today the manifest
the tag resolves to is the **access-bearing component descriptor** (`artifactType`
`application/vnd.ocm.software.component-descriptor.v2`), whose layers include the full
descriptor (with resource `access` specs) plus any local-blob layers.

When a component version is **copied from one registry to another**, the `access` specs are
rewritten (local references re-point at the target registry's blob layout; image references may
be relocated). This changes the descriptor bytes, which changes the manifest digest. Any
signature computed over that manifest digest — e.g. a plain `cosign sign <ref>` — is therefore
**invalidated by transport**. This is the core obstacle to signing OCM components with standard
cosign tooling.

OCM already solves the *payload* half of this with a transport-agnostic **normalization**
algorithm (`jsonNormalisation/v4alpha1`) that strips access/location/signature fields and yields
a stable digest, which OCM's own signing handlers sign and store inside the descriptor's
`signatures[]`. That mechanism is unchanged by this design and remains available. What is
missing is a way to make the **OCI manifest that cosign signs** stable across copies, so that the
broad ecosystem of cosign/sigstore tooling (referrer-attached signatures, attestations, policy
controllers) can be used against OCM components directly.

### 2. Goal & non-goals

**Goal.** Introduce an opt-in, versioned OCI storage layout in which:

1. The tag resolves to a **normalized, access-free descriptor manifest** whose digest (`D_norm`)
   is **stable across registry-to-registry copies**. This is the manifest cosign signs.
2. The **access-bearing descriptor** (with local blobs) is stored as a **referrer** of the
   normalized manifest — regenerated per registry, never signed — mirroring how cosign attaches
   signatures/attestations as referrers.
3. OCM owns the **binding**: given the signed normalized manifest, OCM resolves the access
   referrer and proves `normalize(access_descriptor) == normalized_descriptor` before trusting
   its accesses or pulling content. Resource content is bound to the signature via resource
   digests carried in the (signed) normalized descriptor.

**Non-goals.**

- OCM does not sign or verify cosign signatures itself. Signing/verifying is done with **standard
  cosign** by the user/CI (`cosign sign repo@D_norm`, `cosign verify`). OCM's responsibility is to
  produce a cosign-signable layout and to enforce the binding above. (An optional OCM signing
  handler that targets `D_norm` may be added later; it is out of scope here.)
- The existing OCM in-descriptor signature mechanism (`signatures[]`, `jsonNormalisation/v4alpha1`
  digests signed by RSA/GPG/Sigstore handlers) is not removed or changed.
- The current (v2) layout remains the default. This design is additive and opt-in.

### 3. Key insight

The only descriptor content that changes under transport is the **access/location** information.
Resource **content digests** are content-addresses and are stable. If the manifest the tag points
to contains *only the stable content* (metadata + resource digests, no access), its digest is
stable, and a signature over it survives copying. The volatile access information is pushed into a
separate, unsigned referrer that is freely regenerated per registry.

### 4. Layout: today vs. proposed

#### 4.1 Today (unchanged, remains default)

```
tag: <component>:<version>
      │
      ▼
┌─────────────────────────────────────────────┐
│ OCI Image Manifest   (digest = D_v2)         │  ← UNSTABLE across copies
│ artifactType: ...component-descriptor.v2     │    (accesses rewritten → D_v2 changes)
│ config:  ...component.config.v1+json         │
│ layers:                                      │
│   - ...component-descriptor.v2+json  (F)     │  ← full descriptor WITH accesses
│   - <local blob layer>                       │
│   - <local blob layer>                       │
└─────────────────────────────────────────────┘
```

### 4.2 Proposed (new, opt-in)

```
tag: <component>:<version>
      │
      ▼
┌───────────────────────────────────────────────────┐
│ NORMALIZED Manifest  (digest = D_norm)             │  ← STABLE across copies
│ artifactType: ...component-descriptor.normalized.v1│  ← cosign signs THIS digest
│ config:  application/vnd.oci.empty.v1+json  ({})   │
│ layers:                                            │
│   - ...component-descriptor.normalized.v1+json (N) │  ← descriptor, access STRIPPED,
│ annotations:                                       │      JCS-canonical, resource DIGESTS kept
│   software.ocm.component-model/layout-version: v1  │
│   software.ocm.component-model/normalisation-algo: │
│       jsonNormalisation/v4alpha1                   │
│   org.opencontainers.image.ref.name (name:version) │
└───────────────────────▲───────────────────────────┘
                        │ subject
     ┌──────────────────┼───────────────────────────┬───────────────────────────┐
     │ referrer         │                            │ referrer                  │ referrer
┌────┴───────────────────────────────┐  ┌────────────┴──────────┐  ┌─────────────┴──────────┐
│ ACCESS Manifest (D_acc)            │  │ cosign signature      │  │ attestation / SBOM     │
│ artifactType: ...descriptor.access.v1│ │ (standard cosign,     │  │ (standard cosign)      │
│ subject: D_norm                    │  │  subject: D_norm)     │  └────────────────────────┘
│ config: ...component.config.v1+json│  └───────────────────────┘
│ layers:                            │       ← REGENERATED per registry, NOT signed
│   - ...component-descriptor.v2+json (F)  ← FULL access-bearing descriptor
│   - <local blob layer>             │
│   - <local blob layer>             │
└────────────────────────────────────┘
```

Property: copying A→B preserves `D_norm`, the normalized layer blob `N`, and the cosign signature
referrers **verbatim**; only the ACCESS manifest (and its local-blob layers) is regenerated for B.

### 5. Artifacts, media types, version markers

New constants live in `bindings/go/oci/spec/descriptor/media_type.go` and a new package
`bindings/go/oci/spec/layout/normalized/v1`.

| Purpose | Value |
| --- | --- |
| Normalized manifest `artifactType` | `application/vnd.ocm.software.component-descriptor.normalized.v1` |
| Normalized descriptor layer media type | `application/vnd.ocm.software.component-descriptor.normalized.v1+json` |
| Normalized manifest config | `application/vnd.oci.empty.v1+json` (`{}`, digest `sha256:44136fa3...`) |
| Access manifest `artifactType` | `application/vnd.ocm.software.component-descriptor.access.v1` |
| Access descriptor layer media type | `application/vnd.ocm.software.component-descriptor.v2+json` (unchanged) |
| Access manifest config | `application/vnd.ocm.software.component.config.v1+json` (unchanged) |
| Layout version constant | `LayoutVersion = "v1"` |
| Layout-version annotation key | `software.ocm.component-model/layout-version` |
| Normalisation-algo annotation key | `software.ocm.component-model/normalisation-algo` |

#### 5.1 Normalized descriptor layer `N`

`N` is exactly the byte output of `normalisation.Normalise(F, "jsonNormalisation/v4alpha1")` — a
**readable component descriptor document** (not a hashing-only blob). That algorithm already:

1. Applies the `jsonNormalisation/v4alpha1` **exclusion set** to the full descriptor `F`:
   - drop `component.resources[].access`, `component.sources[].access`
   - drop `component.repositoryContexts`
   - drop `component.signatures`, `nestedDigests`
   - drop `component.resources[].srcRefs`
   - **keep** `component.resources[].digest` and `component.sources[].digest`
   - keep `component`, resource/source identity (`name`, `version`, `extraIdentity`), `type`,
     `relation`, `labels` (subject to the existing signing-label rule), `references`
   - resources whose access type is `none` follow the existing rule (digest removed)
2. Serializing the result **JCS-canonical** (RFC 8785), matching the existing engine, so the bytes
   are deterministic and identical across registries.

The manifest over `N` (empty config, single layer `N`, fixed `artifactType`, stable annotations)
therefore has a stable digest `D_norm`.

> Design note: the annotation `normalisation-algo` records exactly which exclusion/canonicalisation
> rules produced `N`, so the bind check (§7) and any future normalization revisions are unambiguous
> and independently reproducible. A future `v4alpha2`/`v5` bumps this annotation and, if the layer
> shape changes incompatibly, the layout media-type version.

#### 5.2 Access manifest `A`

Carries the **full** access-bearing v2 descriptor `F` as its descriptor layer plus all local-blob
layers, with `subject = D_norm`. Full (not slim) so existing descriptor-consumption code reads it
unchanged and the bind check can re-normalize it directly. The `component.config.v1+json` config is
unchanged from today.

### 6. Detection & resolution (read path)

```
resolve tag → manifest M (digest D)
 ├─ M.artifactType == ...component-descriptor.v2         → OLD path (unchanged)
 └─ M.artifactType == ...component-descriptor.normalized.v1 → NEW path:
      1. read N from M.layers[0]                       (the signed, access-free descriptor)
      2. referrers(D_norm), filter artifactType == ...access.v1   → access manifest A
           (fallback when no referrers API: tag `sha256-<D_norm>.acc`, see §9)
      3. read full descriptor F (+ local blobs) from A
      4. BIND CHECK (see §7)
      5. return F for use; resource content pulled via F.access,
         verified against F.digest (== N.digest, which cosign signed)
```

Signature verification is external and unchanged by copying:

```
cosign verify repo@D_norm   # stable digest → works before AND after transport
```

### 7. The binding OCM owns

The signed manifest is access-free; the accesses OCM uses to pull content live in the **unsigned**
access referrer. The access information is the **only** part of the component that is not covered
by the signature (it must change when copying between registries). The design therefore treats
every access referrer as untrusted input and derives all trust from a single gate: does it
re-normalize to the signed bytes? OCM must prove the access referrer corresponds to the signed
normalized descriptor before trusting it:

```
BIND CHECK(N, F):
  N'  := normalize_v4alpha1_document(F)     # apply §5.1 to the resolved full descriptor
  assert bytesEqual(N', N)                  # N is M.layers[0] as stored (the signed bytes)
  # equivalently: assert digest(manifest_over(N')) == D_norm
  on mismatch: hard error
      "access descriptor does not match signed normalized descriptor (possible tampering/mismatch)"
```

Function: `VerifyNormalizedMatchesAccess(N []byte, F *descriptor.Descriptor) error`.

After the bind check passes:

- every resource `digest` OCM uses came from the signed `N`;
- when a resource blob is pulled via `F.access`, its content is verified against that digest;
- thus content is transitively bound to the cosign signature over `D_norm`, even though the
  signature never covered the access information.

#### 7.1 Binding invariant: every resource MUST be digested

The bind check only protects resources that carry a `digest` in the signed `N`. A resource with
no digest would be **unbound**: a passing access referrer could point its access at attacker-
controlled content with nothing to verify against. Therefore the new layout enforces, at
**publish time**, that every resource carries a digest whose hash algorithm is sha256 or stronger.
Publishing a component with an undigested resource in the new layout is rejected.

Two intentional allowances, consistent with the existing `jsonNormalisation/v4alpha1` behavior:

- **Excluded-from-signature resources.** A resource explicitly marked with the OCM sentinel
  (`digest.hashAlgorithm == "NO-DIGEST"`, `digest.normalisationAlgorithm == "EXCLUDE-FROM-SIGNATURE"`,
  as produced for `none`-access resources) is allowed. Its content is intentionally not part of the
  signature and there is no pullable content to substitute.
- **Sources are not required to be digested.** OCM's normalization already includes sources without
  requiring a digest, so this layout does not add a stricter rule for sources. Only resources are
  enforced.

This guarantees there is no unbound *resource* content and makes referrer selection (§11) an
availability concern rather than an integrity one.

Field note: on the runtime descriptor type, `Resource.Digest` is a pointer (`*Digest`, nil when
absent) while `Source.Digest` is a value. The enforcement above only reads `Resource.Digest`.

### 8. Write & copy (publish / transport)

#### 8.1 Write (`AddComponentVersion`, new layout, opt-in)

```
1. build full descriptor F (accesses + local blobs)          as today
2. N := normalize_v4alpha1_document(F)                        (§5.1)
3. push blob N; build+push NORMALIZED manifest M              → D_norm ; tag repo:version → D_norm
       config = oci.empty ; layers = [N] ; artifactType = normalized.v1 ; annotations (§5)
4. push local-blob layers + blob F; build+push ACCESS manifest A
       subject = D_norm ; artifactType = access.v1 ; config = component.config ; layers = [F, blobs…]
5. (signing is out-of-band: `cosign sign repo@D_norm`)
```

#### 8.2 Copy A→B

```
1. copy manifest M + blob N + cosign signature referrers  VERBATIM   (D_norm preserved → sig valid)
2. regenerate ACCESS manifest for B:
      re-upload local blobs into B ; rewrite local references ; new A' with subject = D_norm
3. tag repo_B:version → D_norm
```

`D_norm` and the signature are unchanged in B; only `A` differs (and it is unsigned).

### 9. Backwards compatibility, versioning, fallback

- **Opt-in.** New layout is selected by a repository option (e.g. `WithComponentVersionLayout(...)`
  / a `layout` field on the OCI repository config). Default remains the current v2 layout, so
  existing repositories and clients are untouched.
- **Detection.** New-layout-aware clients branch on the tag manifest's `artifactType`
  (`normalized.v1` vs `v2`); the `layout-version` annotation is a redundant backstop. A client that
  predates this feature and reads a new-layout repo encounters an unknown `artifactType` at the tag
  and fails cleanly rather than misinterpreting bytes.
- **Explicit versioning.** All new media types carry explicit version segments (`normalized.v1`,
  `access.v1`, `LayoutVersion = "v1"`). Future incompatible changes bump these; the annotation
  records the normalization algorithm independently.
- **Registries without the OCI referrers API.** Reuse OCM's existing referrer-fallback plumbing
  (`bindings/go/oci/spec/index/component/v1`) and cosign's tag convention: the access manifest is
  discoverable via a predictable fallback tag `sha256-<D_norm>.acc`, alongside cosign's own
  `sha256-<D_norm>.sig`. Discovery tries the referrers API first, then the fallback tag.

### 10. Code surface (for the single implementation commit)

- `bindings/go/oci/spec/descriptor/media_type.go` — new `artifactType`/media-type/version/annotation
  constants.
- `bindings/go/oci/spec/layout/normalized/v1` (new) — layout constants, annotation keys, referrer
  discovery + fallback-tag helpers.
- `bindings/go/descriptor/normalisation` — **reused directly**. `normalisation.Normalise(cd,
  v4alpha1.Algorithm)` already returns the canonicalized, access-stripped descriptor **bytes**
  (the readable JCS document; the signing digest is `sha256` of these bytes). The normalized layer
  `N` IS this output. No new entry point required.
- `bindings/go/oci/store_descriptor.go` (`AddDescriptorToStore`) — new-layout write path producing
  `M` + `A`; **publish-time validation that every resource/source is digested (sha256+)** (§7.1),
  rejecting the write otherwise.
- `bindings/go/oci/repository.go` (`AddComponentVersion` + read path) — branch on layout option;
  add referrer resolution and the bind check (`VerifyNormalizedMatchesAccess`).
- transfer/copy logic — verbatim copy of `M` + `N` + signature referrers; regeneration of `A`.
- repository config / option — opt-in layout selection.
- tests — round-trip; copy A→B preserves `D_norm` and signature; bind check rejects a tampered
  access descriptor; **multiple access referrers: malicious one that fails bind check is skipped,
  and fallthrough across passing survivors on unresolvable/failed-digest access**; publish rejects
  an undigested resource; no-referrers-API fallback discovery; local-blob resources under the
  access referrer.

### 11. Edge cases & open questions

- **Local blobs are in scope.** They move under the access referrer as OCI layers; their content
  digests are carried in the signed `N`, so pulled blobs are verified against signed digests.
- **Multiple access referrers (selection rule).** A registry can accumulate more than one
  `access.v1` referrer (stale copies, or a malicious pushed referrer). Selection is safety-first
  and never trusts attacker-mutable metadata:
  1. Enumerate all `access.v1` referrers (referrers API, then fallback tag §9).
  2. Keep only those that **pass the bind check** (§7). This is the *sole* trust gate; everything
     else about a referrer is untrusted. Discard (log) the rest.
  3. Order survivors deterministically by their **own manifest digest ascending** — a
     content-derived key, never a timestamp or other value an attacker can choose.
  4. Use the first survivor; if any of its accesses fail to resolve, or a pulled blob fails its
     per-resource digest check, **fall through** to the next survivor. Hard-fail only when all
     survivors are exhausted.

  This is safe because §7.1 guarantees every resource is digested and every survivor re-normalizes
  to the identical signed `N` (hence identical digests): integrity is independent of which survivor
  is chosen, so selection is purely about resolvability/availability. A stale, dead, or malicious
  referrer is simply skipped.
- **`nestedDigests` / referenced components.** Aggregate signing over component references is
  handled by the existing OCM mechanism and is orthogonal; confirm during implementation that
  nested references round-trip through the new layout unchanged.
- **Non-JSON descriptor encodings.** The normalized layer is JSON+JCS only; YAML descriptor
  encodings remain a v2-layout concern.
- **Optional OCM cosign handler.** Deferred; the layout is the contract and is standard-cosign
  interoperable on its own.
- **Local-resource read-back (`GetLocalResource`/`GetLocalSource`).** In this first iteration the
  normalized layout supports publishing local blobs (they live under the access referrer) and
  reading the full component descriptor (`GetComponentVersion`, which resolves via the access
  referrer and bind check). Retrieving an individual local resource's *content* via
  `GetLocalResource`/`GetLocalSource` is **not yet wired** for the normalized layout — those calls
  resolve the tag to the access-free normalized manifest, whose config carries no descriptor layer.
  Until wired via the access referrer, these calls fail cleanly with an explanatory error rather
  than dereferencing a nil layer. Full support is a follow-up.