### PR TITLE
chore: Add index for routing `bindings/go` monolithic library

### DIFF
--- a/website/static/open-component-model/bindings/go/index.html
+++ b/website/static/open-component-model/bindings/go/index.html
@@ -1,0 +1,10 @@
+<html><head>
+  <meta name="go-import"
+        content="ocm.software/open-component-model
+                 git https://github.com/open-component-model/open-component-model">
+  <meta name="go-source"
+        content="ocm.software/open-component-model
+                 https://github.com/open-component-model/open-component-model
+                 https://github.com/open-component-model/open-component-model/tree/main{/dir}
+                 https://github.com/open-component-model/open-component-model/blob/main{/dir}/{file}#L{line}">
+</head></html>


### PR DESCRIPTION
#### What this PR does / why we need it
Add `index.html` for Go module discovery at `ocm.software/open-component-model/bindings/go`.


After the monolithic bindings release ([bindings/go/v0.0.1-alpha1](https://github.com/open-component-model/open-component-model/releases/tag/bindings/go/v0.0.1-alpha1)), `go get ocm.software/open-component-model/bindings/go@v0.0.1-alpha1` fails with:
```
unrecognized import path "ocm.software/open-component-model/bindings/go":
reading https://ocm.software/open-component-model/bindings/go?go-get=1: 404 Not Found
```
The Go toolchain performs [remote import path discovery](https://go.dev/ref/mod#vcs-find) by fetching `https://<domain>/<path>?go-get=1` and looking for a `<meta name="go-import">` tag. The `ocm.software` domain serves these via static HTML files in `website/static/open-component-model/bindings/go/`. Each sub-binding has one (e.g. [`runtime`](https://github.com/open-component-model/open-component-model/blob/main/website/static/open-component-model/bindings/go/runtime)), but the `bindings/go` path itself had no file resulting in a 404.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Testing

##### How to test the changes


##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
