### PR TITLE
chore(gha): add renovate ignore schedule option

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -9,6 +9,10 @@ on:
         type: choice
         default: enabled
         options: [ enabled, disabled, reset ]
+      ignoreSchedule:
+        description: 'Ignore renovate.json5 schedule'
+        type: boolean
+        default: false
   push:
     branches:
       - main
@@ -105,6 +109,7 @@ jobs:
           RENOVATE_REPOSITORY_CACHE: ${{ github.event_name == 'workflow_dispatch' && inputs.repoCache || 'enabled' }}
           RENOVATE_ALLOWED_COMMANDS: |
             ^./.github/scripts/renovate-post-upgrade.sh$
+          RENOVATE_FORCE: ${{ (github.event_name == 'workflow_dispatch' && inputs.ignoreSchedule) && '{"schedule":null}' || '' }}
 
       - name: Compress renovate cache
         if: ${{ env.RENOVATE_DRY_RUN == '' && (github.event_name != 'workflow_dispatch' || inputs.repoCache != 'disabled') }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Because the Renovate Workflow was disabled on Sunday, all our dep-bump PRs were not created (they run on a schedule on Sunday). Recreating those PRs locally is not viable because (1) all the commits were unsigned and (2) I would need to update them manually whenever the commit history would be out of date. 

Hence, I want to introduce another workflow option to run renovate and specifically disable the schedule configuration. This should recreate all the PRs that are usually created on a schedule.

I am using the [`force`](https://docs.renovatebot.com/self-hosted-configuration/#force) option to do so.

I believe this makes sense because there might be another Sunday, where GHA are off, the workflow is disabled, the GO Proxy not reachable or whatever other reason there might be. In such cases, we want to be able to re-run renovate and ignore the schedule.

#### Which issue(s) this PR fixes

All of them