### PR TITLE
docs(agents): document the kind/* PR-label rule

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -74,6 +74,14 @@ chore(deps): update dependencies
 
 Types: `feat`, `fix`, `chore`, `docs`, `test`, `perf`. Breaking changes use `!`: `feat(api)!: remove deprecated method`.
 
+### PR Labels
+
+Every PR needs at least one `kind/*` label or the `verify-labels` check rejects it.
+The title auto-labeler assigns one only for `feat` (`kind/feature`), `fix` (`kind/bugfix`),
+and `chore` (`kind/chore`). It does not for `docs`, `test`, or `perf`: those map to `area/*`
+only, so add a `kind/*` label by hand on such PRs (usually `kind/chore`). Accepted values:
+`kind/feature`, `kind/bugfix`, `kind/chore`, `kind/dependency`, `kind/refactor`.
+
 ### Code Generation
 
 Use `task generate` after adding or modifying code generation markers. 


### PR DESCRIPTION
Documents a PR-label rule that was missing and obscured.

`verify-labels` rejects any PR without a `kind/*` label. The title auto-labeler assigns one only for `feat`, `fix`, and `chore`. `docs`, `test`, and `perf` map to `area/*` only, so those PRs need a `kind/*` added by hand. The guide did not say this, and its "auto-labeling" mention implied it was handled, so `docs:`/`test:`/`perf:` PRs silently fail the check.
