### PR TITLE
fix: Update versioncheck test to new release tags

### DIFF
--- a/cli/internal/versioncheck/check.go
+++ b/cli/internal/versioncheck/check.go
@@ -21,7 +21,7 @@ const (
 	// DefaultGitHubRepo is the GitHub repository name (monorepo containing CLI, controller, etc.).
 	DefaultGitHubRepo = "open-component-model"
 	// DefaultTagPrefix identifies CLI releases within the monorepo's release tags.
-	DefaultTagPrefix = "cli/v"
+	DefaultTagPrefix = "v"
 	// DefaultHTTPTimeout is the maximum duration for the GitHub API request.
 	// Kept short to avoid delaying CLI commands in degraded network conditions.
 	DefaultHTTPTimeout = 5 * time.Second

--- a/cli/internal/versioncheck/doc.go
+++ b/cli/internal/versioncheck/doc.go
@@ -14,12 +14,12 @@
 //
 // # Release Filtering
 //
-// The OCM project is a monorepo with releases for multiple components. This package only
-// considers releases tagged with the "cli/v" prefix (e.g. "cli/v0.5.0"). It excludes:
+// The OCM project is a monorepo with unified releases. This package considers releases
+// tagged with the "v" prefix (e.g. "v0.13.0"). It excludes:
 //
 //   - Draft releases
 //   - GitHub pre-releases (prerelease flag set)
-//   - Semantic version pre-releases (e.g. "cli/v1.0.0-rc.1")
+//   - Semantic version pre-releases (e.g. "v1.0.0-rc.1")
 //
 // # Opt-Out
 //


### PR DESCRIPTION
#### What this PR does / why we need it

`cli/integration` tests are failing on main (and in PRs). Reason is that our most recent releases pushed the last `cli/v` release past the first page of the results and it is thus no longer found in the test.

#### Context 
The version check feature was introduced in #2491 (2026-05-18) when CLI releases used `cli/v` prefixed tags (last one: [`cli/v0.7.0`](https://github.com/open-component-model/open-component-model/releases/tag/cli/v0.7.0) on 2026-05-27).

  The release flow was consolidated in #2746 (2026-06-03), switching to unified v* tags starting with [`v0.8.0`](https://github.com/open-component-model/open-component-model/releases/tag/v0.8.0). Since then, 20+ releases have been published under the new scheme, pushing all `cli/v*` releases off the first page of the GitHub Releases API.

#### Which issue(s) this PR fixes


##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
