### PR TITLE
fix(oci): accept legacy cnudie config media types in version listing

### DIFF
--- a/bindings/go/oci/internal/lister/component/component_versions_test.go
+++ b/bindings/go/oci/internal/lister/component/component_versions_test.go
@@ -226,6 +226,31 @@ func TestReferenceTagVersionResolver(t *testing.T) {
 			expected: "v1.0.0",
 		},
 		{
+			name: "cnudie component version without annotation (pre-OCM gardener)",
+			ref:  "example.com/repo",
+			tag:  "v1.0.0",
+			store: &mockStore{
+				resolveFunc: func(ctx context.Context, ref string) (ociImageSpecV1.Descriptor, error) {
+					return ociImageSpecV1.Descriptor{
+						MediaType: ociImageSpecV1.MediaTypeImageManifest,
+					}, nil
+				},
+				fetchFunc: func(ctx context.Context, desc ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+					data, err := json.Marshal(&ociImageSpecV1.Manifest{
+						MediaType: ociImageSpecV1.MediaTypeImageManifest,
+						Config: ociImageSpecV1.Descriptor{
+							MediaType: componentConfig.LegacyMediaType,
+						},
+					})
+					if err != nil {
+						return nil, fmt.Errorf("failed to marshal manifest: %w", err)
+					}
+					return io.NopCloser(bytes.NewReader(data)), nil
+				},
+			},
+			expected: "v1.0.0",
+		},
+		{
 			name: "old component version with annotation present (not fallback case)",
 			ref:  "example.com/repo",
 			tag:  "v1.0.0",

--- a/bindings/go/oci/internal/validate/validate.go
+++ b/bindings/go/oci/internal/validate/validate.go
@@ -59,8 +59,11 @@ func ComponentVersionDescriptor(
 		// Checks for old component versions pre-2024 which didn't have an annotation.
 		// In that case, we check if the manifest has a config of type ocm config and if yes, we can just return
 		// the tag as valid. We only do this for manifest layers and not index layers because pre-2024 component versions
-		// didn't have indexes.
-		oldOCMComponentVersion = manifest.Config.MediaType == componentConfig.MediaType
+		// didn't have indexes. The legacy cnudie config media types identify component versions published by
+		// pre-OCM Gardener tooling, which also carry no annotation (see issue #2889).
+		oldOCMComponentVersion = manifest.Config.MediaType == componentConfig.MediaType ||
+			manifest.Config.MediaType == componentConfig.LegacyMediaType ||
+			manifest.Config.MediaType == componentConfig.Legacy2MediaType
 	case ociImageSpecV1.MediaTypeImageIndex:
 		data, err = fetcher.Fetch(ctx, desc)
 		if err != nil {

--- a/bindings/go/oci/internal/validate/validate_test.go
+++ b/bindings/go/oci/internal/validate/validate_test.go
@@ -117,6 +117,46 @@ func TestComponentVersionDescriptor(t *testing.T) {
 			expectedVersion: "v0.9.0",
 		},
 		{
+			name:      "legacy cnudie manifest without annotation",
+			component: "example.com/component",
+			tag:       "v0.8.0",
+			descriptor: ociImageSpecV1.Descriptor{
+				MediaType: ociImageSpecV1.MediaTypeImageManifest,
+			},
+			fetcher: &mockFetcher{
+				fetchFunc: func(ctx context.Context, desc ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+					manifest := ociImageSpecV1.Manifest{
+						Config: ociImageSpecV1.Descriptor{
+							MediaType: componentConfig.LegacyMediaType,
+						},
+					}
+					data, _ := json.Marshal(manifest)
+					return io.NopCloser(bytes.NewReader(data)), nil
+				},
+			},
+			expectedVersion: "v0.8.0",
+		},
+		{
+			name:      "legacy cnudie metadata manifest without annotation",
+			component: "example.com/component",
+			tag:       "v0.7.0",
+			descriptor: ociImageSpecV1.Descriptor{
+				MediaType: ociImageSpecV1.MediaTypeImageManifest,
+			},
+			fetcher: &mockFetcher{
+				fetchFunc: func(ctx context.Context, desc ociImageSpecV1.Descriptor) (io.ReadCloser, error) {
+					manifest := ociImageSpecV1.Manifest{
+						Config: ociImageSpecV1.Descriptor{
+							MediaType: componentConfig.Legacy2MediaType,
+						},
+					}
+					data, _ := json.Marshal(manifest)
+					return io.NopCloser(bytes.NewReader(data)), nil
+				},
+			},
+			expectedVersion: "v0.7.0",
+		},
+		{
 			name:      "unsupported media type",
 			component: "example.com/component",
 			tag:       "v1.0.0",

--- a/bindings/go/oci/spec/config/component/component_config.go
+++ b/bindings/go/oci/spec/config/component/component_config.go
@@ -12,6 +12,17 @@ import (
 // see https://github.com/open-component-model/ocm/blob/4a1aa4fa4668b2a0758a0d0a2d2c0e7c5d180d7e/api/ocm/extensions/repositories/genericocireg/componentmapping/constants.go#L45
 const MediaType = "application/vnd.ocm.software.component.config.v1+json"
 
+// LegacyMediaType and Legacy2MediaType are the config media types of component
+// versions published by pre-OCM Gardener (cnudie) tooling. Those manifests
+// carry no software.ocm.componentversion annotation, so the config media type
+// is the only marker identifying them as component versions. The names mirror
+// OCM v1's LegacyComponentDescriptorConfigMimeType and
+// Legacy2ComponentDescriptorConfigMimeType.
+const (
+	LegacyMediaType  = "application/vnd.gardener.cloud.cnudie.component.config.v1+json"
+	Legacy2MediaType = "application/vnd.oci.gardener.cloud.cnudie.component-descriptor-metadata.config.v2+json"
+)
+
 // Config is a Component-Descriptor OCI configuration that is used to componentVersionStore the reference to the
 // (pseudo-)layer used to componentVersionStore the Component-Descriptor in.
 type Config struct {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

`ocm get cvs` failed with "no roots provided and no roots found in the dag" for repositories published by pre-OCM Gardener (cnudie) tooling: those OCI manifests carry no `software.ocm.componentversion` annotation, so every tag
was skipped and the version list came back empty — a regression against OCM v1, which lists such repositories fine. 

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes: https://github.com/open-component-model/open-component-model/issues/2889

Signed-off-by: Piotr Janik <piotr.janik@sap.com>
