### PR TITLE
chore(docs): document the GitHub access type

### DIFF
--- a/.github/config/wordlist.txt
+++ b/.github/config/wordlist.txt
@@ -954,3 +954,6 @@ ifying
 Wget's
 presigned
 WgetCredentials
+GitHubCredentials
+GitHubRepository
+normalisation

--- a/website/config/_default/module.yaml
+++ b/website/config/_default/module.yaml
@@ -112,6 +112,12 @@ mounts:
       matrix:
         versions:
           - main
+  - source: ../bindings/go/github/spec/credentials/v1/schemas
+    target: static/main/schemas/bindings/go/credentials/github/v1
+    sites:
+      matrix:
+        versions:
+          - main
   - source: ../bindings/go/rsa/spec/credentials/v1/schemas
     target: static/main/schemas/bindings/go/credentials/rsa/v1
     sites:

--- a/website/content/docs/concepts/resource-repositories.md
+++ b/website/content/docs/concepts/resource-repositories.md
@@ -38,14 +38,17 @@ flowchart TB
         OCI["OCI Resource Repository"]
         Helm["Helm Resource Repository"]
         Wget["Wget Resource Repository"]
+        GitHub["GitHub Resource Repository"]
     end
 
     CD -->|"OCIImage/v1 access"| OCI
     CD -->|"Helm/v1 access"| Helm
     CD -->|"Wget/v1 access"| Wget
+    CD -->|"GitHub/v1 access"| GitHub
     OCI --> Registry["OCI Registry"]
     Helm --> HelmRepo["Helm Chart Repository"]
     Wget --> HTTP["HTTP/HTTPS Server"]
+    GitHub --> GitHubAPI["GitHub REST API"]
 ```
 
 ## How It Works

--- a/website/content/docs/how-to/add-resources-from-github.md
+++ b/website/content/docs/how-to/add-resources-from-github.md
@@ -126,8 +126,8 @@ EOF
 
 {{< callout context="note" >}}
 The `ref` is resolved and replaced by the commit it points at while the component version is built, so this ends up
-identical to the pinned-commit variant in the descriptor. Which one to write is a question of what you want to happen
-at build time — see [Pin to a commit](#pin-to-a-commit).
+identical to the pinned-commit variant in the descriptor. Which one to write is a question of what you want pinned at
+build time: a commit you already know, or whatever the branch or tag points at right now.
 {{< /callout >}}
 
 {{< /tab >}}

--- a/website/content/docs/how-to/add-resources-from-github.md
+++ b/website/content/docs/how-to/add-resources-from-github.md
@@ -166,7 +166,7 @@ would keep pointing wherever the branch moves to.
 ### Build the component version
 
 ```bash
-ocm add cv --repository ctf::./transport-archive --constructor ./component-constructor.yaml
+ocm add cv
 ```
 
 OCM downloads the archive to hash it, and says so:

--- a/website/content/docs/how-to/add-resources-from-github.md
+++ b/website/content/docs/how-to/add-resources-from-github.md
@@ -125,9 +125,9 @@ EOF
 ```
 
 {{< callout context="note" >}}
-The `ref` is resolved and replaced by the commit it points at while the component version is built, so this ends up
-identical to the pinned-commit variant in the descriptor. Which one to write is a question of what you want pinned at
-build time: a commit you already know, or whatever the branch or tag points at right now.
+The `ref` is resolved to a commit while the component version is built, and that commit is added to the access. The `ref`
+itself stays for provenance. Which one to write is a question of what you want pinned at build time: 
+a commit you already know, or whatever the branch or tag points at right now.
 {{< /callout >}}
 
 {{< /tab >}}
@@ -284,7 +284,7 @@ The output is the gzipped tar archive GitHub serves, written as a single file. U
   Fetch the resource you just added
 - [How-To: Air-Gap Transfer]({{< relref "docs/how-to/air-gap-transfer.md" >}}) - Move component versions into
   disconnected environments
-- [How-To: Sign and Verify]({{< relref "docs/how-to/sign-and-verify.md" >}}) - Cover the digest you just recorded with
+- [How-To: Sign a Component Version]({{< relref "sign-component-version.md" >}}) - Cover the digest you just recorded with
   a signature
 
 ## Related Documentation

