### PR TITLE
fix: update renovate config to not abort on hiccup

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -324,4 +324,13 @@
     ],
     executionMode: 'branch',
   },
+  // Prevent a transient npm registry hiccup from aborting the whole run.
+  // See renovatebot/renovate#26196.
+  hostRules: [
+    {
+      matchHost: 'registry.npmjs.org',
+      timeout: 120000,
+      abortOnError: false,
+    },
+  ],
 }

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -68,7 +68,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.OCMBOT_APP_ID }}
+          client-id: ${{ secrets.OCMBOT_APP_ID }}
           private-key: ${{ secrets.OCMBOT_PRIV_KEY }}
           repositories: ${{ github.event.repository.name }}
           # Post per-PR check results.
@@ -83,6 +83,8 @@ jobs:
           permission-statuses: write
           # Bump action SHAs in .github/workflows/*.
           permission-workflows: write
+          # Read Dependabot alerts so Renovate can prioritize security updates.
+          permission-vulnerability-alerts: read
 
       - name: Ensure Dry-Run on Pull Requests
         if: ${{ github.event_name == 'pull_request' }}
@@ -98,7 +100,7 @@ jobs:
           RENOVATE_ONBOARDING: 'false'
           RENOVATE_USERNAME: 'ocmbot[bot]'
           RENOVATE_PLATFORM: 'github'
-          RENOVATE_PLATFORM_COMMIT: 'true'
+          RENOVATE_PLATFORM_COMMIT: 'enabled'
           RENOVATE_REPOSITORIES: "${{ github.repository }}"
           RENOVATE_REPOSITORY_CACHE: ${{ github.event_name == 'workflow_dispatch' && inputs.repoCache || 'enabled' }}
           RENOVATE_ALLOWED_COMMANDS: |


### PR DESCRIPTION
[Last run](https://github.com/open-component-model/open-component-model/actions/runs/30342728530) finished with `external-host-error` and skipped the PR write phase - nothing created, updated, or closed. Gomod / actions / docker updates all affected, not just npm.

A single npm lookup for `@types/node` timed out against the npm registry. npm's datasource defaults to `abortOnError: true`, so on an onboarded repo that timeout escalates to a repo-wide abort: renovate deletes the branch list and skips the PR write phase for every manager, not just npm.

With `abortOnError: false` scoped to the npm host, a slow npm lookup just skips that one dep for that run. Everything else ships.

Also folded in three deprecation-warning cleanups on the workflow (`app-id` -> `client-id`, `RENOVATE_PLATFORM_COMMIT: 'enabled'`, `permission-vulnerability-alerts: read`).