### PR TITLE
fix(sigstore): replace deprecated cosign --private-infrastructure flag

### DIFF
--- a/bindings/go/sigstore/signing/handler/handler.go
+++ b/bindings/go/sigstore/signing/handler/handler.go
@@ -260,7 +260,9 @@ func (h *Handler) Verify(
 		extraArgs = append(extraArgs, "--trusted-root", trustedRootPath)
 	}
 	if cfg.PrivateInfrastructure {
-		extraArgs = append(extraArgs, "--private-infrastructure")
+		// --insecure-ignore-tlog replaces --private-infrastructure, which cosign deprecated in
+		// v3.1.0 and removes in v4. It is a pure alias, available since cosign v2.0.
+		extraArgs = append(extraArgs, "--insecure-ignore-tlog")
 	}
 
 	slog.InfoContext(ctx, "sigstore verify: enforcing identity constraints",

--- a/bindings/go/sigstore/signing/handler/handler_test.go
+++ b/bindings/go/sigstore/signing/handler/handler_test.go
@@ -635,7 +635,7 @@ func TestHandler_Verify(t *testing.T) {
 			creds: &trustedrootv1.TrustedRoot{TrustedRootJSONFile: "/path/to/private_trusted_root.json"},
 			assertArgs: func(t *testing.T, args []string) {
 				r := require.New(t)
-				r.True(hasArg(args, "--private-infrastructure"))
+				r.True(hasArg(args, "--insecure-ignore-tlog"))
 				r.Equal("/path/to/private_trusted_root.json", argValue(args, "--trusted-root"))
 			},
 		},
@@ -813,7 +813,7 @@ func TestVerify_PrivateInfrastructureWithTrustedRootCredential(t *testing.T) {
 	err := h.Verify(t.Context(), signed, cfg, creds)
 	r.NoError(err)
 	r.NotNil(mock.lastVerifyArgs)
-	r.True(hasArg(mock.lastVerifyArgs, "--private-infrastructure"))
+	r.True(hasArg(mock.lastVerifyArgs, "--insecure-ignore-tlog"))
 }
 
 func TestVerify_CertificateOIDCIssuerAcceptsHTTP(t *testing.T) {

--- a/bindings/go/sigstore/signing/v1alpha1/config.go
+++ b/bindings/go/sigstore/signing/v1alpha1/config.go
@@ -107,7 +107,7 @@ type VerifyConfig struct {
 	// deployed Sigstore stack. When set, the verifier skips the public Rekor
 	// transparency-log lookup; signature, certificate chain, identity, and SCT
 	// checks are unchanged. Must be paired with a trusted-root credential.
-	// Maps to cosign --private-infrastructure.
+	// Maps to cosign --insecure-ignore-tlog.
 	PrivateInfrastructure bool `json:"privateInfrastructure,omitempty"`
 
 	// CertificateOIDCIssuer is the exact OIDC issuer URL the signing certificate

--- a/bindings/go/sigstore/signing/v1alpha1/schemas/VerifyConfig.schema.json
+++ b/bindings/go/sigstore/signing/v1alpha1/schemas/VerifyConfig.schema.json
@@ -24,7 +24,7 @@
     },
     "privateInfrastructure": {
       "type": "boolean",
-      "description": "PrivateInfrastructure indicates the signature was made against a privately\ndeployed Sigstore stack. When set, the verifier skips the public Rekor\ntransparency-log lookup; signature, certificate chain, identity, and SCT\nchecks are unchanged. Must be paired with a trusted-root credential.\nMaps to cosign --private-infrastructure."
+      "description": "PrivateInfrastructure indicates the signature was made against a privately\ndeployed Sigstore stack. When set, the verifier skips the public Rekor\ntransparency-log lookup; signature, certificate chain, identity, and SCT\nchecks are unchanged. Must be paired with a trusted-root credential.\nMaps to cosign --insecure-ignore-tlog."
     },
     "type": {
       "$ref": "#/$defs/ocm.software.open-component-model.bindings.go.runtime.Type",


### PR DESCRIPTION
cosign v3.1.0 deprecated `--private-infrastructure` (to be removed in v4). It is a pure alias for `--insecure-ignore-tlog`, which has existed since cosign v2.0 — well below our minimum supported version.

This swaps the emitted flag. The OCM `VerifyConfig.PrivateInfrastructure` field is unchanged, so no config or schema break for users.

Fixes #3067