### PR TITLE
docs: how-to for running multiple OCM CLI versions in parallel

### DIFF
--- a/.github/config/wordlist.txt
+++ b/.github/config/wordlist.txt
@@ -940,3 +940,4 @@ Neisener
 ilja
 iljaweis
 weis
+direnv

--- a/.github/config/wordlist.txt
+++ b/.github/config/wordlist.txt
@@ -941,3 +941,4 @@ ilja
 iljaweis
 weis
 direnv
+unversioned

--- a/website/content/docs/how-to/parallel-cli-versions.md
+++ b/website/content/docs/how-to/parallel-cli-versions.md
@@ -1,0 +1,148 @@
+---
+title: "Run multiple OCM CLI versions in parallel"
+description: "Install and switch between specific OCM CLI versions for testing and migration."
+icon: "🔀"
+weight: 15
+toc: true
+---
+
+## Goal
+
+Install multiple OCM CLI versions side-by-side and switch between them — useful when testing against a release candidate, validating a migration, or reproducing version-specific behavior.
+
+## You'll end up with
+
+- Multiple versioned OCM CLI binaries (e.g. `ocm-v0.11.0`, `ocm-v0.12.0`) on your PATH
+- Optionally, a per-project version pin using `direnv`
+
+**Estimated time:** ~10 minutes
+
+## Prerequisites
+
+Either:
+- An [OCM CLI already installed]({{< relref "ocm-cli-installation.md" >}}), or
+- Docker (to bootstrap without an existing installation — see the [Docker bootstrap]({{< relref "ocm-cli-installation.md" >}}) section in the install guide)
+
+And:
+- `~/.local/bin` on your PATH (the default location from the [install guide]({{< relref "ocm-cli-installation.md" >}}))
+- [direnv](https://direnv.net) if you want per-project version pinning (optional)
+
+## Download a specific version
+
+OCM distributes its own CLI as an OCM component. Any published version can be fetched directly — no package manager or version switcher tool needed.
+
+`--output` is required here: without it the binary is saved as `ocm` (or `ocm.exe` on Windows), overwriting your current installation. Always include the full versioned filename in the output path.
+
+{{< tabs "download-methods" >}}
+{{< tab "Existing OCM CLI" >}}
+
+Use your current `ocm` installation to download any version:
+
+```shell
+ocm download resource \
+  ghcr.io/open-component-model//ocm.software/cli:v0.12.0 \
+  --identity os=linux,architecture=amd64 \
+  --output ~/.local/bin/ocm-v0.12.0
+chmod +x ~/.local/bin/ocm-v0.12.0
+```
+
+Repeat for each version you need, substituting the tag and output filename.
+
+{{< /tab >}}
+{{< tab "Docker (no existing OCM)" >}}
+
+Use the container image as a one-time downloader. The same approach works whether you have `ocm` installed or not:
+
+```shell
+docker run --rm \
+  -v "$HOME/.local/bin:/workspace" \
+  -w /workspace \
+  ghcr.io/open-component-model/cli:v0.12.0 \
+  download resource \
+  ghcr.io/open-component-model//ocm.software/cli:v0.12.0 \
+  --identity os=linux,architecture=amd64 \
+  --output /workspace/ocm-v0.12.0
+chmod +x ~/.local/bin/ocm-v0.12.0
+```
+
+{{< /tab >}}
+{{< /tabs >}}
+
+{{< callout title="Windows" icon="outline/info-circle" >}}
+Include `.exe` in the output filename. Without it the binary won't be runnable:
+
+```powershell
+ocm download resource `
+  ghcr.io/open-component-model//ocm.software/cli:v0.12.0 `
+  --identity os=windows,architecture=amd64 `
+  --output "$HOME\.local\bin\ocm-v0.12.0.exe"
+```
+{{< /callout >}}
+
+{{< callout title="Release candidates" icon="outline/info-circle" >}}
+RC tags follow the same scheme: `v0.13.0-rc.1`, `v0.13.0-rc.2`, etc. Substitute the RC tag for any stable version tag above.
+{{< /callout >}}
+
+## Verify
+
+```shell
+ocm-v0.12.0 version
+ocm-v0.11.0 version
+```
+
+Each command should print its own version JSON, confirming both binaries are independent and functional.
+
+## Pin a version to a project directory
+
+To use a specific OCM version inside one directory without affecting anything else on your system, use [direnv](https://direnv.net).
+
+Create a local `ocm` symlink pointing at the versioned binary, then tell direnv to prepend it to PATH:
+
+```shell
+mkdir -p .bin
+ln -sf ~/.local/bin/ocm-v0.12.0 .bin/ocm
+echo 'PATH_add .bin' >> .envrc
+direnv allow
+```
+
+When you enter the directory, `ocm` resolves to `v0.12.0`. Outside it, your default `ocm` is unchanged.
+
+Verify the pin is active:
+
+```shell
+which ocm    # should print .bin/ocm
+ocm version  # should print v0.12.0
+```
+
+{{< callout title="Note" icon="outline/info-circle" >}}
+Add `.bin/` to your `.gitignore` to avoid committing the symlink.
+{{< /callout >}}
+
+## Troubleshooting
+
+### Symptom: `command not found: ocm-v0.12.0`
+
+**Cause:** `~/.local/bin` is not on your PATH, or the binary was not made executable.
+
+**Fix:**
+
+```shell
+chmod +x ~/.local/bin/ocm-v0.12.0
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc  # or ~/.zshrc
+source ~/.bashrc
+```
+
+### Symptom: `ocm` inside the project still resolves to the system binary
+
+**Cause:** direnv is not installed, or `.envrc` has not been allowed.
+
+**Fix:**
+
+```shell
+direnv allow   # run from inside the project directory
+```
+
+## Next steps
+
+- [Install the OCM CLI]({{< relref "ocm-cli-installation.md" >}}) — full installation options including attestation verification
+- [Download resources from component versions]({{< relref "download-resources-from-component-versions.md" >}}) — the mechanism this guide is built on

--- a/website/content/docs/how-to/parallel-cli-versions.md
+++ b/website/content/docs/how-to/parallel-cli-versions.md
@@ -13,9 +13,8 @@ Install multiple OCM CLI versions side-by-side and switch between them, useful f
 ## You'll end up with
 
 - Multiple versioned OCM CLI binaries (e.g. `ocm-v0.11.0`, `ocm-v0.12.0`) on your PATH
-- Optionally, a per-project version pin using `direnv`
 
-**Estimated time:** ~10 minutes
+**Estimated time:** ~5 minutes
 
 ## Prerequisites
 
@@ -27,7 +26,6 @@ Either:
 And:
 
 - `~/.local/bin` on your PATH (the default location from the [install guide]({{< relref "ocm-cli-installation.md" >}}))
-- [direnv](https://direnv.net) if you want per-project version pinning (optional)
 
 ## Download a specific version
 
@@ -96,32 +94,6 @@ ocm-v0.11.0 version
 
 Each command should print its own version JSON, confirming both binaries are independent and functional.
 
-## Pin a version to a project directory
-
-To use a specific OCM version inside one directory without affecting anything else on your system, use [direnv](https://direnv.net).
-
-Create a local `ocm` symlink pointing at the versioned binary, then tell direnv to prepend it to PATH:
-
-```shell
-mkdir -p .bin
-ln -sf ~/.local/bin/ocm-v0.12.0 .bin/ocm
-echo 'PATH_add .bin' >> .envrc
-direnv allow
-```
-
-When you enter the directory, `ocm` resolves to `v0.12.0`. Outside it, your default `ocm` is unchanged.
-
-Verify the pin is active:
-
-```shell
-which ocm    # should print .bin/ocm
-ocm version  # should print v0.12.0
-```
-
-{{< callout title="Note" icon="outline/info-circle" >}}
-Add `.bin/` to your `.gitignore` to avoid committing the symlink.
-{{< /callout >}}
-
 ## Troubleshooting
 
 ### Symptom: `command not found: ocm-v0.12.0`
@@ -138,16 +110,6 @@ source ~/.bashrc
 # Zsh:
 # echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
 # source ~/.zshrc
-```
-
-### Symptom: `ocm` inside the project still resolves to the system binary
-
-**Cause:** direnv is not installed, or `.envrc` has not been allowed.
-
-**Fix:**
-
-```shell
-direnv allow   # run from inside the project directory
 ```
 
 ## Next steps

--- a/website/content/docs/how-to/parallel-cli-versions.md
+++ b/website/content/docs/how-to/parallel-cli-versions.md
@@ -20,10 +20,12 @@ Install multiple OCM CLI versions side-by-side and switch between them, useful f
 ## Prerequisites
 
 Either:
+
 - An [OCM CLI already installed]({{< relref "ocm-cli-installation.md" >}}), or
 - Docker (to bootstrap without an existing installation; see the [Docker bootstrap]({{< relref "ocm-cli-installation.md" >}}) section in the install guide)
 
 And:
+
 - `~/.local/bin` on your PATH (the default location from the [install guide]({{< relref "ocm-cli-installation.md" >}}))
 - [direnv](https://direnv.net) if you want per-project version pinning (optional)
 
@@ -36,7 +38,8 @@ OCM distributes its own CLI as an OCM component. Any published version can be fe
 {{< tabs "download-methods" >}}
 {{< tab "Existing OCM CLI" >}}
 
-Use your current `ocm` installation to download any version:
+Use your current `ocm` installation to download any version.
+Replace `os` and `architecture` with your platform values (`linux/darwin`, `amd64/arm64`):
 
 ```shell
 ocm download resource \
@@ -49,9 +52,10 @@ chmod +x ~/.local/bin/ocm-v0.12.0
 Repeat for each version you need, substituting the tag and output filename.
 
 {{< /tab >}}
-{{< tab "Docker (no existing OCM)" >}}
+{{< tab "Docker (Linux/macOS)" >}}
 
-Use the container image as a one-time downloader. The same approach works whether you have `ocm` installed or not:
+Use the container image as a one-time downloader on Linux or macOS.
+Replace `os` and `architecture` with your platform values (`linux/darwin`, `amd64/arm64`):
 
 ```shell
 docker run --rm \
@@ -128,8 +132,12 @@ Add `.bin/` to your `.gitignore` to avoid committing the symlink.
 
 ```shell
 chmod +x ~/.local/bin/ocm-v0.12.0
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc  # or ~/.zshrc
+# Bash:
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 source ~/.bashrc
+# Zsh:
+# echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
+# source ~/.zshrc
 ```
 
 ### Symptom: `ocm` inside the project still resolves to the system binary

--- a/website/content/docs/how-to/parallel-cli-versions.md
+++ b/website/content/docs/how-to/parallel-cli-versions.md
@@ -8,7 +8,7 @@ toc: true
 
 ## Goal
 
-Install multiple OCM CLI versions side-by-side and switch between them — useful when testing against a release candidate, validating a migration, or reproducing version-specific behavior.
+Install multiple OCM CLI versions side-by-side and switch between them, useful for testing against a release candidate, validating a migration, or reproducing version-specific behavior.
 
 ## You'll end up with
 
@@ -21,7 +21,7 @@ Install multiple OCM CLI versions side-by-side and switch between them — usefu
 
 Either:
 - An [OCM CLI already installed]({{< relref "ocm-cli-installation.md" >}}), or
-- Docker (to bootstrap without an existing installation — see the [Docker bootstrap]({{< relref "ocm-cli-installation.md" >}}) section in the install guide)
+- Docker (to bootstrap without an existing installation; see the [Docker bootstrap]({{< relref "ocm-cli-installation.md" >}}) section in the install guide)
 
 And:
 - `~/.local/bin` on your PATH (the default location from the [install guide]({{< relref "ocm-cli-installation.md" >}}))
@@ -29,7 +29,7 @@ And:
 
 ## Download a specific version
 
-OCM distributes its own CLI as an OCM component. Any published version can be fetched directly — no package manager or version switcher tool needed.
+OCM distributes its own CLI as an OCM component. Any published version can be fetched directly, with no package manager or version switcher tool needed.
 
 `--output` is required here: without it the binary is saved as `ocm` (or `ocm.exe` on Windows), overwriting your current installation. Always include the full versioned filename in the output path.
 
@@ -144,5 +144,5 @@ direnv allow   # run from inside the project directory
 
 ## Next steps
 
-- [Install the OCM CLI]({{< relref "ocm-cli-installation.md" >}}) — full installation options including attestation verification
-- [Download resources from component versions]({{< relref "download-resources-from-component-versions.md" >}}) — the mechanism this guide is built on
+- [Install the OCM CLI]({{< relref "ocm-cli-installation.md" >}}): full installation options including attestation verification
+- [Download resources from component versions]({{< relref "download-resources-from-component-versions.md" >}}): the mechanism this guide is built on

--- a/website/content/docs/how-to/parallel-cli-versions.md
+++ b/website/content/docs/how-to/parallel-cli-versions.md
@@ -96,9 +96,13 @@ ocm-v0.11.0 version
 
 Each command should print its own version JSON, confirming both binaries are independent and functional.
 
-## Pin a version to a project directory
+## Pin a version to a project directory (macOS / Linux / WSL)
 
 To use a specific OCM version inside one directory without affecting anything else on your system, use [direnv](https://direnv.net).
+
+{{< callout title="Prerequisite" icon="outline/info-circle" >}}
+This section requires direnv to be installed **and** its shell hook configured in your shell profile. Add `eval "$(direnv hook bash)"` to `~/.bashrc` (Bash) or `eval "$(direnv hook zsh)"` to `~/.zshrc` (Zsh), then restart your shell. See the [direnv hook docs](https://direnv.net/docs/hook.html) for details.
+{{< /callout >}}
 
 Create a local `ocm` symlink pointing at the versioned binary, then tell direnv to prepend it to PATH:
 
@@ -130,14 +134,20 @@ Add `.bin/` to your `.gitignore` to avoid committing the symlink.
 
 **Fix:**
 
+Bash:
+
 ```shell
 chmod +x ~/.local/bin/ocm-v0.12.0
-# Bash:
 echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 source ~/.bashrc
-# Zsh:
-# echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
-# source ~/.zshrc
+```
+
+Zsh:
+
+```shell
+chmod +x ~/.local/bin/ocm-v0.12.0
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
+source ~/.zshrc
 ```
 
 ### Symptom: `ocm` inside the project still resolves to the system binary

--- a/website/content/docs/how-to/parallel-cli-versions.md
+++ b/website/content/docs/how-to/parallel-cli-versions.md
@@ -33,7 +33,7 @@ And:
 
 OCM distributes its own CLI as an OCM component. Any published version can be fetched directly, with no package manager or version switcher tool needed.
 
-`--output` is required here: without it the binary is saved as `ocm` (or `ocm.exe` on Windows), overwriting your current installation. Always include the full versioned filename in the output path.
+`--output` sets the destination path including the filename. Without it the binary is written to the current working directory under the name from the `downloadName` label (`ocm` or `ocm.exe` on Windows), which would place an unversioned binary wherever you happen to run the command. Always include the full versioned filename in the output path.
 
 {{< tabs "download-methods" >}}
 {{< tab "Existing OCM CLI" >}}

--- a/website/content/docs/how-to/parallel-cli-versions.md
+++ b/website/content/docs/how-to/parallel-cli-versions.md
@@ -1,5 +1,5 @@
 ---
-title: "Run multiple OCM CLI versions in parallel"
+title: "Install multiple OCM CLI versions in parallel"
 description: "Install and switch between specific OCM CLI versions for testing and migration."
 icon: "🔀"
 weight: 15

--- a/website/content/docs/how-to/parallel-cli-versions.md
+++ b/website/content/docs/how-to/parallel-cli-versions.md
@@ -8,7 +8,7 @@ toc: true
 
 ## Goal
 
-Install multiple OCM CLI versions side-by-side and switch between them, useful for testing against a release candidate, validating a migration, or reproducing version-specific behavior.
+Install multiple OCM CLI versions side-by-side and switch between them, useful for using v1 (legacy) and current OCM CLI version in parallel, testing against a release candidate, or debugging version-specific behavior.
 
 ## You'll end up with
 
@@ -96,13 +96,9 @@ ocm-v0.11.0 version
 
 Each command should print its own version JSON, confirming both binaries are independent and functional.
 
-## Pin a version to a project directory (macOS / Linux / WSL)
+## Pin a version to a project directory
 
 To use a specific OCM version inside one directory without affecting anything else on your system, use [direnv](https://direnv.net).
-
-{{< callout title="Prerequisite" icon="outline/info-circle" >}}
-This section requires direnv to be installed **and** its shell hook configured in your shell profile. Add `eval "$(direnv hook bash)"` to `~/.bashrc` (Bash) or `eval "$(direnv hook zsh)"` to `~/.zshrc` (Zsh), then restart your shell. See the [direnv hook docs](https://direnv.net/docs/hook.html) for details.
-{{< /callout >}}
 
 Create a local `ocm` symlink pointing at the versioned binary, then tell direnv to prepend it to PATH:
 
@@ -134,20 +130,14 @@ Add `.bin/` to your `.gitignore` to avoid committing the symlink.
 
 **Fix:**
 
-Bash:
-
 ```shell
 chmod +x ~/.local/bin/ocm-v0.12.0
+# Bash:
 echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 source ~/.bashrc
-```
-
-Zsh:
-
-```shell
-chmod +x ~/.local/bin/ocm-v0.12.0
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
-source ~/.zshrc
+# Zsh:
+# echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
+# source ~/.zshrc
 ```
 
 ### Symptom: `ocm` inside the project still resolves to the system binary

--- a/website/content/docs/how-to/parallel-cli-versions.md
+++ b/website/content/docs/how-to/parallel-cli-versions.md
@@ -22,7 +22,7 @@ Install multiple OCM CLI versions side-by-side and switch between them, useful f
 Either:
 
 - An [OCM CLI already installed]({{< relref "ocm-cli-installation.md" >}}), or
-- Docker (to bootstrap without an existing installation; see the [Docker bootstrap]({{< relref "ocm-cli-installation.md" >}}) section in the install guide)
+- Docker (to bootstrap without an existing installation; see the [Docker bootstrap]({{< relref "ocm-cli-installation.md" >}}#docker-bootstrap) section in the install guide)
 
 And:
 


### PR DESCRIPTION
Inspired by @piotrjanik 's [comment](https://github.com/open-component-model/open-component-model/pull/3235#discussion_r3691240793) I added a how-to guide for installing and switching between multiple OCM CLI versions side-by-side, useful for testing against a release candidate, having v1 and v2 in parallel or reproducing the behavior of a specific version for debugging.

#3235 should be merged first to get the link to the Docker bootstrap mentioned in the prerequisite not fail with a 404 (same happen in the deploy preview in this PR).

Closes #3260