### PR TITLE
feat(constructor-digest): TEST PR for verify user-supplied resource digest at construction

### DIFF
--- a/bindings/go/constructor/runtime/constructor.go
+++ b/bindings/go/constructor/runtime/constructor.go
@@ -84,6 +84,9 @@ type Resource struct {
 	Relation ResourceRelation `json:"-"`
 	// Options bundles optional, construction-time directives for the resource.
 	Options ResourceOptions `json:"-"`
+	// Digest is the optional digest of the referenced resource.
+	// If provided, it will be verified against the calculated digest during construction.
+	Digest *Digest `json:"-"`
 	// AccessOrInput defines the access or input information of the resource.
 	// In a component constructor, there is only one access or input information.
 	AccessOrInput `json:"-"`

--- a/bindings/go/constructor/runtime/constructor.go
+++ b/bindings/go/constructor/runtime/constructor.go
@@ -84,8 +84,8 @@ type Resource struct {
 	Relation ResourceRelation `json:"-"`
 	// Options bundles optional, construction-time directives for the resource.
 	Options ResourceOptions `json:"-"`
-	// Digest is the optional digest of the referenced resource.
-	// If provided, it will be verified against the calculated digest during construction.
+	// Digest optionally pins the expected digest of the resource.
+	// If set, it is verified against the resource content during construction.
 	Digest *Digest `json:"-"`
 	// AccessOrInput defines the access or input information of the resource.
 	// In a component constructor, there is only one access or input information.

--- a/bindings/go/constructor/runtime/convert_desc.go
+++ b/bindings/go/constructor/runtime/convert_desc.go
@@ -113,6 +113,14 @@ func ConvertFromDescriptorResource(resource *descriptor.Resource) *Resource {
 		target.SourceRefs = ConvertFromDescriptorSourceRefs(resource.SourceRefs)
 	}
 
+	if resource.Digest != nil {
+		target.Digest = &Digest{
+			HashAlgorithm:          resource.Digest.HashAlgorithm,
+			NormalisationAlgorithm: resource.Digest.NormalisationAlgorithm,
+			Value:                  resource.Digest.Value,
+		}
+	}
+
 	target.AccessOrInput = ConvertAccessFromDescriptor(resource.Access)
 	return target
 }
@@ -131,6 +139,14 @@ func ConvertToDescriptorResource(resource *Resource) *descriptor.Resource {
 
 	if resource.SourceRefs != nil {
 		target.SourceRefs = ConvertToDescriptorSourceRefs(resource.SourceRefs)
+	}
+
+	if resource.Digest != nil {
+		target.Digest = &descriptor.Digest{
+			HashAlgorithm:          resource.Digest.HashAlgorithm,
+			NormalisationAlgorithm: resource.Digest.NormalisationAlgorithm,
+			Value:                  resource.Digest.Value,
+		}
 	}
 
 	target.Access = ConvertAccessToDescriptor(resource.AccessOrInput)

--- a/bindings/go/constructor/runtime/convert_desc_test.go
+++ b/bindings/go/constructor/runtime/convert_desc_test.go
@@ -1249,3 +1249,40 @@ func TestConvertFromDescriptorSourceRefs(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertResourceDigestRoundTrip(t *testing.T) {
+	digest := &Digest{
+		HashAlgorithm:          "SHA-256",
+		NormalisationAlgorithm: "genericBlobDigest/v1",
+		Value:                  "abc123",
+	}
+	input := &Resource{
+		ElementMeta: ElementMeta{
+			ObjectMeta: ObjectMeta{Name: "test-resource", Version: "1.0.0"},
+		},
+		Type:     "blob",
+		Relation: ExternalRelation,
+		Digest:   digest,
+	}
+
+	// runtime -> descriptor carries the digest.
+	desc := ConvertToDescriptorResource(input)
+	assert.NotNil(t, desc.Digest)
+	assert.Equal(t, "SHA-256", desc.Digest.HashAlgorithm)
+	assert.Equal(t, "genericBlobDigest/v1", desc.Digest.NormalisationAlgorithm)
+	assert.Equal(t, "abc123", desc.Digest.Value)
+
+	// descriptor -> runtime restores an equal digest.
+	back := ConvertFromDescriptorResource(desc)
+	assert.Equal(t, digest, back.Digest)
+}
+
+func TestConvertResourceDigestNil(t *testing.T) {
+	input := &Resource{
+		ElementMeta: ElementMeta{ObjectMeta: ObjectMeta{Name: "test-resource", Version: "1.0.0"}},
+		Type:        "blob",
+	}
+	desc := ConvertToDescriptorResource(input)
+	assert.Nil(t, desc.Digest)
+	assert.Nil(t, ConvertFromDescriptorResource(desc).Digest)
+}

--- a/bindings/go/constructor/runtime/convert_desc_test.go
+++ b/bindings/go/constructor/runtime/convert_desc_test.go
@@ -1272,9 +1272,10 @@ func TestConvertResourceDigestRoundTrip(t *testing.T) {
 	assert.Equal(t, "genericBlobDigest/v1", desc.Digest.NormalisationAlgorithm)
 	assert.Equal(t, "abc123", desc.Digest.Value)
 
-	// descriptor -> runtime restores an equal digest.
+	// descriptor -> runtime restores an equal, distinct digest.
 	back := ConvertFromDescriptorResource(desc)
 	assert.Equal(t, digest, back.Digest)
+	assert.NotSame(t, digest, back.Digest)
 }
 
 func TestConvertResourceDigestNil(t *testing.T) {

--- a/bindings/go/constructor/runtime/convert_v1.go
+++ b/bindings/go/constructor/runtime/convert_v1.go
@@ -113,6 +113,7 @@ func ConvertFromV1Resource(resource *v1.Resource) Resource {
 		Type:        resource.Type,
 		Relation:    ResourceRelation(resource.Relation),
 		Options:     ConvertFromV1ResourceOptions(resource.Options),
+		Digest:      ConvertFromV1Digest(resource.Digest),
 	}
 
 	if resource.SourceRefs != nil {
@@ -147,6 +148,7 @@ func ConvertToV1Resource(resource *Resource) (*v1.Resource, error) {
 		Type:        resource.Type,
 		Relation:    v1.ResourceRelation(resource.Relation),
 		Options:     ConvertToV1ResourceOptions(resource.Options),
+		Digest:      ConvertToV1Digest(resource.Digest),
 	}
 
 	if resource.SourceRefs != nil {
@@ -316,6 +318,7 @@ func ConvertToRuntimeConstructorResource(resource v1.Resource) Resource {
 		Type:        resource.Type,
 		Relation:    ResourceRelation(resource.Relation),
 		Options:     ConvertFromV1ResourceOptions(resource.Options),
+		Digest:      ConvertFromV1Digest(resource.Digest),
 	}
 
 	if resource.HasInput() {

--- a/bindings/go/constructor/runtime/convert_v1_test.go
+++ b/bindings/go/constructor/runtime/convert_v1_test.go
@@ -1721,3 +1721,30 @@ func TestConvertFromV1Resource(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertResourceDigestV1RoundTrip(t *testing.T) {
+	v1res := v1.Resource{
+		ElementMeta: v1.ElementMeta{
+			ObjectMeta: v1.ObjectMeta{Name: "test-resource", Version: "1.0.0"},
+		},
+		Type:     "blob",
+		Relation: v1.ExternalRelation,
+		Digest: &v1.Digest{
+			HashAlgorithm:          "SHA-256",
+			NormalisationAlgorithm: "genericBlobDigest/v1",
+			Value:                  "abc123",
+		},
+	}
+
+	// v1 -> runtime carries the digest.
+	rt := ConvertToRuntimeConstructorResource(v1res)
+	assert.NotNil(t, rt.Digest)
+	assert.Equal(t, "SHA-256", rt.Digest.HashAlgorithm)
+	assert.Equal(t, "genericBlobDigest/v1", rt.Digest.NormalisationAlgorithm)
+	assert.Equal(t, "abc123", rt.Digest.Value)
+
+	// runtime -> v1 restores an equal digest.
+	back, err := ConvertToV1Resource(&rt)
+	assert.NoError(t, err)
+	assert.Equal(t, v1res.Digest, back.Digest)
+}

--- a/bindings/go/constructor/runtime/convert_v1_test.go
+++ b/bindings/go/constructor/runtime/convert_v1_test.go
@@ -1482,6 +1482,33 @@ func TestConvertToV1Resource(t *testing.T) {
 				Options: &v1.ResourceOptions{OwnershipPolicy: "bogus"},
 			},
 		},
+		{
+			name: "resource with digest",
+			resource: &Resource{
+				ElementMeta: ElementMeta{
+					ObjectMeta: ObjectMeta{Name: "test", Version: "1.0.0"},
+				},
+				Type:     "test-type",
+				Relation: ExternalRelation,
+				Digest: &Digest{
+					HashAlgorithm:          "SHA-256",
+					NormalisationAlgorithm: "genericBlobDigest/v1",
+					Value:                  "abc123",
+				},
+			},
+			want: &v1.Resource{
+				ElementMeta: v1.ElementMeta{
+					ObjectMeta: v1.ObjectMeta{Name: "test", Version: "1.0.0"},
+				},
+				Type:     "test-type",
+				Relation: v1.ExternalRelation,
+				Digest: &v1.Digest{
+					HashAlgorithm:          "SHA-256",
+					NormalisationAlgorithm: "genericBlobDigest/v1",
+					Value:                  "abc123",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1712,6 +1739,33 @@ func TestConvertFromV1Resource(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "resource with digest",
+			resource: &v1.Resource{
+				ElementMeta: v1.ElementMeta{
+					ObjectMeta: v1.ObjectMeta{Name: "test", Version: "1.0.0"},
+				},
+				Type:     "test-type",
+				Relation: v1.ExternalRelation,
+				Digest: &v1.Digest{
+					HashAlgorithm:          "SHA-256",
+					NormalisationAlgorithm: "genericBlobDigest/v1",
+					Value:                  "abc123",
+				},
+			},
+			want: Resource{
+				ElementMeta: ElementMeta{
+					ObjectMeta: ObjectMeta{Name: "test", Version: "1.0.0"},
+				},
+				Type:     "test-type",
+				Relation: ExternalRelation,
+				Digest: &Digest{
+					HashAlgorithm:          "SHA-256",
+					NormalisationAlgorithm: "genericBlobDigest/v1",
+					Value:                  "abc123",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1742,9 +1796,53 @@ func TestConvertResourceDigestV1RoundTrip(t *testing.T) {
 	assert.Equal(t, "SHA-256", rt.Digest.HashAlgorithm)
 	assert.Equal(t, "genericBlobDigest/v1", rt.Digest.NormalisationAlgorithm)
 	assert.Equal(t, "abc123", rt.Digest.Value)
+	// The digest must be a distinct allocation, not aliased to the source.
+	assert.NotSame(t, v1res.Digest, rt.Digest)
 
-	// runtime -> v1 restores an equal digest.
+	// runtime -> v1 restores an equal, distinct digest.
 	back, err := ConvertToV1Resource(&rt)
 	assert.NoError(t, err)
 	assert.Equal(t, v1res.Digest, back.Digest)
+	assert.NotSame(t, rt.Digest, back.Digest)
+}
+
+func TestConvertResourceDigestV1Nil(t *testing.T) {
+	v1res := v1.Resource{
+		ElementMeta: v1.ElementMeta{
+			ObjectMeta: v1.ObjectMeta{Name: "test-resource", Version: "1.0.0"},
+		},
+		Type: "blob",
+	}
+	rt := ConvertToRuntimeConstructorResource(v1res)
+	assert.Nil(t, rt.Digest)
+
+	back, err := ConvertToV1Resource(&rt)
+	assert.NoError(t, err)
+	assert.Nil(t, back.Digest)
+}
+
+// TestConvertResourceDigestFullChain proves a pinned digest survives the entire
+// conversion chain v1 -> runtime -> descriptor -> runtime -> v1 unchanged.
+func TestConvertResourceDigestFullChain(t *testing.T) {
+	original := &v1.Digest{
+		HashAlgorithm:          "SHA-256",
+		NormalisationAlgorithm: "genericBlobDigest/v1",
+		Value:                  "abc123",
+	}
+	v1res := v1.Resource{
+		ElementMeta: v1.ElementMeta{
+			ObjectMeta: v1.ObjectMeta{Name: "test-resource", Version: "1.0.0"},
+		},
+		Type:     "blob",
+		Relation: v1.ExternalRelation,
+		Digest:   original,
+	}
+
+	runtimeRes := ConvertToRuntimeConstructorResource(v1res)
+	descRes := ConvertToDescriptorResource(&runtimeRes)
+	backToRuntime := ConvertFromDescriptorResource(descRes)
+	backToV1, err := ConvertToV1Resource(backToRuntime)
+	assert.NoError(t, err)
+
+	assert.Equal(t, original, backToV1.Digest)
 }

--- a/bindings/go/constructor/runtime/zz_generated.deepcopy.go
+++ b/bindings/go/constructor/runtime/zz_generated.deepcopy.go
@@ -269,6 +269,11 @@ func (in *Resource) DeepCopyInto(out *Resource) {
 		}
 	}
 	out.Options = in.Options
+	if in.Digest != nil {
+		in, out := &in.Digest, &out.Digest
+		*out = new(Digest)
+		**out = **in
+	}
 	in.AccessOrInput.DeepCopyInto(&out.AccessOrInput)
 	return
 }

--- a/bindings/go/constructor/spec/v1/constructor.go
+++ b/bindings/go/constructor/spec/v1/constructor.go
@@ -126,8 +126,8 @@ type Resource struct {
 	// Options bundles optional, construction-time directives for the resource
 	// It is omitted entirely when no options are set.
 	Options *ResourceOptions `json:"options,omitempty"`
-	// Digest is the optional digest of the referenced resource.
-	// If provided, it will be verified against the calculated digest during construction.
+	// Digest optionally pins the expected digest of the resource.
+	// If set, it is verified against the resource content during construction.
 	Digest *Digest `json:"digest,omitempty"`
 
 	AccessOrInput `json:",inline"`

--- a/bindings/go/constructor/spec/v1/constructor.go
+++ b/bindings/go/constructor/spec/v1/constructor.go
@@ -126,6 +126,9 @@ type Resource struct {
 	// Options bundles optional, construction-time directives for the resource
 	// It is omitted entirely when no options are set.
 	Options *ResourceOptions `json:"options,omitempty"`
+	// Digest is the optional digest of the referenced resource.
+	// If provided, it will be verified against the calculated digest during construction.
+	Digest *Digest `json:"digest,omitempty"`
 
 	AccessOrInput `json:",inline"`
 }

--- a/bindings/go/constructor/spec/v1/convert.go
+++ b/bindings/go/constructor/spec/v1/convert.go
@@ -26,6 +26,13 @@ func ConvertToRuntimeResource(resource Resource) descriptor.Resource {
 	if resource.ExtraIdentity != nil {
 		target.ExtraIdentity = resource.ExtraIdentity.DeepCopy()
 	}
+	if resource.Digest != nil {
+		target.Digest = &descriptor.Digest{
+			HashAlgorithm:          resource.Digest.HashAlgorithm,
+			NormalisationAlgorithm: resource.Digest.NormalisationAlgorithm,
+			Value:                  resource.Digest.Value,
+		}
+	}
 	target.Relation = descriptor.ResourceRelation(resource.Relation)
 	return target
 }

--- a/bindings/go/constructor/spec/v1/zz_generated.deepcopy.go
+++ b/bindings/go/constructor/spec/v1/zz_generated.deepcopy.go
@@ -192,6 +192,11 @@ func (in *Resource) DeepCopyInto(out *Resource) {
 		*out = new(ResourceOptions)
 		**out = **in
 	}
+	if in.Digest != nil {
+		in, out := &in.Digest, &out.Digest
+		*out = new(Digest)
+		**out = **in
+	}
 	in.AccessOrInput.DeepCopyInto(&out.AccessOrInput)
 	return
 }

--- a/bindings/go/wget/integration/constructor_digest_integration_test.go
+++ b/bindings/go/wget/integration/constructor_digest_integration_test.go
@@ -1,0 +1,138 @@
+package integration_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+
+	"ocm.software/open-component-model/bindings/go/constructor"
+	constructorruntime "ocm.software/open-component-model/bindings/go/constructor/runtime"
+	constructorv1 "ocm.software/open-component-model/bindings/go/constructor/spec/v1"
+	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+	wgetrepository "ocm.software/open-component-model/bindings/go/wget/repository"
+)
+
+// Test_Integration_WgetAccessDigestVerification drives a wget access resource through the
+// real constructor with a digest processor. A matching, author-supplied digest must pass
+// and be recorded; a mismatching one must fail construction.
+func Test_Integration_WgetAccessDigestVerification(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	content := []byte("wget-access-content")
+	sum := sha256.Sum256(content)
+	correctDigest := hex.EncodeToString(sum[:])
+
+	newServer := func(t *testing.T) *httptest.Server {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(content)
+		}))
+		t.Cleanup(srv.Close)
+		return srv
+	}
+
+	t.Run("matching digest passes and is recorded", func(t *testing.T) {
+		r := require.New(t)
+		srv := newServer(t)
+
+		repo := constructWgetAccess(t, fmt.Sprintf(`
+components:
+  - name: ocm.software/wget-app
+    version: v1.0.0
+    provider:
+      name: ocm
+    resources:
+      - name: remote
+        version: v1.0.0
+        relation: external
+        type: blob
+        access:
+          type: Wget/v1
+          url: %s/file.bin
+          mediaType: application/octet-stream
+        digest:
+          hashAlgorithm: SHA-256
+          normalisationAlgorithm: genericBlobDigest/v1
+          value: "%s"
+`, srv.URL, correctDigest))
+
+		desc, err := repo.GetComponentVersion(ctx, "ocm.software/wget-app", "v1.0.0")
+		r.NoError(err)
+		r.Len(desc.Component.Resources, 1)
+		res := desc.Component.Resources[0]
+		r.NotNil(res.Digest)
+		r.Equal(correctDigest, res.Digest.Value)
+	})
+
+	t.Run("mismatching digest fails construction", func(t *testing.T) {
+		r := require.New(t)
+		srv := newServer(t)
+
+		_, err := constructWgetAccessErr(t, fmt.Sprintf(`
+components:
+  - name: ocm.software/wget-app
+    version: v1.0.0
+    provider:
+      name: ocm
+    resources:
+      - name: remote
+        version: v1.0.0
+        relation: external
+        type: blob
+        access:
+          type: Wget/v1
+          url: %s/file.bin
+          mediaType: application/octet-stream
+        digest:
+          hashAlgorithm: SHA-256
+          normalisationAlgorithm: genericBlobDigest/v1
+          value: "0000000000000000000000000000000000000000000000000000000000000000"
+`, srv.URL))
+		r.Error(err)
+		r.ErrorContains(err, "digest mismatch")
+	})
+}
+
+// constructWgetAccess runs the constructor for a wget access resource with a digest
+// processor and returns the target repository. It fails the test if construction errors.
+func constructWgetAccess(t *testing.T, yamlData string) *inMemoryTargetRepository {
+	t.Helper()
+	repo, err := constructWgetAccessErr(t, yamlData)
+	require.NoError(t, err)
+	return repo
+}
+
+// constructWgetAccessErr is like constructWgetAccess but returns the construction error.
+func constructWgetAccessErr(t *testing.T, yamlData string) (*inMemoryTargetRepository, error) {
+	t.Helper()
+	r := require.New(t)
+
+	var spec constructorv1.ComponentConstructor
+	r.NoError(yaml.Unmarshal([]byte(yamlData), &spec))
+
+	repo := newInMemoryTargetRepository()
+	err := constructor.NewDefaultConstructor(
+		constructorruntime.ConvertToRuntimeConstructor(&spec),
+		constructor.Options{
+			TargetRepositoryProvider:        inMemoryTargetProvider{repo: repo},
+			ResourceDigestProcessorProvider: wgetDigestProvider{},
+		},
+	).Construct(context.Background())
+
+	return repo, err
+}
+
+// wgetDigestProvider resolves every resource to the wget resource repository as digest processor.
+type wgetDigestProvider struct{}
+
+func (wgetDigestProvider) GetDigestProcessor(_ context.Context, _ *descriptor.Resource) (constructor.ResourceDigestProcessor, error) {
+	return wgetrepository.NewResourceRepository(), nil
+}

--- a/cli/cmd/add/component-version/cmd.go
+++ b/cli/cmd/add/component-version/cmd.go
@@ -224,7 +224,7 @@ add component-version --%[1]s ./archive --%[2]s %[3]s.yaml
 	cmd.Flags().String(FlagBlobCacheDirectory, filepath.Join(".ocm", "cache"), "path to the blob cache directory")
 	enum.Var(cmd.Flags(), FlagComponentVersionConflictPolicy, ComponentVersionConflictPolicies(), "policy to apply when a component version already exists in the repository")
 	enum.Var(cmd.Flags(), FlagExternalComponentVersionCopyPolicy, ExternalComponentVersionCopyPolicies(), "policy to apply when a component reference to a component version outside of the constructor or target repository is encountered")
-	cmd.Flags().Bool(FlagSkipReferenceDigestProcessing, false, "skip digest processing for resources and sources. Any resource referenced via access type will not have their digest updated.")
+	cmd.Flags().Bool(FlagSkipReferenceDigestProcessing, false, "skip digest processing for resources and sources. Any resource referenced via access type will not have their digest updated, and any digest specified in the constructor will not be verified against the referenced content.")
 	enum.VarP(cmd.Flags(), FlagOutput, "o", []string{render.OutputFormatTable.String(), render.OutputFormatYAML.String(), render.OutputFormatJSON.String(), render.OutputFormatNDJSON.String(), render.OutputFormatTree.String()}, "output format of the component descriptors")
 	enum.VarP(cmd.Flags(), FlagDisplayMode, "", []string{render.StaticRenderMode, render.LiveRenderMode}, `static: print the output once the complete component graph is discovered
   live (experimental): continuously updates the output to represent the current construction state of the component graph`)
@@ -314,6 +314,10 @@ func AddComponentVersion(cmd *cobra.Command, _ []string) error {
 	constructorSpec, err := GetComponentConstructor(constructorFile)
 	if err != nil {
 		return fmt.Errorf("getting component constructor failed: %w", err)
+	}
+
+	if skipReferenceDigestProcessing {
+		warnOnSkippedDigestVerification(cmd.Context(), constructorSpec)
 	}
 
 	output, err := enum.Get(cmd.Flags(), FlagOutput)
@@ -427,6 +431,28 @@ func GetComponentConstructor(file *file.Flag) (*constructorruntime.ComponentCons
 	}
 
 	return constructorruntime.ConvertToRuntimeConstructor(&data), nil
+}
+
+// warnOnSkippedDigestVerification emits a warning for every resource that carries an
+// explicit digest while reference digest processing is skipped. In that case the digest
+// is recorded as-is but never verified against the referenced content, so a stale or
+// wrong digest would go unnoticed.
+func warnOnSkippedDigestVerification(ctx context.Context, constructorSpec *constructorruntime.ComponentConstructor) {
+	if constructorSpec == nil {
+		return
+	}
+	for _, component := range constructorSpec.Components {
+		for _, resource := range component.Resources {
+			if resource.Digest == nil {
+				continue
+			}
+			slog.WarnContext(ctx,
+				"resource specifies a digest but reference digest processing is skipped; the digest will not be verified against the referenced content",
+				slog.String("component", component.Name),
+				slog.String("resource", resource.Name),
+			)
+		}
+	}
 }
 
 func getComponentConstructorFile(cmd *cobra.Command) (*file.Flag, error) {


### PR DESCRIPTION
This draft PR contains changes to constructor and cli to be able to test the changes across modules. I'll close it once the single module PRs have been merged.

The PR lets an author pin the expected digest of an access-referenced resource directly in the component constructor. During `ocm add cv` the digest is carried into the descriptor before digest processing runs, so the existing verify path checks the downloaded content against it and fails on mismatch. The JSON schema already accepted `digest` on access-based resources — this wires it through the Go types and conversions.

- New optional `digest` field on constructor resources (spec + runtime + conversions)
- Warns when a resource carries a digest while `--skip-reference-digest-processing` is set (recorded but not verified)
- Round-trip + wget access verification tests

Follow-up: adopt this in the OCM release workflow's component constructor (`.github/components/ocm-release/component-constructor.yaml`), sourcing per-asset SHA-256 from the GitHub attestation subjects. Separate PR, since it needs a released CLI that understands the field.
