### PR TITLE
docs(website): add component-based CLI installation method

### DIFF
--- a/website/content/docs/getting-started/ocm-cli-installation.md
+++ b/website/content/docs/getting-started/ocm-cli-installation.md
@@ -36,6 +36,70 @@ curl -sfL https://ocm.software/install-cli.sh | {{< site-version "env" >}}bash
 ```
 
 {{< /tab >}}
+{{< tab "OCM Component" >}}
+
+OCM distributes its own CLI as an OCM component version, the same mechanism it enables
+for your software.
+
+{{< callout title="Requires an existing OCM installation" icon="outline/info-circle" >}}
+This method needs `ocm` already on your PATH. For a first install, use the `wget` or `curl`
+tab instead. If you have Docker but no `ocm`, see the [Docker bootstrap](#docker-bootstrap)
+section below.
+{{< /callout >}}
+
+Download the CLI binary for your platform. Replace `os` and `architecture` as needed
+(`linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, `windows/arm64`).
+The binary will be downloaded to the current working directory (specify `--output` to set the full output path, including filename):
+
+```shell
+ocm download resource \
+  ghcr.io/open-component-model//ocm.software/cli:{{< site-version "semver" >}} \
+  --identity os=linux,architecture=amd64
+```
+
+Then make the downloaded binary executable and move it to your PATH:
+
+```shell
+chmod +x ./ocm
+mkdir -p $HOME/.local/bin
+mv ./ocm $HOME/.local/bin/ocm
+```
+
+{{< callout title="Windows" icon="outline/info-circle" >}}
+The resource is downloaded as `ocm.exe` for Windows platform if not specified otherwise using the `--output` option.
+Make sure to add the directory containing `ocm.exe` to your PATH.
+{{< /callout >}}
+
+To inspect the full component version before downloading:
+
+```shell
+ocm get cv ghcr.io/open-component-model//ocm.software/cli:{{< site-version "semver" >}} -o yaml
+```
+
+<details id="docker-bootstrap">
+<summary>Docker bootstrap (no existing OCM installation)</summary>
+
+Use the official OCM container image as a one-time downloader. The image contains the
+`ocm` binary and writes the downloaded resource to its working directory, which you can
+map to a local path via a volume mount:
+
+```shell
+mkdir -p "$HOME/.local/bin"
+docker run --rm \
+  -v "$HOME/.local/bin:/workspace" \
+  -w /workspace \
+  ghcr.io/open-component-model/cli:{{< site-version "semver" >}} \
+  download resource \
+  ghcr.io/open-component-model//ocm.software/cli:{{< site-version "semver" >}} \
+  --identity os=linux,architecture=amd64
+chmod +x "$HOME/.local/bin/ocm"
+```
+
+Replace `os` and `architecture` with your platform. This approach works on Linux and macOS.
+
+</details>
+
+{{< /tab >}}
 {{< tab "Build from Source" >}}
 
 {{< callout title="Note" icon="outline/info-circle" >}}
@@ -101,6 +165,15 @@ Expected output:
 {"major":"0","minor":"1","patch":"0","gitVersion":"0.1.0","goVersion":"go1.26.0","compiler":"gc","platform":"darwin/arm64"}
 ```
 
+{{< callout title="If the output looks different" icon="outline/info-circle" >}}
+If the field names are **capitalised** (`Major`, `Minor`, `Patch`), you are running the legacy v1
+CLI, not v2. A previous v1 installation is shadowing the new binary. Run `which ocm` (Linux/macOS)
+or `where.exe ocm` (Windows) to see which binary is active — then either move `~/.local/bin` earlier
+in your PATH or remove the v1 binary. Common v1 install locations are `/opt/homebrew/bin`
+(Homebrew), `/usr/local/bin` (old install script), `~/go/bin` (built from source), and the Nix
+profile store.
+{{< /callout >}}
+
 ## Verify Binary Authenticity
 
 The install script automatically verifies binaries using [GitHub attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) when the [GitHub CLI](https://cli.github.com/) is authenticated.
@@ -110,7 +183,7 @@ If automatic verification is unavailable, you can verify manually using one of t
 
 {{< tab "GitHub CLI" >}}
 
-The simplest method — requires the [GitHub CLI](https://cli.github.com/) with authentication.
+The simplest method: requires the [GitHub CLI](https://cli.github.com/) with authentication.
 
 ```shell
 gh auth login --hostname github.com
@@ -121,7 +194,7 @@ gh attestation verify $(which ocm) --repo open-component-model/open-component-mo
 {{< tab "Cosign (no GitHub auth)" >}}
 
 Uses [Sigstore cosign](https://docs.sigstore.dev/cosign/signing/overview/) to cryptographically verify the binary's provenance.
-No GitHub authentication required — the attestation API is public.
+No GitHub authentication required: the attestation API is public.
 
 ```shell
 # Compute the binary's SHA-256 digest

--- a/website/layouts/shortcodes/site-version.html
+++ b/website/layouts/shortcodes/site-version.html
@@ -7,6 +7,20 @@ git checkout releases/v{{ $version }}
 {{- else if eq $format "env" -}}
   {{- if ne $version "main" -}}
 OCM_VERSION={{ $version }} {{ end -}}
+{{- else if eq $format "semver" -}}
+  {{/* Full major.minor.0 for OCM component/image references. The version config
+       only carries major.minor names, so .0 is appended (patches are not tracked
+       here). On the "main" docs there is no installable "main" component, so the
+       reference resolves to the latest release: the default content version. */}}
+  {{- $base := $version -}}
+  {{- if eq $version "main" -}}
+    {{- range .Site.Home.Rotate "version" -}}
+      {{- if .Site.Version.IsDefault -}}
+        {{- $base = .Site.Version.Name -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $base -}}.0
 {{- else -}}
   {{- $version -}}
 {{- end -}}


### PR DESCRIPTION
## What

Adds a tab for component-based installation method to the [CLI installation guide](https://ocm.software/docs/getting-started/install-the-ocm-cli/), closing the gap where this was only mentioned in release notes.

- New **"OCM Component"** tab showing how to install the CLI via `ocm download resource` from the published `ocm.software/cli` component,  same distribution mechanism OCM enables for user software.
- **Docker bootstrap** (collapsible) for users without an existing `ocm` binary, using the official `ghcr.io/open-component-model/cli` container image as a one-time downloader.
- **Windows callout**: the resource downloads as `ocm` on every platform (via the `downloadName` label), so Windows users rename it to `ocm.exe`; the Docker bootstrap is Linux/macOS only.

Added to the  `site-version` shortcode a `semver` format that renders a full `major.minor.0` reference. On the `main` docs - where no installable `main` component exists - it resolves to the latest release (default content version) using the same `Rotate`/`IsDefault` pattern as `version-banner.html`. This is then used in the doc.

## Why

Existing OCM users can install/upgrade the CLI through OCM itself, and it's the sharpest proof-of-concept for the model: OCM distributing OCM. The hen-and-egg problem (you need the CLI to pull from a component) is handled by the Docker bootstrap path.

## Testing

Verified against the live registry (`ghcr.io/open-component-model//ocm.software/cli:0.12.0`):

- `ocm download resource` with the `Wget/v1` access type works with a current CLI build; the `downloadName` label forces the output filename to `ocm`, and the binary needs `chmod +x`.
- The Docker bootstrap (`-v "$HOME/...:/workspace" -w /workspace`) writes the binary to the mounted directory as expected.
- `npm run build` is clean; the shortcode renders `0.12.0` on the `main` build (resolved from the default version) with no stray whitespace.

Refs open-component-model/ocm-project#1227
