### PR TITLE
chore(fix): SIG-CHARTER file was calching with the Steering Charter

### DIFF
--- a/docs/community/SIGs/CONTRIBUTING.md
+++ b/docs/community/SIGs/CONTRIBUTING.md
@@ -24,7 +24,7 @@ This guide covers participation in the SIG itself. For contributing **code** to 
 
 1. Read the [SIG Handbook](./SIG-Handbook.md) for governance and lifecycle rules.
 2. Browse [`sigs.yaml`](./sigs.yaml) and pick the SIG whose scope matches your interest. Each SIG has its own folder with a charter and meeting notes.
-3. Skim the [SIG Runtime charter](./Runtime/SIG-Runtime-CHARTER.md) so you know what is in scope and what is not.
+3. Skim the [SIG Runtime Overview](Runtime/SIG-Runtime-OVERVIEW.md) so you know what is in scope and what is not.
 4. Join the SIG's channels (listed in the charter) and read the [OCM Code of Conduct](https://github.com/open-component-model/.github/blob/main/CODE_OF_CONDUCT.md).
 
 ## Ways to Participate
@@ -39,7 +39,7 @@ There is no single ladder. These are the SIG-specific entry points; for the gene
 
 ## Communication and Meetings
 
-- **SIG channels and meeting time:** [SIG Runtime charter, Communication](./Runtime/SIG-Runtime-CHARTER.md#communication) and [Meetings](./Runtime/SIG-Runtime-CHARTER.md#meetings).
+- **SIG channels and meeting time:** [SIG Runtime Overview, Communication](Runtime/SIG-Runtime-OVERVIEW.md#communication) and [Meetings](Runtime/SIG-Runtime-OVERVIEW.md#meetings).
 - **Project-wide channels:** [ocm.software/community](https://ocm.software/community).
 - **OCM Community Call and TSC meeting:** [How We Work](https://ocm.software/community/how-we-work/).
 
@@ -60,7 +60,7 @@ Voting rights may lapse after extended inactivity. The full rules, including quo
 
 ### Charter or scope change
 
-Open a PR against the [SIG Runtime charter](./Runtime/SIG-Runtime-CHARTER.md). Add the change to the next TSC agenda.
+Open a PR against the [SIG Runtime Overview](Runtime/SIG-Runtime-OVERVIEW.md). Add the change to the next TSC agenda.
 Major changes require a two-thirds supermajority of voting members and TSC approval.
 
 ### New SIG
@@ -73,4 +73,4 @@ For larger changes, please open an [ADR](../../adr) first.
 
 ## Need Help?
 
-Ask in the SIG channels listed in the [charter](./Runtime/SIG-Runtime-CHARTER.md#communication), or at the next community call. The Chair and Tech Lead listed in the [SIG Runtime charter](./Runtime/SIG-Runtime-CHARTER.md#roles) are the right first contacts. All participation is governed by the [OCM Code of Conduct](https://github.com/open-component-model/.github/blob/main/CODE_OF_CONDUCT.md).
+Ask in the SIG channels listed in the [charter](Runtime/SIG-Runtime-OVERVIEW.md#communication), or at the next community call. The Chair and Tech Lead listed in the [SIG Runtime Overview](Runtime/SIG-Runtime-OVERVIEW.md#roles) are the right first contacts. All participation is governed by the [OCM Code of Conduct](https://github.com/open-component-model/.github/blob/main/CODE_OF_CONDUCT.md).

--- a/docs/community/SIGs/Runtime/SIG-Runtime-OVERVIEW.md
+++ b/docs/community/SIGs/Runtime/SIG-Runtime-OVERVIEW.md
@@ -1,4 +1,4 @@
-# SIG Runtime — Charter
+# SIG Runtime — Overview
 
 **Status:** Proposed  
 **Last updated:** 2025-10-16

--- a/docs/steering/meeting-notes/2026-02-02.md
+++ b/docs/steering/meeting-notes/2026-02-02.md
@@ -56,7 +56,7 @@ Quorum: ✅
 
 - [ ] Jakob to change upcoming vote for SIG Runtime Chair to distribute Balance of Power outside of company.
   - Gergely volunteering from TSC, Gergely to read up on [SIG-Handbook](../../community/SIGs/SIG-Handbook.md) 
-    and the [Charter](../../community/SIGs/Runtime/SIG-Runtime-CHARTER.md)
+    and the [Overview](../../community/SIGs/Runtime/SIG-Runtime-OVERVIEW.md)
   - Jakob to provide support to prepare Gergely on SIG Chair position. Offer applies to all potential candidates.
   - Both positions of Chair and Tech Lead can be filled by the same person in theory.
 - [ ] All currently inner-source plannings / reviews / retrospectives 

--- a/docs/steering/meeting-notes/2026-03-02.md
+++ b/docs/steering/meeting-notes/2026-03-02.md
@@ -55,7 +55,7 @@ Quorum: ✅
   - Gerald to give an update on this after adoption in the next TSC call.
 - [x] Jakob to change upcoming vote for SIG Runtime Chair to distribute Balance of Power outside of company.
   - Gergely volunteering from TSC, Gergely to read up on [SIG-Handbook](../../community/SIGs/SIG-Handbook.md)
-    and the [Charter](../../community/SIGs/Runtime/SIG-Runtime-CHARTER.md)
+    and the [Overview](../../community/SIGs/Runtime/SIG-Runtime-OVERVIEW.md)
   - Jakob to provide support to prepare Gergely on SIG Chair position. Offer applies to all potential candidates.
   - Both positions of Chair and Tech Lead can be filled by the same person in theory.
 - [ ] Jakob - All currently inner-source plannings / reviews / retrospectives

--- a/website/content/blog/ocm_v2_announcement.md
+++ b/website/content/blog/ocm_v2_announcement.md
@@ -188,7 +188,7 @@ The [OCM TSC](https://github.com/open-component-model/open-component-model/blob/
 
 ### SIG Runtime
 
-The [SIG Runtime](https://github.com/open-component-model/open-component-model/blob/main/docs/community/SIGs/Runtime/SIG-Runtime-CHARTER.md) is the primary governance body for the OCM runtime implementation. It oversees the development of the CLI, controllers, and library, ensuring that technical decisions are made openly and aligned with the broader project direction. Technical decisions are centrally tracked and aligned with the TSC via ADRs.
+The [SIG Overview](https://github.com/open-component-model/open-component-model/blob/main/docs/community/SIGs/Runtime/SIG-Runtime-OVERVIEW.md) is the primary governance body for the OCM runtime implementation. It oversees the development of the CLI, controllers, and library, ensuring that technical decisions are made openly and aligned with the broader project direction. Technical decisions are centrally tracked and aligned with the TSC via ADRs.
 
 ### How to Get Involved
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

The sig charter doc is clashing with the steering charter. Renaming it helps in discovery a lot. Naming it the same way might make people mistake it to be the technical charter.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Testing

##### How to test the changes

<!--
Required files to test the changes:

.ocmconfig
```yaml
type: generic.config.ocm.software/v1
configurations:
  - type: credentials.config.ocm.software
    repositories:
      - repository:
          type: DockerConfig/v1
          dockerConfigFile: "~/.docker/config.json"
```

Commands that test the change:

```bash
ocm get cv xxx

ocm transfer xxx
```
-->

##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
