### PR TITLE
chore: add Go module bindings for GitHub access specification

### DIFF
--- a/website/static/open-component-model/bindings/go/github
+++ b/website/static/open-component-model/bindings/go/github
@@ -1,0 +1,10 @@
+<html><head>
+  <meta name="go-import"
+        content="ocm.software/open-component-model
+                 git https://github.com/open-component-model/open-component-model">
+  <meta name="go-source"
+        content="ocm.software/open-component-model
+                 https://github.com/open-component-model/open-component-model
+                 https://github.com/open-component-model/open-component-model/tree/main{/dir}
+                 https://github.com/open-component-model/open-component-model/blob/main{/dir}/{file}#L{line}">
+</head></html>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Adds Go module bindings for GitHub access specification

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Contributes: https://github.com/open-component-model/ocm-project/issues/1070

##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