--- a/website/content/docs/how-to/add-resources-from-github.md
+++ b/website/content/docs/how-to/add-resources-from-github.md
@@ -1,0 +1,299 @@
+---
+title: "Add Resources from GitHub"
+description: "Add the source archive of a GitHub commit to a component version with the GitHub access type."
+icon: "🐙"
+weight: 18
+toc: true
+---
+
+## Goal
+
+Add a [GitHub repository archive](https://docs.github.com/en/rest/repos/contents?apiVersion=2026-03-10#download-a-repository-archive-tar)
+to a component version, either as a resource or as a source, using the
+[`GitHub/v1` access type]({{< relref "docs/reference/input-and-access-types.md#githubv1" >}}).
+The access stores the repository URL and a commit; the archive stays on GitHub until something asks for it. 
+
+## You'll end up with
+
+- A component version in a local transport archive, with the GitHub archive declared as a resource or as a source
+- A resource pinned to a commit and carrying a digest over the archive at that commit — even if you wrote only a `ref`
+- That archive downloaded back out, to confirm the round trip works
+
+**Estimated time:** ~10 minutes
+
+## Prerequisites
+
+- [OCM CLI]({{< relref "docs/getting-started/ocm-cli-installation.md" >}}) installed
+
+This guide reads a public repository, so it runs end-to-end without credentials — start at step 2. Step 1 covers
+reaching a private repository, or lifting the anonymous rate limit.
+
+## Steps
+
+{{< steps >}}
+
+{{< step >}}
+
+### Authenticate against a private repository {#authenticate-against-a-private-repository}
+
+*Optional — skip this if the repository is public.*
+
+Anonymous requests are rate-limited per IP, and a private repository answers `404` rather than `401`: GitHub does not
+reveal that the repository exists. Both problems are solved with a token.
+
+[Configure credentials]({{< relref "docs/how-to/configure-multiple-credentials.md" >}}) of type
+`GitHubCredentials/v1`. OCM matches them by a consumer identity of type `GitHubRepository` derived from `repoUrl`:
+
+```bash
+cat > .ocmconfig << 'EOF'
+type: generic.config.ocm.software/v1
+configurations:
+  - type: credentials.config.ocm.software
+    consumers:
+      - identity:
+          type: GitHubRepository
+          hostname: github.com
+        credentials:
+          - type: GitHubCredentials/v1
+            token: ghp_your_token
+EOF
+```
+
+Omitting `path` matches every repository on that host. See
+[Credential Consumer Identities: GitHubRepository]({{< relref "docs/reference/credential-consumer-identities.md#githubrepository" >}})
+for the full attribute set.
+
+{{< callout context="note" >}}
+For GitHub Enterprise, set `hostname` to your host. Any host other than `github.com` is treated as Enterprise
+automatically, so the credentials need nothing else; set `apiHostname` on the access only when the REST API lives on a
+different host than the repository.
+{{< /callout >}}
+
+Add `--config .ocmconfig` to the commands in the following steps, or drop the file in one of the
+[well-known locations]({{< relref "docs/reference/ocm-cli/ocm.md" >}}) the CLI reads automatically.
+
+{{< /step >}}
+
+{{< step >}}
+
+### Create the component constructor
+
+Each tab describes the same archive. Write one of them to `component-constructor.yaml`:
+
+{{< tabs "github-spec" >}}
+{{< tab "Resource: pinned commit" >}}
+
+```bash
+cat > component-constructor.yaml << 'EOF'
+components:
+  - name: github.com/acme.org/myapp
+    version: 1.0.0
+    provider:
+      name: acme.org
+    resources:
+      - name: ocm-sources
+        type: directoryTree
+        version: 1.0.0
+        relation: external
+        access:
+          type: GitHub/v1
+          repoUrl: https://github.com/open-component-model/open-component-model
+          commit: b4bb4e880aa5c159366db7cc2ae800e1ee14dbda
+EOF
+```
+
+{{< /tab >}}
+{{< tab "Resource: branch or tag" >}}
+
+```bash
+cat > component-constructor.yaml << 'EOF'
+components:
+  - name: github.com/acme.org/myapp
+    version: 1.0.0
+    provider:
+      name: acme.org
+    resources:
+      - name: ocm-sources
+        type: directoryTree
+        version: 1.0.0
+        relation: external
+        access:
+          type: GitHub/v1
+          repoUrl: https://github.com/open-component-model/open-component-model
+          ref: refs/tags/v0.8.0
+EOF
+```
+
+{{< callout context="note" >}}
+The `ref` is resolved and replaced by the commit it points at while the component version is built, so this ends up
+identical to the pinned-commit variant in the descriptor. Which one to write is a question of what you want to happen
+at build time — see [Pin to a commit](#pin-to-a-commit).
+{{< /callout >}}
+
+{{< /tab >}}
+{{< tab "Source" >}}
+
+```bash
+cat > component-constructor.yaml << 'EOF'
+components:
+  - name: github.com/acme.org/myapp
+    version: 1.0.0
+    provider:
+      name: acme.org
+    sources:
+      - name: ocm-sources
+        type: directoryTree
+        version: 1.0.0
+        access:
+          type: GitHub/v1
+          repoUrl: https://github.com/open-component-model/open-component-model
+          commit: b4bb4e880aa5c159366db7cc2ae800e1ee14dbda
+EOF
+```
+
+{{< callout context="caution" >}}
+A source must carry a `commit`. A `ref` is accepted, but only resources get pinned — nothing rewrites a source, so it
+would keep pointing wherever the branch moves to.
+{{< /callout >}}
+
+{{< /tab >}}
+{{< /tabs >}}
+
+{{< /step >}}
+
+{{< step >}}
+
+### Build the component version
+
+```bash
+ocm add cv --repository ctf::./transport-archive --constructor ./component-constructor.yaml
+```
+
+OCM downloads the archive to hash it, and says so:
+
+```text
+level=WARN msg="computing the digest of a github resource downloads the full commit archive and discards it after
+hashing" repoUrl=https://github.com/open-component-model/open-component-model commit=b4bb4e88…
+```
+
+That is expected: the digest has to be computed over real bytes. The archive is not kept — only its digest is. Then
+the component is listed:
+
+```text
+ COMPONENT                 │ VERSION │ PROVIDER
+───────────────────────────┼─────────┼──────────
+ github.com/acme.org/myapp │ 1.0.0   │ acme.org
+```
+
+{{< /step >}}
+
+{{< step >}}
+
+### Check what ended up in the descriptor
+
+```bash
+ocm get cv ./transport-archive//github.com/acme.org/myapp:1.0.0 -o yaml
+```
+
+{{< tabs "github-descriptor" >}}
+{{< tab "Resource: pinned commit" >}}
+
+```yaml
+    resources:
+    - access:
+        commit: b4bb4e880aa5c159366db7cc2ae800e1ee14dbda
+        repoUrl: https://github.com/open-component-model/open-component-model
+        type: GitHub/v1
+      digest:
+        hashAlgorithm: SHA-256
+        normalisationAlgorithm: genericBlobDigest/v1
+        value: fc4a80e964482534612b6a02935523b9ecb5160bee91266926a2d1bb027ccfcf
+      name: ocm-sources
+      relation: external
+      type: directoryTree
+      version: 1.0.0
+```
+
+The access is recorded as written, and the resource gained a digest over the archive at that commit.
+
+{{< /tab >}}
+{{< tab "Resource: branch or tag" >}}
+
+```yaml
+    resources:
+    - access:
+        commit: b4bb4e880aa5c159366db7cc2ae800e1ee14dbda
+        ref: refs/tags/v0.8.0
+        repoUrl: https://github.com/open-component-model/open-component-model
+        type: GitHub/v1
+      digest:
+        hashAlgorithm: SHA-256
+        normalisationAlgorithm: genericBlobDigest/v1
+        value: fc4a80e964482534612b6a02935523b9ecb5160bee91266926a2d1bb027ccfcf
+      name: ocm-sources
+      relation: external
+      type: directoryTree
+      version: 1.0.0
+```
+
+The resolved `commit` now sits alongside the `ref`, with the same digest as the pinned variant. The `ref` is kept for
+provenance; from here on the `commit` is what OCM reads.
+
+{{< /tab >}}
+{{< tab "Source" >}}
+
+```yaml
+    sources:
+    - access:
+        commit: b4bb4e880aa5c159366db7cc2ae800e1ee14dbda
+        repoUrl: https://github.com/open-component-model/open-component-model
+        type: GitHub/v1
+      name: ocm-sources
+      type: directoryTree
+      version: 1.0.0
+```
+
+No `digest` and no `relation`: a source is a pointer, so there is nothing recorded to verify it against later.
+
+{{< /tab >}}
+{{< /tabs >}}
+
+{{< /step >}}
+
+{{< step >}}
+
+### Download the resource back
+
+```bash
+ocm download resource ./transport-archive//github.com/acme.org/myapp:1.0.0 \
+  --identity name=ocm-sources \
+  --output ./sources.tar.gz
+```
+
+You should see: `level=INFO msg="resource downloaded successfully" output=./sources.tar.gz`.
+
+The output is the gzipped tar archive GitHub serves, written as a single file. Unpack it with `tar -xzf`.
+
+{{< /step >}}
+
+{{< /steps >}}
+
+## Next Steps
+
+- [How-To: Download Resources from Component Versions]({{< relref "docs/how-to/download-resources-from-component-versions.md" >}}) -
+  Fetch the resource you just added
+- [How-To: Air-Gap Transfer]({{< relref "docs/how-to/air-gap-transfer.md" >}}) - Move component versions into
+  disconnected environments
+- [How-To: Sign and Verify]({{< relref "docs/how-to/sign-and-verify.md" >}}) - Cover the digest you just recorded with
+  a signature
+
+## Related Documentation
+
+- [Reference: Input and Access Types]({{< relref "docs/reference/input-and-access-types.md#githubv1" >}}) - Field
+  reference for the `GitHub/v1` access type
+- [Reference: Resource Repositories]({{< relref "docs/reference/resource-repositories.md#github-resource-repository" >}}) -
+  Capabilities, download and digest processing
+- [Reference: Credential Consumer Identities]({{< relref "docs/reference/credential-consumer-identities.md#githubrepository" >}}) -
+  Identity attributes and matching rules for `GitHubRepository` consumers
+- [Reference: Credential Types]({{< relref "docs/reference/credential-types.md#githubcredentialsv1" >}}) - Full field
+  reference for `GitHubCredentials/v1`

--- a/website/content/docs/reference/credential-consumer-identities.md
+++ b/website/content/docs/reference/credential-consumer-identities.md
@@ -307,13 +307,13 @@ optional; see the note on anonymous access under
 
 ### Identity Attributes
 
-| Attribute  | Required | Description                                                                        |
-|------------|----------|------------------------------------------------------------------------------------|
-| `type`     | Yes      | Must be `GitHubRepository`                                                         |
-| `hostname` | Yes      | Repository hostname (e.g. `github.com`, a GitHub Enterprise host)                  |
-| `path`     | No       | Repository path (e.g. `open-component-model/ocm`). If omitted, matches any path.   |
-| `scheme`   | No       | URL scheme (`https`, `http`). If omitted, matches any scheme.                      |
-| `port`     | No       | Port number as string. If omitted, matches any port.                               |
+| Attribute  | Required | Description                                                                                        |
+|------------|----------|----------------------------------------------------------------------------------------------------|
+| `type`     | Yes      | Must be `GitHubRepository`                                                                         |
+| `hostname` | Yes      | Repository hostname (e.g. `github.com`, a GitHub Enterprise host)                                  |
+| `path`     | No       | Repository path (e.g. `open-component-model/ocm`). If omitted, matches any path.                   |
+| `scheme`   | No       | URL scheme (`https`, `http`). If omitted, matches any scheme.                                      |
+| `port`     | No       | Port number as string. When `scheme` is set, default ports apply (`https` → `443`, `http` → `80`). |
 
 ### Credential Properties
 

--- a/website/content/docs/reference/credential-consumer-identities.md
+++ b/website/content/docs/reference/credential-consumer-identities.md
@@ -307,13 +307,13 @@ optional; see the note on anonymous access under
 
 ### Identity Attributes
 
-| Attribute  | Required | Description                                                                                        |
-|------------|----------|----------------------------------------------------------------------------------------------------|
-| `type`     | Yes      | Must be `GitHubRepository`                                                                         |
-| `hostname` | Yes      | Repository hostname (e.g. `github.com`, a GitHub Enterprise host)                                  |
-| `path`     | No       | Repository path (e.g. `open-component-model/ocm`). If omitted, matches any path.                   |
-| `scheme`   | No       | URL scheme (`https`, `http`). If omitted, matches any scheme.                                      |
-| `port`     | No       | Port number as string. When `scheme` is set, default ports apply (`https` → `443`, `http` → `80`). |
+| Attribute  | Required | Description                                                                                       |
+|------------|----------|---------------------------------------------------------------------------------------------------|
+| `type`     | Yes      | Must be `GitHubRepository`                                                                        |
+| `hostname` | Yes      | Repository hostname (e.g. `github.com`, a GitHub Enterprise host)                                 |
+| `path`     | No       | Repository path (e.g. `open-component-model/open-component-model`). If omitted, matches any path. |
+| `scheme`   | No       | URL scheme (`https`, `http`). If omitted, matches any scheme.                                     |
+| `port`     | No       | Port number as string. If omitted, the scheme's default applies (`https` → `443`, `http` → `80`). |
 
 ### Credential Properties
 

--- a/website/content/docs/reference/credential-consumer-identities.md
+++ b/website/content/docs/reference/credential-consumer-identities.md
@@ -42,13 +42,8 @@ The following types are defined by the core OCM modules:
 | [`OCIRegistry`](#ociregistry)                 | Authenticating against OCI registries           |
 | [`HelmChartRepository`](#helmchartrepository) | Authenticating against Helm chart repositories  |
 | [`Wget`](#wget)                               | Authenticating against plain HTTP/HTTPS servers |
+| [`GitHubRepository`](#githubrepository)       | Authenticating against the GitHub REST API      |
 | [`RSA/v1alpha1`](#rsav1alpha1)                | Providing signing and verification keys         |
-| Identity Type                                 | Used For                                       |
-|-----------------------------------------------|------------------------------------------------|
-| [`OCIRegistry`](#ociregistry)                 | Authenticating against OCI registries          |
-| [`HelmChartRepository`](#helmchartrepository) | Authenticating against Helm chart repositories |
-| [`GitHubRepository`](#githubrepository)       | Authenticating against the GitHub REST API     |
-| [`RSA/v1alpha1`](#rsav1alpha1)                | Providing signing and verification keys        |
 
 ---
 
@@ -300,6 +295,9 @@ so the symptom is a `401` from the server rather than a configuration error.
 For migrating a Wget consumer entry from OCM v1, covering the renamed identity type, the `pathprefix` to `path`
 conversion, and the inverted authentication precedence, see
 [Tutorial: Work with HTTP Resources]({{< relref "docs/tutorials/wget-http-resources.md#credential-changes" >}}).
+
+---
+
 ## GitHubRepository
 
 Used when OCM resolves or downloads a resource with a `GitHub/v1` access — resolving a ref to a commit or fetching a

--- a/website/content/docs/reference/credential-consumer-identities.md
+++ b/website/content/docs/reference/credential-consumer-identities.md
@@ -329,7 +329,7 @@ optional; see the note on anonymous access under
 - identity:
     type: GitHubRepository
     hostname: github.com
-    path: open-component-model/ocm
+    path: open-component-model/open-component-model
   credentials:
     - type: GitHubCredentials/v1
       token: ghp_example_token

--- a/website/content/docs/reference/credential-consumer-identities.md
+++ b/website/content/docs/reference/credential-consumer-identities.md
@@ -43,6 +43,12 @@ The following types are defined by the core OCM modules:
 | [`HelmChartRepository`](#helmchartrepository) | Authenticating against Helm chart repositories  |
 | [`Wget`](#wget)                               | Authenticating against plain HTTP/HTTPS servers |
 | [`RSA/v1alpha1`](#rsav1alpha1)                | Providing signing and verification keys         |
+| Identity Type                                 | Used For                                       |
+|-----------------------------------------------|------------------------------------------------|
+| [`OCIRegistry`](#ociregistry)                 | Authenticating against OCI registries          |
+| [`HelmChartRepository`](#helmchartrepository) | Authenticating against Helm chart repositories |
+| [`GitHubRepository`](#githubrepository)       | Authenticating against the GitHub REST API     |
+| [`RSA/v1alpha1`](#rsav1alpha1)                | Providing signing and verification keys        |
 
 ---
 
@@ -294,6 +300,55 @@ so the symptom is a `401` from the server rather than a configuration error.
 For migrating a Wget consumer entry from OCM v1, covering the renamed identity type, the `pathprefix` to `path`
 conversion, and the inverted authentication precedence, see
 [Tutorial: Work with HTTP Resources]({{< relref "docs/tutorials/wget-http-resources.md#credential-changes" >}}).
+## GitHubRepository
+
+Used when OCM resolves or downloads a resource with a `GitHub/v1` access — resolving a ref to a commit or fetching a
+commit's source archive via the GitHub REST API. The identity is derived from the access's `repoUrl`. Credentials are
+optional; see the note on anonymous access under
+[`GitHubCredentials/v1`]({{< relref "credential-types.md#githubcredentialsv1" >}}).
+
+### Identity Attributes
+
+| Attribute  | Required | Description                                                                        |
+|------------|----------|------------------------------------------------------------------------------------|
+| `type`     | Yes      | Must be `GitHubRepository`                                                         |
+| `hostname` | Yes      | Repository hostname (e.g. `github.com`, a GitHub Enterprise host)                  |
+| `path`     | No       | Repository path (e.g. `open-component-model/ocm`). If omitted, matches any path.   |
+| `scheme`   | No       | URL scheme (`https`, `http`). If omitted, matches any scheme.                      |
+| `port`     | No       | Port number as string. If omitted, matches any port.                               |
+
+### Credential Properties
+
+| Property | Description                                |
+|----------|--------------------------------------------|
+| `token`  | GitHub or GitHub Enterprise access token   |
+
+### Examples
+
+**github.com:**
+
+```yaml
+- identity:
+    type: GitHubRepository
+    hostname: github.com
+    path: open-component-model/ocm
+  credentials:
+    - type: GitHubCredentials/v1
+      token: ghp_example_token
+```
+
+**GitHub Enterprise host:**
+
+```yaml
+- identity:
+    type: GitHubRepository
+    hostname: git.example.corp
+  credentials:
+    - type: GitHubCredentials/v1
+      token: ghe_example_token
+```
+
+Omitting `path` matches every repository on that host.
 
 ---
 

--- a/website/content/docs/reference/credential-types.md
+++ b/website/content/docs/reference/credential-types.md
@@ -30,6 +30,7 @@ OCM ships with the following built-in credential types:
 | [`OCICredentials/v1`](#ocicredentialsv1)                   | `OCIRegistry` consumers                  | OCI registry username/password and token auth                   |
 | [`HelmHTTPCredentials/v1`](#helmhttpcredentialsv1)         | `HelmChartRepository` consumers (HTTP/S) | Helm HTTP repository auth and TLS client certs                  |
 | [`WgetCredentials/v1`](#wgetcredentialsv1)                 | `Wget` consumers                         | HTTP/S Basic Auth, bearer token, and mutual TLS                 |
+| [`GitHubCredentials/v1`](#githubcredentialsv1)             | `GitHubRepository` consumers             | GitHub and GitHub Enterprise REST API token auth                |
 | [`RSACredentials/v1`](#rsacredentialsv1)                   | `RSA/v1alpha1` consumers                 | RSA signing and verification key material                       |
 | [`GPGCredentials/v1alpha1`](#gpgcredentialsv1alpha1)       | `GPG/v1alpha1` consumers                 | GPG signing and verification key material                       |
 | [`OIDCIdentityToken/v1alpha1`](#oidcidentitytokenv1alpha1) | `SigstoreSigner/v1alpha1` consumers      | OIDC token for Sigstore keyless signing via Fulcio              |
@@ -213,6 +214,29 @@ is set, and a client certificate has no effect on a plain `http://` URL.
 [`Wget`]({{< relref "credential-consumer-identities.md#wget" >}}) consumer identities, covering both the
 [`Wget/v1` access type]({{< relref "input-and-access-types.md#wgetv1-access" >}}) and the
 [`Wget/v1` input type]({{< relref "input-and-access-types.md#wgetv1-input" >}}).
+## GitHubCredentials/v1
+
+{{< schema-renderer url="/schemas/bindings/go/credentials/github/v1/GitHubCredentials.schema.json" >}}
+
+### Example
+
+```yaml
+consumers:
+  - identity:
+      type: GitHubRepository
+      hostname: github.com
+    credentials:
+      - type: GitHubCredentials/v1
+        token: ghp_example_token
+```
+
+A legacy `Credentials/v1` property bag with a `token` property works as well.
+
+Configuring no consumer at all is valid: the GitHub REST API is then called anonymously.
+
+### Used With
+
+[`GitHubRepository`]({{< relref "credential-consumer-identities.md#githubrepository" >}}) consumer identities.
 
 ---
 

--- a/website/content/docs/reference/credential-types.md
+++ b/website/content/docs/reference/credential-types.md
@@ -233,7 +233,18 @@ consumers:
         token: ghp_example_token
 ```
 
-A legacy `Credentials/v1` property bag with a `token` property works as well.
+A legacy [`Credentials/v1`](#directcredentialsv1) property bag with a `token` property works as well:
+
+```yaml
+consumers:
+  - identity:
+      type: GitHubRepository
+      hostname: github.com
+    credentials:
+      - type: Credentials/v1
+        properties:
+          token: ghp_example_token
+```
 
 Configuring no consumer at all is valid: the GitHub REST API is then called anonymously.
 

--- a/website/content/docs/reference/credential-types.md
+++ b/website/content/docs/reference/credential-types.md
@@ -214,6 +214,9 @@ is set, and a client certificate has no effect on a plain `http://` URL.
 [`Wget`]({{< relref "credential-consumer-identities.md#wget" >}}) consumer identities, covering both the
 [`Wget/v1` access type]({{< relref "input-and-access-types.md#wgetv1-access" >}}) and the
 [`Wget/v1` input type]({{< relref "input-and-access-types.md#wgetv1-input" >}}).
+
+---
+
 ## GitHubCredentials/v1
 
 {{< schema-renderer url="/schemas/bindings/go/credentials/github/v1/GitHubCredentials.schema.json" >}}

--- a/website/content/docs/reference/credential-types.md
+++ b/website/content/docs/reference/credential-types.md
@@ -233,7 +233,7 @@ consumers:
         token: ghp_example_token
 ```
 
-A legacy [`Credentials/v1`](#directcredentialsv1) property bag with a `token` property works as well:
+The legacy [`Credentials/v1`](#directcredentialsv1) fallback works as well, with `token` in its `properties` map:
 
 ```yaml
 consumers:

--- a/website/content/docs/reference/input-and-access-types.md
+++ b/website/content/docs/reference/input-and-access-types.md
@@ -305,6 +305,46 @@ access type instead. The [Helm resource repository]({{< relref "resource-reposit
 only supports HTTP/HTTPS-based chart repositories.
 {{< /callout >}}
 
+### `GitHub/v1`
+
+References a commit of a GitHub repository, downloaded as a source archive via the GitHub
+REST API. Also usable unversioned as `GitHub`. Legacy aliases: `github`, `github/v1`,
+`gitHub`, `gitHub/v1`.
+
+| Field         | Type   | Required | Description                                                                                                                      |
+|---------------|--------|----------|----------------------------------------------------------------------------------------------------------------------------------|
+| `repoUrl`     | string | yes      | Repository URL (scheme optional, `https` assumed), e.g. `github.com/open-component-model/ocm`.                                   |
+| `apiHostname` | string | no       | Overrides the GitHub REST API hostname for GitHub Enterprise.                                                                    |
+| `commit`      | string | no*      | 40-character hex commit SHA. When set it is authoritative.                                                                       |
+| `ref`         | string | no*      | Git reference (e.g. `refs/heads/main`), resolved to a commit at download time and pinned onto the resource by digest processing. |
+
+\* At least one of `commit` or `ref` must be set. A resource may be authored with only a
+`ref`; its `commit` is pinned later during digest processing. A source is never pinned, so
+give it a `commit`.
+
+```yaml
+resources:
+  - name: my-source
+    version: 1.0.0
+    type: directoryTree
+    relation: external
+    access:
+      type: GitHub/v1
+      repoUrl: https://github.com/open-component-model/ocm
+      commit: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2
+```
+
+The same access works under `sources:`, where it stays a remote reference: sources carry no
+digest and no copy mode embeds them.
+
+{{< callout context="note" >}}
+Any `repoUrl` host other than `github.com` is treated as GitHub Enterprise, with the REST API
+on that same host. Set `apiHostname` only when the API lives on a different host.
+
+`apiHostname` and the optional `commit` extend the OCM spec's `gitHub` access type: the spec
+lists `commit` as required and has no `apiHostname` attribute.
+{{< /callout >}}
+
 ### `File/v1alpha1`
 
 References a file by URI ([RFC 8089](https://datatracker.ietf.org/doc/html/rfc8089)). Legacy alias: `file`.

--- a/website/content/docs/reference/resource-repositories.md
+++ b/website/content/docs/reference/resource-repositories.md
@@ -231,9 +231,15 @@ The credential consumer identity is derived from the `repoUrl` field in the acce
 | `scheme`   | `https`                     |
 | `path`     | `open-component-model/ocm`  |
 
-This identity works the same way for GitHub Enterprise hosts. Credentials are optional: without them requests are
-anonymous, subject to GitHub's per-IP rate limit, and private repositories answer 404. When credentials resolve, their
-`token` property (a GitHub or GitHub Enterprise access token) authenticates against the GitHub REST API.
+The identity is derived from `repoUrl` on GitHub Enterprise hosts too. Credentials are optional: without them requests
+are anonymous, subject to GitHub's per-IP rate limit, and private repositories answer 404. When credentials resolve,
+their `token` property (a GitHub or GitHub Enterprise access token) authenticates against the GitHub REST API.
+
+{{< callout context="caution" >}}
+`apiHostname` does not change the consumer identity. When the REST API lives on a host other than the repository, the
+identity still carries the `repoUrl` host, so configure the consumer for that host rather than for `apiHostname`. The
+resolved token is then sent to the `apiHostname` host.
+{{< /callout >}}
 
 See [Credential Consumer Identities: GitHubRepository]({{< relref "credential-consumer-identities.md" >}}#githubrepository)
 for matching rules.

--- a/website/content/docs/reference/resource-repositories.md
+++ b/website/content/docs/reference/resource-repositories.md
@@ -194,6 +194,68 @@ whatever the server returned. See
 
 ---
 
+## GitHub Resource Repository
+
+Handles source archives of a pinned commit in a GitHub (or GitHub Enterprise) repository.
+
+### Supported Access Types
+
+| Access Type                                                        |
+|--------------------------------------------------------------------|
+| [`GitHub/v1`]({{< relref "input-and-access-types.md" >}}#githubv1) |
+
+### Capabilities
+
+| Operation         | Supported |
+|-------------------|-----------|
+| Download          | Yes       |
+| Upload            | No        |
+| Digest Processing | Yes       |
+
+{{< callout context="note" >}}
+Upload is not supported: the `GitHub/v1` access type is a read-only source reference. Content is pushed to GitHub
+through git, not through OCM.
+{{< /callout >}}
+
+### Credential Resolution
+
+The credential consumer identity is derived from the `repoUrl` field in the access specification. The identity type is
+`GitHubRepository`.
+
+**Example:** For a resource with `repoUrl: https://github.com/open-component-model/ocm`:
+
+| Attribute  | Value                       |
+|------------|-----------------------------|
+| `type`     | `GitHubRepository`          |
+| `hostname` | `github.com`                |
+| `scheme`   | `https`                     |
+| `path`     | `open-component-model/ocm`  |
+
+This identity works the same way for GitHub Enterprise hosts. Credentials are optional: without them requests are
+anonymous, subject to GitHub's per-IP rate limit, and private repositories answer 404. When credentials resolve, their
+`token` property (a GitHub or GitHub Enterprise access token) authenticates against the GitHub REST API.
+
+See [Credential Consumer Identities: GitHubRepository]({{< relref "credential-consumer-identities.md" >}}#githubrepository)
+for matching rules.
+
+### Download Behavior
+
+Downloads the source archive of the commit pinned in the access via the GitHub REST API. The archive is returned as an
+in-memory gzipped tar blob.
+
+### Digest Processing
+
+If the access has only a `ref`, the GitHub digest processor resolves it to a `commit` and writes that commit onto the
+resource. This works like an OCI tag that is pinned to a digest. It then downloads the archive at that commit and
+hashes it: `SHA-256` over the archive bytes, normalisation `genericBlobDigest/v1`.
+If the access already has a `commit`, the ref is not resolved again. A branch can move on, or be deleted after a merge,
+and that must not break a component version that has not changed.
+
+The digest is checked on both paths. If the resource already declares one, the computed value must match it. The hash
+and normalisation algorithms are only compared when they are set: an empty field is filled in with the computed value.
+
+---
+
 ## External Resource Repositories (Plugins)
 
 External plugins declare supported access types in their capability specification and implement the same three

--- a/website/scripts/register-docs-version.js
+++ b/website/scripts/register-docs-version.js
@@ -217,6 +217,7 @@ const CLI_DERIVED_MODULES = [
     `${MODULE_PREFIX}/bindings/go/constructor`,
     `${MODULE_PREFIX}/bindings/go/credentials`,
     `${MODULE_PREFIX}/bindings/go/descriptor/v2`,
+    `${MODULE_PREFIX}/bindings/go/github`,
     `${MODULE_PREFIX}/bindings/go/gpg`,
     `${MODULE_PREFIX}/bindings/go/helm`,
     `${MODULE_PREFIX}/bindings/go/http`,
@@ -235,6 +236,7 @@ function buildModuleBlocks(version, fullVersion, deps) {
     const constructorVersion = deps?.[`${MODULE_PREFIX}/bindings/go/constructor`];
     const credentialsVersion = deps?.[`${MODULE_PREFIX}/bindings/go/credentials`];
     const descriptorVersion = deps?.[`${MODULE_PREFIX}/bindings/go/descriptor/v2`];
+    const githubVersion = deps?.[`${MODULE_PREFIX}/bindings/go/github`];
     const gpgVersion = deps?.[`${MODULE_PREFIX}/bindings/go/gpg`];
     const helmVersion = deps?.[`${MODULE_PREFIX}/bindings/go/helm`];
     const httpVersion = deps?.[`${MODULE_PREFIX}/bindings/go/http`];
@@ -316,6 +318,15 @@ function buildModuleBlocks(version, fullVersion, deps) {
             mounts: [{
                 source: 'spec/credentials/v1/schemas',
                 target: `static/${version}/schemas/bindings/go/credentials/helm/v1`,
+                sites: { matrix: { versions: [version] } }
+            }]
+        },
+        {
+            path: `${MODULE_PREFIX}/bindings/go/github`,
+            version: githubVersion,
+            mounts: [{
+                source: 'spec/credentials/v1/schemas',
+                target: `static/${version}/schemas/bindings/go/credentials/github/v1`,
                 sites: { matrix: { versions: [version] } }
             }]
         },
@@ -442,6 +453,8 @@ function updateImportTags(parsed, version, fullVersion, deps) {
             newTag = deps[`${MODULE_PREFIX}/bindings/go/oci`];
         } else if (deps && imp.path.endsWith('/bindings/go/helm')) {
             newTag = deps[`${MODULE_PREFIX}/bindings/go/helm`];
+        } else if (deps && imp.path.endsWith('/bindings/go/github')) {
+            newTag = deps[`${MODULE_PREFIX}/bindings/go/github`];
         } else if (deps && imp.path.endsWith('/bindings/go/rsa')) {
             newTag = deps[`${MODULE_PREFIX}/bindings/go/rsa`];
         } else if (deps && imp.path.endsWith('/bindings/go/gpg')) {

--- a/website/scripts/register-docs-version.test.js
+++ b/website/scripts/register-docs-version.test.js
@@ -8,11 +8,12 @@ const { parseArguments, hasAnyImportForVersion, hasAllImportsForVersion, buildMo
 
 // Resolved CLI-derived versions for tests that need every binding import emitted.
 // buildModuleBlocks now drops bindings whose version is undefined (filter at the
-// end), so tests asserting "all 13 imports" / "all schema targets" must pass deps.
+// end), so tests asserting "all 14 imports" / "all schema targets" must pass deps.
 const ALL_DEPS = {
     'ocm.software/open-component-model/bindings/go/constructor': 'v0.0.7',
     'ocm.software/open-component-model/bindings/go/credentials': 'v0.0.13',
     'ocm.software/open-component-model/bindings/go/descriptor/v2': 'v2.0.3-alpha3',
+    'ocm.software/open-component-model/bindings/go/github': 'v0.0.1',
     'ocm.software/open-component-model/bindings/go/gpg': 'v0.0.1',
     'ocm.software/open-component-model/bindings/go/helm': 'v0.0.1',
     'ocm.software/open-component-model/bindings/go/http': 'v0.0.5',
@@ -121,9 +122,9 @@ test('hasAllImportsForVersion: returns true when the full import set (built with
 
 // --- buildModuleBlocks ---
 
-test('buildModuleBlocks: returns 13 imports (website + CLI + 10 bindings + controller)', () => {
+test('buildModuleBlocks: returns 14 imports (website + CLI + 11 bindings + controller)', () => {
     const { imports } = buildModuleBlocks('0.3', '0.3.0', ALL_DEPS);
-    assert.equal(imports.length, 13);
+    assert.equal(imports.length, 14);
 });
 
 test('buildModuleBlocks: does not return a mount field', () => {
@@ -222,6 +223,7 @@ test('buildModuleBlocks: schema imports have correct targets with version prefix
         'content/docs/reference/ocm-cli',
         'static/2.0/schemas/bindings/go/constructor',
         'static/2.0/schemas/bindings/go/credentials/direct/v1',
+        'static/2.0/schemas/bindings/go/credentials/github/v1',
         'static/2.0/schemas/bindings/go/credentials/gpg/v1alpha1',
         'static/2.0/schemas/bindings/go/credentials/helm/v1',
         'static/2.0/schemas/bindings/go/credentials/oci/v1',
@@ -246,6 +248,7 @@ test('buildModuleBlocks: schema imports have correct sources', () => {
         'spec/config/v1alpha1/schemas',
         'spec/credentials/oidcidentitytoken/v1alpha1/schemas',
         'spec/credentials/trustedroot/v1alpha1/schemas',
+        'spec/credentials/v1/schemas',
         'spec/credentials/v1/schemas',
         'spec/credentials/v1/schemas',
         'spec/credentials/v1/schemas',
@@ -487,6 +490,7 @@ test('updateImportTags: updates versioned tags for matching version', () => {
         'ocm.software/open-component-model/bindings/go/constructor': 'v0.0.8',
         'ocm.software/open-component-model/bindings/go/credentials': 'v0.0.14',
         'ocm.software/open-component-model/bindings/go/descriptor/v2': 'v2.0.4',
+        'ocm.software/open-component-model/bindings/go/github': 'v0.0.2',
         'ocm.software/open-component-model/bindings/go/gpg': 'v0.0.2',
         'ocm.software/open-component-model/bindings/go/helm': 'v0.0.2',
         'ocm.software/open-component-model/bindings/go/http': 'v0.0.5',
@@ -558,6 +562,11 @@ test('updateImportTags: updates versioned tags for matching version', () => {
                 mounts: [{ sites: { matrix: { versions: ['0.3'] } } }]
             },
             {
+                path: 'ocm.software/open-component-model/bindings/go/github',
+                version: 'bindings/go/github/v0.0.1',
+                mounts: [{ sites: { matrix: { versions: ['0.3'] } } }]
+            },
+            {
                 path: 'ocm.software/open-component-model/kubernetes/controller',
                 version: 'kubernetes/controller/v0.3.0',
                 mounts: [{ sites: { matrix: { versions: ['0.3'] } } }]
@@ -580,6 +589,7 @@ test('updateImportTags: updates versioned tags for matching version', () => {
     assert.equal(byPath['ocm.software/open-component-model/bindings/go/rsa'], 'v0.0.2');
     assert.equal(byPath['ocm.software/open-component-model/bindings/go/sigstore'], 'v0.0.2');
     assert.equal(byPath['ocm.software/open-component-model/bindings/go/wget'], 'v0.0.2');
+    assert.equal(byPath['ocm.software/open-component-model/bindings/go/github'], 'v0.0.2');
     assert.equal(byPath['ocm.software/open-component-model/kubernetes/controller'], 'v0.3.1');
 });
 
@@ -655,6 +665,7 @@ test('updateImportTags: patching freshly-built blocks equals building directly w
         'ocm.software/open-component-model/bindings/go/constructor': 'v0.0.8',
         'ocm.software/open-component-model/bindings/go/credentials': 'v0.0.14',
         'ocm.software/open-component-model/bindings/go/descriptor/v2': 'v2.0.4',
+        'ocm.software/open-component-model/bindings/go/github': 'v0.0.2',
         'ocm.software/open-component-model/bindings/go/gpg': 'v0.0.2',
         'ocm.software/open-component-model/bindings/go/helm': 'v0.0.2',
         'ocm.software/open-component-model/bindings/go/oci': 'v0.0.47',


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Documents the `GitHub/v1` access type, its resource repository, credential type and consumer identity.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes: https://github.com/open-component-model/ocm-project/issues/1195