### PR TITLE
chore: Update blogpost with version that exists

### DIFF
--- a/website/content/blog/2026-08-14-monolithic-bindings.md
+++ b/website/content/blog/2026-08-14-monolithic-bindings.md
@@ -44,7 +44,7 @@ The only difference in your `go.mod` is the `require` line:
 
 ```diff
 -require ocm.software/open-component-model/bindings/go/oci v0.0.49
-+require ocm.software/open-component-model/bindings/go v0.0.1
++require ocm.software/open-component-model/bindings/go v0.0.2
 ```
 
 ## What Stays the Same
@@ -68,7 +68,7 @@ needed.
 After the first monolithic release, update your go.mod:
 
 * Remove all references to `ocm.software/open-component-model/bindings/go/*`
-* Run `go get ocm.software/open-component-model/bindings/go@v0.0.1` 
+* Run `go get ocm.software/open-component-model/bindings/go@v0.0.2` 
 * Run `go mod tidy`
 
 While previously released per-module versions remain available, we discourage continuing to


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
https://ocm.software/blog/2026-08-14-monolithic-bindings/ references `0.0.1`, which doesn't exist. To avoid confusion change it to `0.0.2`

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Testing


##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
