### PR TITLE
fix: credential type registration [2/2] (#1146)

### DIFF
--- a/bindings/go/github/digest/digest.go
+++ b/bindings/go/github/digest/digest.go
@@ -18,6 +18,7 @@ import (
 	githubinternal "ocm.software/open-component-model/bindings/go/github/internal"
 	"ocm.software/open-component-model/bindings/go/github/repository/resource"
 	"ocm.software/open-component-model/bindings/go/github/spec/access"
+	ghcreds "ocm.software/open-component-model/bindings/go/github/spec/credentials"
 	credsv1 "ocm.software/open-component-model/bindings/go/github/spec/credentials/v1"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/digestprocessor"
 	"ocm.software/open-component-model/bindings/go/runtime"
@@ -163,4 +164,8 @@ func (p *DigestProcessor) ProcessResourceDigest(
 	res.Digest.Value = resolvedValue
 
 	return res, nil
+}
+
+func (p *DigestProcessor) GetCredentialTypeScheme() *runtime.Scheme {
+	return ghcreds.Scheme
 }

--- a/bindings/go/github/repository/resource/resource_repository.go
+++ b/bindings/go/github/repository/resource/resource_repository.go
@@ -12,6 +12,7 @@ import (
 	"ocm.software/open-component-model/bindings/go/github/internal/download"
 	githubaccess "ocm.software/open-component-model/bindings/go/github/spec/access"
 	v1 "ocm.software/open-component-model/bindings/go/github/spec/access/v1"
+	ghcreds "ocm.software/open-component-model/bindings/go/github/spec/credentials"
 	credsv1 "ocm.software/open-component-model/bindings/go/github/spec/credentials/v1"
 	ocmhttp "ocm.software/open-component-model/bindings/go/http"
 	httpv1alpha1 "ocm.software/open-component-model/bindings/go/http/spec/config/v1alpha1"
@@ -137,4 +138,8 @@ func (r *ResourceRepository) DownloadResource(ctx context.Context, resource *des
 // reference; content reaches GitHub through git, not through OCM.
 func (r *ResourceRepository) UploadResource(_ context.Context, _ *descriptor.Resource, _ blob.ReadOnlyBlob, _ runtime.Typed) (*descriptor.Resource, error) {
 	return nil, fmt.Errorf("github repositories do not support upload operations")
+}
+
+func (r *ResourceRepository) GetCredentialTypeScheme() *runtime.Scheme {
+	return ghcreds.Scheme
 }

--- a/bindings/go/gpg/signing/handler/handler.go
+++ b/bindings/go/gpg/signing/handler/handler.go
@@ -17,6 +17,7 @@ import (
 
 	descruntime "ocm.software/open-component-model/bindings/go/descriptor/runtime"
 	gpgcredentials "ocm.software/open-component-model/bindings/go/gpg/signing/handler/internal/credentials"
+	gpgcredentialsspec "ocm.software/open-component-model/bindings/go/gpg/spec/credentials"
 	gpgcredentialsv1 "ocm.software/open-component-model/bindings/go/gpg/spec/credentials/v1alpha1"
 	identityv1 "ocm.software/open-component-model/bindings/go/gpg/spec/identity/v1alpha1"
 	"ocm.software/open-component-model/bindings/go/gpg/spec/signing/v1alpha1"
@@ -251,4 +252,8 @@ func validateHashAlgorithm(alg string) error {
 		return nil
 	}
 	return fmt.Errorf("unsupported hash algorithm %q", alg)
+}
+
+func (h *Handler) GetCredentialTypeScheme() *runtime.Scheme {
+	return gpgcredentialsspec.Scheme
 }

--- a/bindings/go/gpg/spec/credentials/scheme.go
+++ b/bindings/go/gpg/spec/credentials/scheme.go
@@ -1,0 +1,12 @@
+package credentials
+
+import (
+	v1alpha1 "ocm.software/open-component-model/bindings/go/gpg/spec/credentials/v1alpha1"
+	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+var Scheme = runtime.NewScheme()
+
+func init() {
+	v1alpha1.MustRegisterCredentialType(Scheme)
+}

--- a/bindings/go/helm/digest/digest.go
+++ b/bindings/go/helm/digest/digest.go
@@ -16,6 +16,7 @@ import (
 	"ocm.software/open-component-model/bindings/go/helm/internal/download"
 	"ocm.software/open-component-model/bindings/go/helm/spec/access"
 	helmv1 "ocm.software/open-component-model/bindings/go/helm/spec/access/v1"
+	helmcreds "ocm.software/open-component-model/bindings/go/helm/spec/credentials"
 	helmcredsv1 "ocm.software/open-component-model/bindings/go/helm/spec/credentials/v1"
 	ocicredsv1 "ocm.software/open-component-model/bindings/go/oci/spec/credentials/v1"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/digestprocessor"
@@ -41,6 +42,13 @@ func NewDigestProcessor(tempFolder string) *DigestProcessor {
 
 func (p *DigestProcessor) GetResourceRepositoryScheme() *ocmruntime.Scheme {
 	return access.Scheme
+}
+
+// GetCredentialTypeScheme returns the credential payload types this digest processor consumes
+// (currently HelmHTTPCredentials/v1). oci:// helm repositories are authenticated with
+// OCICredentials/v1, which is declared by the OCI binding.
+func (p *DigestProcessor) GetCredentialTypeScheme() *ocmruntime.Scheme {
+	return helmcreds.Scheme
 }
 
 // GetResourceDigestProcessorCredentialConsumerIdentity resolves the credential consumer identity for digest processing.

--- a/bindings/go/helm/input/method.go
+++ b/bindings/go/helm/input/method.go
@@ -10,6 +10,7 @@ import (
 	"ocm.software/open-component-model/bindings/go/constructor"
 	constructorruntime "ocm.software/open-component-model/bindings/go/constructor/runtime"
 	helminternal "ocm.software/open-component-model/bindings/go/helm/internal"
+	helmcreds "ocm.software/open-component-model/bindings/go/helm/spec/credentials"
 	credsv1 "ocm.software/open-component-model/bindings/go/helm/spec/credentials/v1"
 	"ocm.software/open-component-model/bindings/go/helm/spec/input"
 	"ocm.software/open-component-model/bindings/go/helm/spec/input/v1"
@@ -157,4 +158,8 @@ func (i *InputMethod) createRemoteResourceAccess(resource *constructorruntime.Re
 	resource.Type = HelmRepositoryType
 
 	return resource, nil
+}
+
+func (i *InputMethod) GetCredentialTypeScheme() *runtime.Scheme {
+	return helmcreds.Scheme
 }

--- a/bindings/go/oci/credentials/credential_repository.go
+++ b/bindings/go/oci/credentials/credential_repository.go
@@ -52,3 +52,4 @@ func (p *OCICredentialRepository) ConsumerIdentityForConfig(_ context.Context, _
 	return nil, fmt.Errorf("credential consumer identities are not necessary for a docker config file and are thus not supported." +
 		"If you need to use a docker config file, it needs to be available on the host system as is, so it shouldn't need to generate a consumer identity")
 }
+

--- a/bindings/go/oci/credentials/credential_repository.go
+++ b/bindings/go/oci/credentials/credential_repository.go
@@ -52,4 +52,3 @@ func (p *OCICredentialRepository) ConsumerIdentityForConfig(_ context.Context, _
 	return nil, fmt.Errorf("credential consumer identities are not necessary for a docker config file and are thus not supported." +
 		"If you need to use a docker config file, it needs to be available on the host system as is, so it shouldn't need to generate a consumer identity")
 }
-

--- a/bindings/go/oci/repository/resource/resource_repository.go
+++ b/bindings/go/oci/repository/resource/resource_repository.go
@@ -300,6 +300,9 @@ func (p *ResourceRepository) UploadResourceStream(ctx context.Context, resource 
 	return res, nil
 }
 
+// GetCredentialTypeScheme returns the credential payload types this repository consumes
+// (currently OCICredentials/v1). ocicreds.Scheme must NOT be used here: it holds the
+// credential repository configuration types (DockerConfig) instead of payload types.
 func (p *ResourceRepository) GetCredentialTypeScheme() *runtime.Scheme {
-	return ocicreds.Scheme
+	return ocicreds.CredentialTypeScheme
 }

--- a/bindings/go/oci/repository/resource/resource_repository.go
+++ b/bindings/go/oci/repository/resource/resource_repository.go
@@ -17,6 +17,7 @@ import (
 	urlresolver "ocm.software/open-component-model/bindings/go/oci/resolver/url"
 	ociaccess "ocm.software/open-component-model/bindings/go/oci/spec/access"
 	v1 "ocm.software/open-component-model/bindings/go/oci/spec/access/v1"
+	ocicreds "ocm.software/open-component-model/bindings/go/oci/spec/credentials"
 	ocicredsv1 "ocm.software/open-component-model/bindings/go/oci/spec/credentials/v1"
 	credidentityv1 "ocm.software/open-component-model/bindings/go/oci/spec/identity/v1"
 	ociv1 "ocm.software/open-component-model/bindings/go/oci/spec/repository/v1/oci"
@@ -297,4 +298,8 @@ func (p *ResourceRepository) UploadResourceStream(ctx context.Context, resource 
 		return nil, fmt.Errorf("error streaming resource upload: %w", err)
 	}
 	return res, nil
+}
+
+func (p *ResourceRepository) GetCredentialTypeScheme() *runtime.Scheme {
+	return ocicreds.Scheme
 }

--- a/bindings/go/plugin/manager/contracts/credentialplugin/v1/capability.go
+++ b/bindings/go/plugin/manager/contracts/credentialplugin/v1/capability.go
@@ -22,4 +22,7 @@ func init() {
 type CapabilitySpec struct {
 	Type                           runtime.Type `json:"type"`
 	SupportedCredentialPluginTypes []types.Type `json:"supportedCredentialPluginTypes"`
+	// CustomCredentialTypes allows plugins to introduce new credential types that are not predefined in the system.
+	// The graph internally provides them as runtime.Raw and the plugins itself need to convert them back.
+	CustomCredentialTypes []types.Type `json:"customCredentialTypes,omitempty"`
 }

--- a/bindings/go/plugin/manager/contracts/credentialplugin/v1/zz_generated.deepcopy.go
+++ b/bindings/go/plugin/manager/contracts/credentialplugin/v1/zz_generated.deepcopy.go
@@ -21,6 +21,13 @@ func (in *CapabilitySpec) DeepCopyInto(out *CapabilitySpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.CustomCredentialTypes != nil {
+		in, out := &in.CustomCredentialTypes, &out.CustomCredentialTypes
+		*out = make([]types.Type, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/bindings/go/plugin/manager/manager.go
+++ b/bindings/go/plugin/manager/manager.go
@@ -317,6 +317,11 @@ func (pm *PluginManager) addPlugin(ctx context.Context, ocmConfig *genericv1.Con
 			if err := pm.CredentialRepositoryRegistry.AddPlugin(plugin, capability); err != nil {
 				return fmt.Errorf("failed to register plugin %s: %w", plugin.ID, err)
 			}
+			// The credential type registry is a type sink: it takes the credential types the
+			// plugin declares, the repository registry runs the plugin.
+			if err := pm.CredentialTypeRegistry.RegisterCustomTypes(plugin, capability.CustomCredentialTypes); err != nil {
+				return fmt.Errorf("failed to register credential types of plugin %s: %w", plugin.ID, err)
+			}
 		case *componentlisterv1.CapabilitySpec:
 			slog.DebugContext(ctx, "adding component lister plugin", "id", plugin.ID)
 			if err := pm.ComponentListerRegistry.AddPlugin(plugin, capability); err != nil {
@@ -346,6 +351,9 @@ func (pm *PluginManager) addPlugin(ctx context.Context, ocmConfig *genericv1.Con
 			slog.DebugContext(ctx, "adding credential plugin", "id", plugin.ID)
 			if err := pm.CredentialPluginRegistry.AddPlugin(plugin, capability); err != nil {
 				return fmt.Errorf("failed to register plugin %s: %w", plugin.ID, err)
+			}
+			if err := pm.CredentialTypeRegistry.RegisterCustomTypes(plugin, capability.CustomCredentialTypes); err != nil {
+				return fmt.Errorf("failed to register credential types of plugin %s: %w", plugin.ID, err)
 			}
 		default:
 			return fmt.Errorf("unknown capability type %T for plugin %s", capability, plugin.ID)

--- a/bindings/go/plugin/manager/manager.go
+++ b/bindings/go/plugin/manager/manager.go
@@ -30,6 +30,7 @@ import (
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/componentversionrepository"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialplugin"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialrepository"
+	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialtyperepository"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/digestprocessor"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/input"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/resource"
@@ -56,6 +57,7 @@ type PluginManager struct {
 	ResourcePluginRegistry             *resource.ResourceRegistry
 	BlobTransformerRegistry            *blobtransformer.Registry
 	SigningRegistry                    *signinghandler.SigningRegistry
+	CredentialTypeRegistry             *credentialtyperepository.CredentialTypeRegistry
 
 	mu sync.Mutex
 
@@ -79,6 +81,7 @@ func NewPluginManager(ctx context.Context) *PluginManager {
 		ResourcePluginRegistry:             resource.NewResourceRegistry(ctx),
 		BlobTransformerRegistry:            blobtransformer.NewBlobTransformerRegistry(ctx),
 		SigningRegistry:                    signinghandler.NewSigningRegistry(ctx),
+		CredentialTypeRegistry:             credentialtyperepository.NewCredentialTypeRegistry(ctx),
 		baseCtx:                            ctx,
 	}
 }

--- a/bindings/go/plugin/manager/manager_test.go
+++ b/bindings/go/plugin/manager/manager_test.go
@@ -18,6 +18,7 @@ import (
 	genericv1 "ocm.software/open-component-model/bindings/go/configuration/generic/v1/spec"
 	"ocm.software/open-component-model/bindings/go/plugin/internal/dummytype"
 	dummyv1 "ocm.software/open-component-model/bindings/go/plugin/internal/dummytype/v1"
+	credentialpluginv1 "ocm.software/open-component-model/bindings/go/plugin/manager/contracts/credentialplugin/v1"
 	ocmrepositoryv1 "ocm.software/open-component-model/bindings/go/plugin/manager/contracts/ocmrepository/v1"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/types"
 	pluginruntime "ocm.software/open-component-model/bindings/go/plugin/manager/types/runtime"
@@ -409,6 +410,42 @@ func TestCredentialTypeRegistryPopulatedFromPlugin(t *testing.T) {
 		}
 	})
 
-	scheme := pm.CredentialRepositoryRegistry.GetCredentialTypeScheme()
+	scheme := pm.CredentialTypeRegistry.GetCredentialTypeScheme()
 	require.True(t, scheme.IsRegistered(runtime.NewVersionedType("DummyToken", "v1")))
+}
+
+// TestCredentialTypeRegistryPopulatedFromCredentialPluginCapability covers the credential plugin
+// capability: the types it declares reach the credential type registry, while the credential
+// plugin registry owns the plugin itself.
+func TestCredentialTypeRegistryPopulatedFromCredentialPluginCapability(t *testing.T) {
+	ctx := t.Context()
+	pm := NewPluginManager(context.Background())
+
+	credType := runtime.NewVersionedType("VaultToken", "v1")
+	capabilitySpec := credentialpluginv1.CapabilitySpec{
+		Type: runtime.NewUnversionedType(string(credentialpluginv1.CredentialPluginType)),
+		SupportedCredentialPluginTypes: []types.Type{
+			{Type: runtime.NewVersionedType("HashiCorpVault", "v1")},
+		},
+		CustomCredentialTypes: []types.Type{{Type: credType}},
+	}
+	pluginSpec := pluginruntime.PluginSpec{CapabilitySpecs: []runtime.Typed{&capabilitySpec}}
+	rawPluginSpec, err := pluginruntime.ConvertToSpec(&pluginSpec)
+	require.NoError(t, err)
+	serialized, err := json.Marshal(rawPluginSpec)
+	require.NoError(t, err)
+
+	testPlugin := types.Plugin{
+		ID:   "vault-plugin",
+		Path: "/tmp/test-credential-plugin.socket",
+		Config: types.Config{
+			ID:         "vault-plugin",
+			Type:       "unix",
+			PluginType: credentialpluginv1.CredentialPluginType,
+		},
+	}
+	config := &genericv1.Config{Type: runtime.Type{Name: "custom.config", Version: "v1"}}
+
+	require.NoError(t, pm.addPlugin(ctx, config, testPlugin, bytes.NewBuffer(serialized)))
+	require.True(t, pm.CredentialTypeRegistry.GetCredentialTypeScheme().IsRegistered(credType))
 }

--- a/bindings/go/plugin/manager/registries/credentialplugin/registry.go
+++ b/bindings/go/plugin/manager/registries/credentialplugin/registry.go
@@ -52,7 +52,7 @@ func (r *Registry) AddPlugin(plugin mtypes.Plugin, spec runtime.Typed) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	//TODO(matthiasbruns): how do I split custom typed and this now???
+	// TODO(matthiasbruns): how do I split custom typed and this now???
 	capability := credentialpluginv1.CapabilitySpec{}
 	if err := credentialpluginv1.Scheme.Convert(spec, &capability); err != nil {
 		return fmt.Errorf("failed to convert object: %w", err)

--- a/bindings/go/plugin/manager/registries/credentialplugin/registry.go
+++ b/bindings/go/plugin/manager/registries/credentialplugin/registry.go
@@ -52,6 +52,7 @@ func (r *Registry) AddPlugin(plugin mtypes.Plugin, spec runtime.Typed) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	//TODO(matthiasbruns): how do I split custom typed and this now???
 	capability := credentialpluginv1.CapabilitySpec{}
 	if err := credentialpluginv1.Scheme.Convert(spec, &capability); err != nil {
 		return fmt.Errorf("failed to convert object: %w", err)

--- a/bindings/go/plugin/manager/registries/credentialrepository/registry.go
+++ b/bindings/go/plugin/manager/registries/credentialrepository/registry.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"os"
 	"os/exec"
 	"sync"
@@ -26,18 +25,16 @@ func NewCredentialRepositoryRegistry(ctx context.Context) *RepositoryRegistry {
 		consumerTypeRegistrations:           make(map[runtime.Type]runtime.Type),
 		internalCredentialRepositoryPlugins: make(map[runtime.Type]credentials.RepositoryPlugin),
 		scheme:                              runtime.NewScheme(),
-		credentialTypeScheme:                runtime.NewScheme(),
 	}
 }
 
 // RepositoryRegistry holds all plugins that implement capabilities corresponding to RepositoryPlugin operations.
 type RepositoryRegistry struct {
-	ctx                  context.Context
-	mu                   sync.Mutex
-	capabilities         map[string]credentialsv1.CapabilitySpec
-	registry             map[runtime.Type]mtypes.Plugin
-	scheme               *runtime.Scheme
-	credentialTypeScheme *runtime.Scheme
+	ctx          context.Context
+	mu           sync.Mutex
+	capabilities map[string]credentialsv1.CapabilitySpec
+	registry     map[runtime.Type]mtypes.Plugin
+	scheme       *runtime.Scheme
 
 	constructedPlugins        map[string]*constructedPlugin // running plugins
 	consumerTypeRegistrations map[runtime.Type]runtime.Type
@@ -48,21 +45,6 @@ type RepositoryRegistry struct {
 // RepositoryScheme returns the scheme used for credential repository spec types.
 func (r *RepositoryRegistry) RepositoryScheme() *runtime.Scheme {
 	return r.scheme
-}
-
-// GetCredentialTypeScheme returns the runtime scheme containing all registered
-// credential types, including built-in and plugin-declared custom types.
-func (r *RepositoryRegistry) GetCredentialTypeScheme() *runtime.Scheme {
-	return r.credentialTypeScheme
-}
-
-// Register merges a pre-built scheme of built-in credential types into the registry.
-// Call this during startup to make built-in types (e.g. OCICredentials, HelmHTTPCredentials)
-// known before any plugin is loaded.
-func (r *RepositoryRegistry) Register(scheme *runtime.Scheme) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.credentialTypeScheme.MustRegisterScheme(scheme)
 }
 
 // AddPlugin takes a plugin discovered by the manager and adds it to the stored plugin registry.
@@ -89,35 +71,7 @@ func (r *RepositoryRegistry) AddPlugin(plugin mtypes.Plugin, spec runtime.Typed)
 		r.registry[typ.Type] = plugin
 	}
 
-	if err := r.registerCustomCredentialTypes(capability); err != nil {
-		return fmt.Errorf("failed to register custom credential types: %w", err)
-	}
-
 	return nil
-}
-
-func (r *RepositoryRegistry) registerCustomCredentialTypes(capability credentialsv1.CapabilitySpec) error {
-	var errs []error
-	for _, t := range capability.CustomCredentialTypes {
-		typed := &runtime.Raw{}
-		typed.SetType(t.Type)
-		allTypes := append([]runtime.Type{t.Type}, t.Aliases...)
-		conflict := false
-		for _, alias := range allTypes {
-			if r.credentialTypeScheme.IsRegistered(alias) {
-				errs = append(errs, fmt.Errorf("credential type %s already registered", alias))
-				conflict = true
-			}
-		}
-		if conflict {
-			continue
-		}
-		if err := r.credentialTypeScheme.RegisterWithAlias(typed, allTypes...); err != nil {
-			slog.ErrorContext(r.ctx, "failed to build scheme for plugin credential type", "type", t.Type, "error", err)
-			errs = append(errs, err)
-		}
-	}
-	return errors.Join(errs...)
 }
 
 func (r *RepositoryRegistry) GetPlugin(ctx context.Context, spec runtime.Typed) (credentials.RepositoryPlugin, error) {

--- a/bindings/go/plugin/manager/registries/credentialtyperepository/contract.go
+++ b/bindings/go/plugin/manager/registries/credentialtyperepository/contract.go
@@ -1,0 +1,9 @@
+package credentialtyperepository
+
+import (
+	"ocm.software/open-component-model/bindings/go/credentials"
+)
+
+type BuiltinCredentialTypeSchemeProviderPlugin interface {
+	credentials.CredentialTypeSchemeProvider
+}

--- a/bindings/go/plugin/manager/registries/credentialtyperepository/credentialtype_test.go
+++ b/bindings/go/plugin/manager/registries/credentialtyperepository/credentialtype_test.go
@@ -1,61 +1,43 @@
-package credentialrepository_test
+package credentialtyperepository_test
 
-// Tests for the custom credential type registration path that lives inside
-// RepositoryRegistry.AddPlugin (via registerCustomCredentialTypes).
-// These tests were previously in the credentialtype package before the plugin
-// support was consolidated here.
+// Tests for the custom credential type registration path, moved here from the
+// credentialrepository package together with the registration logic itself. External plugins
+// declare the types they introduce in a capability spec; the manager extracts them and hands them
+// to this registry, while the registry owning that capability runs the plugin.
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	v1 "ocm.software/open-component-model/bindings/go/plugin/manager/contracts/credentials/v1"
-	"ocm.software/open-component-model/bindings/go/plugin/internal/dummytype"
-	dummyv1 "ocm.software/open-component-model/bindings/go/plugin/internal/dummytype/v1"
-	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialrepository"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/types"
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
-// credentialTypeCapability builds a CapabilitySpec carrying only CustomCredentialTypes,
-// which is the part exercised by registerCustomCredentialTypes.
-func credentialTypeCapability(customTypes ...types.Type) *v1.CapabilitySpec {
-	return &v1.CapabilitySpec{
-		Type:                  runtime.NewUnversionedType(string(v1.CredentialRepositoryPluginType)),
-		CustomCredentialTypes: customTypes,
-	}
-}
-
-func newRepoRegistry(t *testing.T) *credentialrepository.RepositoryRegistry {
-	t.Helper()
-	return credentialrepository.NewCredentialRepositoryRegistry(t.Context())
-}
-
-func TestAddPlugin_MultipleCustomCredentialTypes(t *testing.T) {
+func TestRegisterCustomTypes_MultipleCustomCredentialTypes(t *testing.T) {
 	r := require.New(t)
-	reg := newRepoRegistry(t)
+	reg := newRegistry(t)
 
 	typeA := runtime.NewVersionedType("CredA", "v1")
 	typeB := runtime.NewVersionedType("CredB", "v2")
-	r.NoError(reg.AddPlugin(types.Plugin{}, credentialTypeCapability(
-		types.Type{Type: typeA},
-		types.Type{Type: typeB},
-	)))
+	r.NoError(reg.RegisterCustomTypes(types.Plugin{ID: "plugin-a"}, []types.Type{
+		{Type: typeA},
+		{Type: typeB},
+	}))
 
 	scheme := reg.GetCredentialTypeScheme()
 	r.True(scheme.IsRegistered(typeA))
 	r.True(scheme.IsRegistered(typeB))
 }
 
-func TestAddPlugin_NoCustomCredentialTypes(t *testing.T) {
+func TestRegisterCustomTypes_NoCustomCredentialTypes(t *testing.T) {
 	r := require.New(t)
-	reg := newRepoRegistry(t)
-	r.NoError(reg.AddPlugin(types.Plugin{}, credentialTypeCapability()))
+	reg := newRegistry(t)
+	r.NoError(reg.RegisterCustomTypes(types.Plugin{ID: "plugin-a"}, nil))
 	r.NotNil(reg.GetCredentialTypeScheme())
 }
 
-func TestAddPlugin_ConflictsBetweenPlugins(t *testing.T) {
+func TestRegisterCustomTypes_ConflictsBetweenPlugins(t *testing.T) {
 	typeA := runtime.NewVersionedType("CredA", "v1")
 	aliasA := runtime.NewUnversionedType("CredA")
 	typeB := runtime.NewVersionedType("CredB", "v1")
@@ -85,26 +67,74 @@ func TestAddPlugin_ConflictsBetweenPlugins(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			r := require.New(t)
-			reg := newRepoRegistry(t)
-			r.NoError(reg.AddPlugin(types.Plugin{ID: "plugin-a"}, credentialTypeCapability(tc.first...)))
-			r.Error(reg.AddPlugin(types.Plugin{ID: "plugin-b"}, credentialTypeCapability(tc.second...)))
+			reg := newRegistry(t)
+			r.NoError(reg.RegisterCustomTypes(types.Plugin{ID: "plugin-a"}, tc.first))
+			r.Error(reg.RegisterCustomTypes(types.Plugin{ID: "plugin-b"}, tc.second))
 		})
 	}
 }
 
-// TestAddPlugin_MultipleTypesDoNotConflictWithRaw verifies that registering several
-// plugin credential types does not cause them to alias each other through *runtime.Raw.
-func TestAddPlugin_MultipleTypesDoNotConflictWithRaw(t *testing.T) {
+// TestRegisterCustomTypes_SamePluginDeclaresTwice covers a plugin binary that lists the same
+// custom type in more than one of its capability specs: it declares its own type, so it must not collide with
+// itself.
+func TestRegisterCustomTypes_SamePluginDeclaresTwice(t *testing.T) {
+	r := require.New(t)
+	reg := newRegistry(t)
+
+	typ := runtime.NewVersionedType("CredA", "v1")
+	alias := runtime.NewUnversionedType("CredA")
+	plugin := types.Plugin{ID: "plugin-a"}
+
+	r.NoError(reg.RegisterCustomTypes(plugin, []types.Type{{Type: typ, Aliases: []runtime.Type{alias}}}))
+	r.NoError(reg.RegisterCustomTypes(plugin, []types.Type{{Type: typ, Aliases: []runtime.Type{alias}}}))
+
+	scheme := reg.GetCredentialTypeScheme()
+	r.True(scheme.IsRegistered(typ))
+	r.True(scheme.IsRegistered(alias))
+}
+
+// TestRegisterCustomTypes_BuiltinTypeIsNotClaimable guards types registered by a builtin plugin: they have no
+// declaring plugin ID, so an external plugin must not be able to take them over.
+func TestRegisterCustomTypes_BuiltinTypeIsNotClaimable(t *testing.T) {
+	r := require.New(t)
+	reg := newRegistry(t)
+
+	typ := runtime.NewVersionedType("CredA", "v1")
+	builtin := runtime.NewScheme()
+	builtin.MustRegisterWithAlias(&runtime.Raw{}, typ)
+
+	r.NoError(reg.Register(builtin))
+	r.ErrorContains(reg.RegisterCustomTypes(types.Plugin{ID: "plugin-a"}, []types.Type{{Type: typ}}), "already registered")
+}
+
+func TestRegisterCustomTypes_NonConflictingTypesStillRegistered(t *testing.T) {
+	r := require.New(t)
+	reg := newRegistry(t)
+
+	typeA := runtime.NewVersionedType("CredA", "v1")
+	typeB := runtime.NewVersionedType("CredB", "v1")
+
+	r.NoError(reg.RegisterCustomTypes(types.Plugin{ID: "plugin-a"}, []types.Type{{Type: typeA}}))
+	r.Error(reg.RegisterCustomTypes(types.Plugin{ID: "plugin-b"}, []types.Type{
+		{Type: typeA},
+		{Type: typeB},
+	}))
+	r.True(reg.GetCredentialTypeScheme().IsRegistered(typeB), "non-conflicting type must still be registered")
+}
+
+// TestRegisterCustomTypes_MultipleTypesDoNotConflictWithRaw verifies that registering several plugin
+// credential types does not cause them to alias each other through *runtime.Raw.
+func TestRegisterCustomTypes_MultipleTypesDoNotConflictWithRaw(t *testing.T) {
 	typeA := runtime.NewVersionedType("PluginCredA", "v1")
 	typeB := runtime.NewVersionedType("PluginCredB", "v1")
 	typeC := runtime.NewVersionedType("PluginCredC", "v2")
 
-	reg := newRepoRegistry(t)
-	require.NoError(t, reg.AddPlugin(types.Plugin{}, credentialTypeCapability(
-		types.Type{Type: typeA},
-		types.Type{Type: typeB},
-		types.Type{Type: typeC},
-	)))
+	reg := newRegistry(t)
+	require.NoError(t, reg.RegisterCustomTypes(types.Plugin{ID: "plugin-a"}, []types.Type{
+		{Type: typeA},
+		{Type: typeB},
+		{Type: typeC},
+	}))
 
 	scheme := reg.GetCredentialTypeScheme()
 
@@ -147,11 +177,11 @@ func TestAddPlugin_MultipleTypesDoNotConflictWithRaw(t *testing.T) {
 		aliasType := runtime.NewUnversionedType("PluginCredWithAlias")
 		unrelated := runtime.NewVersionedType("Unrelated", "v1")
 
-		reg2 := newRepoRegistry(t)
-		r.NoError(reg2.AddPlugin(types.Plugin{}, credentialTypeCapability(
-			types.Type{Type: aliasedType, Aliases: []runtime.Type{aliasType}},
+		reg2 := newRegistry(t)
+		r.NoError(reg2.RegisterCustomTypes(types.Plugin{ID: "plugin-b"}, []types.Type{
+			{Type: aliasedType, Aliases: []runtime.Type{aliasType}},
 			types.Type{Type: unrelated},
-		)))
+		}))
 
 		s := reg2.GetCredentialTypeScheme()
 		r.True(s.IsRegistered(aliasedType))
@@ -178,17 +208,12 @@ func TestAddPlugin_MultipleTypesDoNotConflictWithRaw(t *testing.T) {
 	})
 }
 
-func TestAddPlugin_ConvertRoundTrips(t *testing.T) {
-	type customCred struct {
-		Type  runtime.Type `json:"type"`
-		Token string       `json:"token,omitempty"`
-	}
-
+func TestRegisterCustomTypes_ConvertRoundTrips(t *testing.T) {
 	pluginType := runtime.NewVersionedType("PluginTokenA", "v1")
-	reg := newRepoRegistry(t)
-	require.NoError(t, reg.AddPlugin(types.Plugin{}, credentialTypeCapability(
-		types.Type{Type: pluginType},
-	)))
+	reg := newRegistry(t)
+	require.NoError(t, reg.RegisterCustomTypes(types.Plugin{ID: "plugin-a"}, []types.Type{
+		{Type: pluginType},
+	}))
 
 	scheme := reg.GetCredentialTypeScheme()
 
@@ -215,37 +240,4 @@ func TestAddPlugin_ConvertRoundTrips(t *testing.T) {
 		_, ok := obj.(*runtime.Raw)
 		r.True(ok, "expected *runtime.Raw for plugin type, got %T", obj)
 	})
-}
-
-// ── Register (built-in scheme merging) ───────────────────────────────────────
-
-func TestRegister_BuiltinScheme(t *testing.T) {
-	r := require.New(t)
-	reg := newRepoRegistry(t)
-
-	reg.Register(dummytype.Scheme)
-
-	scheme := reg.GetCredentialTypeScheme()
-	r.True(scheme.IsRegistered(runtime.NewVersionedType(dummyv1.Type, dummyv1.Version)))
-	r.True(scheme.IsRegistered(runtime.NewUnversionedType(dummyv1.Type)))
-	r.True(scheme.IsRegistered(runtime.NewVersionedType(dummyv1.ShortType, dummyv1.Version)))
-	r.True(scheme.IsRegistered(runtime.NewUnversionedType(dummyv1.ShortType)))
-}
-
-func TestRegister_MultipleSchemesAreMerged(t *testing.T) {
-	r := require.New(t)
-	reg := newRepoRegistry(t)
-
-	schemeA := runtime.NewScheme()
-	schemeA.MustRegisterWithAlias(&runtime.Raw{}, runtime.NewVersionedType("CredA", "v1"))
-
-	schemeB := runtime.NewScheme()
-	schemeB.MustRegisterWithAlias(&runtime.Raw{}, runtime.NewVersionedType("CredB", "v1"))
-
-	reg.Register(schemeA)
-	reg.Register(schemeB)
-
-	scheme := reg.GetCredentialTypeScheme()
-	r.True(scheme.IsRegistered(runtime.NewVersionedType("CredA", "v1")))
-	r.True(scheme.IsRegistered(runtime.NewVersionedType("CredB", "v1")))
 }

--- a/bindings/go/plugin/manager/registries/credentialtyperepository/registry.go
+++ b/bindings/go/plugin/manager/registries/credentialtyperepository/registry.go
@@ -5,16 +5,18 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"reflect"
 	"sync"
 
-	credentialsv1 "ocm.software/open-component-model/bindings/go/plugin/manager/contracts/credentials/v1"
 	mtypes "ocm.software/open-component-model/bindings/go/plugin/manager/types"
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
 type CredentialTypeRegistry struct {
-	ctx      context.Context
-	mu       sync.Mutex
+	ctx context.Context
+	mu  sync.Mutex
+	// registry records which plugin declared a credential type. It exists for conflict
+	// attribution only; this registry never starts or owns a plugin process.
 	registry map[runtime.Type]mtypes.Plugin
 
 	scheme *runtime.Scheme
@@ -31,10 +33,55 @@ func NewCredentialTypeRegistry(ctx context.Context) *CredentialTypeRegistry {
 // Register merges a pre-built scheme of built-in credential types into the registry.
 // Call this during startup to make built-in types (e.g. OCICredentials, HelmHTTPCredentials)
 // known before any plugin is loaded.
-func (r *CredentialTypeRegistry) Register(scheme *runtime.Scheme) {
+//
+// Registration is idempotent: more than one plugin of a binding may declare the same types
+// (the helm input method, resource repository and digest processor all consume
+// HelmHTTPCredentials). Types that are already registered for the same prototype are skipped.
+// A type already registered for a different prototype is a genuine conflict and returns an
+// error.
+func (r *CredentialTypeRegistry) Register(scheme *runtime.Scheme) error {
+	if scheme == nil {
+		return nil
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.scheme.MustRegisterScheme(scheme)
+
+	for typ, aliases := range scheme.GetTypes() {
+		prototype, err := scheme.NewObject(typ)
+		if err != nil {
+			return fmt.Errorf("failed to create prototype for credential type %q: %w", typ, err)
+		}
+
+		// Collect the types that are not known yet; already known ones must agree on the
+		// prototype, otherwise two bindings claim the same type for different Go structs.
+		missing := make([]runtime.Type, 0, len(aliases)+1)
+		for _, candidate := range append([]runtime.Type{typ}, aliases...) {
+			if !r.scheme.IsRegistered(candidate) {
+				missing = append(missing, candidate)
+
+				continue
+			}
+
+			registered, err := r.scheme.NewObject(candidate)
+			if err != nil {
+				return fmt.Errorf("failed to create prototype for registered credential type %q: %w", candidate, err)
+			}
+			if reflect.TypeOf(registered) != reflect.TypeOf(prototype) {
+				return fmt.Errorf("credential type %q is already registered as %T and cannot be registered as %T", candidate, registered, prototype)
+			}
+		}
+
+		if len(missing) == 0 {
+			continue
+		}
+
+		if err := r.scheme.RegisterWithAlias(prototype, missing...); err != nil {
+			return fmt.Errorf("failed to register credential type %q: %w", typ, err)
+		}
+	}
+
+	return nil
 }
 
 // GetCredentialTypeScheme returns the runtime scheme containing all registered
@@ -43,51 +90,61 @@ func (r *CredentialTypeRegistry) GetCredentialTypeScheme() *runtime.Scheme {
 	return r.scheme
 }
 
-func (r *CredentialTypeRegistry) registerCustomCredentialTypes(capability credentialsv1.CapabilitySpec) error {
+// RegisterCustomTypes registers credential types declared by an external plugin in one of its
+// capability specs. The caller extracts them, so this registry stays independent of the
+// capability contracts. External plugin types have no compiled-in Go type, so they are registered as
+// [runtime.Raw] and consumers convert them via the scheme.
+//
+// The declaring plugin is remembered per type, so a plugin that declares the same type in more
+// than one of its capability specs is a no-op, while a second plugin claiming a type that is
+// already taken is a conflict. Conflicting entries are skipped and their errors are joined into
+// the return value; non-conflicting entries are always registered, even when other entries
+// conflict.
+func (r *CredentialTypeRegistry) RegisterCustomTypes(plugin mtypes.Plugin, types []mtypes.Type) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	var errs []error
-	for _, t := range capability.CustomCredentialTypes {
+	for _, t := range types {
 		typed := &runtime.Raw{}
 		typed.SetType(t.Type)
 		allTypes := append([]runtime.Type{t.Type}, t.Aliases...)
+
 		conflict := false
+		declared := 0
 		for _, alias := range allTypes {
-			if r.scheme.IsRegistered(alias) {
-				errs = append(errs, fmt.Errorf("credential type %s already registered", alias))
-				conflict = true
+			if !r.scheme.IsRegistered(alias) {
+				continue
 			}
+			// Already known: only the plugin that declared it may declare it again, e.g. from a
+			// second capability spec of the same plugin binary.
+			if declaredBy, ok := r.registry[alias]; ok && declaredBy.ID == plugin.ID {
+				declared++
+
+				continue
+			}
+			errs = append(errs, fmt.Errorf("credential type %s already registered", alias))
+			conflict = true
 		}
 		if conflict {
 			continue
 		}
+		if declared == len(allTypes) {
+			continue
+		}
+
 		if err := r.scheme.RegisterWithAlias(typed, allTypes...); err != nil {
 			slog.ErrorContext(r.ctx, "failed to build scheme for plugin credential type", "type", t.Type, "error", err)
 			errs = append(errs, err)
+
+			continue
+		}
+		for _, alias := range allTypes {
+			r.registry[alias] = plugin
 		}
 	}
+
 	return errors.Join(errs...)
-}
-
-// AddPlugin takes a plugin discovered by the manager and adds it to the stored plugin registry.
-// This function will return an error if the given capability + type already has a registered plugin.
-// Multiple plugins for the same cap+typ is not allowed.
-func (r *CredentialTypeRegistry) AddPlugin(plugin mtypes.Plugin, spec runtime.Typed) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	//capability := credentialsv1.CapabilitySpec{}
-	//if err := credentialsv1.Scheme.Convert(spec, &capability); err != nil {
-	//	return fmt.Errorf("failed to convert object: %w", err)
-	//}
-	//if _, ok := r.capabilities[plugin.ID]; ok {
-	//	return fmt.Errorf("plugin with ID %s already registered", plugin.ID)
-	//}
-	//r.capabilities[plugin.ID] = capability
-	//
-	//if err := r.registerCustomCredentialTypes(capability); err != nil {
-	//	return fmt.Errorf("failed to register custom credential types: %w", err)
-	//}
-
-	return nil
 }
 
 // RegisterInternalCredentialTypeSchemeProvider can be called by actual implementations in the source.
@@ -95,12 +152,14 @@ func (r *CredentialTypeRegistry) AddPlugin(plugin mtypes.Plugin, spec runtime.Ty
 func (r *CredentialTypeRegistry) RegisterInternalCredentialTypeSchemeProvider(
 	plugin BuiltinCredentialTypeSchemeProviderPlugin,
 ) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	if plugin == nil {
+		return fmt.Errorf("cannot register nil credential type scheme provider")
+	}
 
-	scheme := plugin.GetCredentialTypeScheme()
-
-	r.Register(scheme)
+	// Register takes the lock itself, so it must not be held here.
+	if err := r.Register(plugin.GetCredentialTypeScheme()); err != nil {
+		return fmt.Errorf("failed to register credential types of %T: %w", plugin, err)
+	}
 
 	return nil
 }

--- a/bindings/go/plugin/manager/registries/credentialtyperepository/registry.go
+++ b/bindings/go/plugin/manager/registries/credentialtyperepository/registry.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"sync"
 
-	"ocm.software/open-component-model/bindings/go/credentials"
 	credentialsv1 "ocm.software/open-component-model/bindings/go/plugin/manager/contracts/credentials/v1"
 	mtypes "ocm.software/open-component-model/bindings/go/plugin/manager/types"
 	"ocm.software/open-component-model/bindings/go/runtime"
@@ -23,13 +22,9 @@ type CredentialTypeRegistry struct {
 
 func NewCredentialTypeRegistry(ctx context.Context) *CredentialTypeRegistry {
 	return &CredentialTypeRegistry{
-		ctx:                                 ctx,
-		capabilities:                        make(map[string]credentialsv1.CapabilitySpec),
-		registry:                            make(map[runtime.Type]mtypes.Plugin),
-		constructedPlugins:                  make(map[string]*constructedPlugin), // running plugins
-		consumerTypeRegistrations:           make(map[runtime.Type]runtime.Type),
-		internalCredentialRepositoryPlugins: make(map[runtime.Type]credentials.RepositoryPlugin),
-		scheme:                              runtime.NewScheme(),
+		ctx:      ctx,
+		registry: make(map[runtime.Type]mtypes.Plugin),
+		scheme:   runtime.NewScheme(),
 	}
 }
 
@@ -79,18 +74,18 @@ func (r *CredentialTypeRegistry) AddPlugin(plugin mtypes.Plugin, spec runtime.Ty
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	capability := credentialsv1.CapabilitySpec{}
-	if err := credentialsv1.Scheme.Convert(spec, &capability); err != nil {
-		return fmt.Errorf("failed to convert object: %w", err)
-	}
-	if _, ok := r.capabilities[plugin.ID]; ok {
-		return fmt.Errorf("plugin with ID %s already registered", plugin.ID)
-	}
-	r.capabilities[plugin.ID] = capability
-
-	if err := r.registerCustomCredentialTypes(capability); err != nil {
-		return fmt.Errorf("failed to register custom credential types: %w", err)
-	}
+	//capability := credentialsv1.CapabilitySpec{}
+	//if err := credentialsv1.Scheme.Convert(spec, &capability); err != nil {
+	//	return fmt.Errorf("failed to convert object: %w", err)
+	//}
+	//if _, ok := r.capabilities[plugin.ID]; ok {
+	//	return fmt.Errorf("plugin with ID %s already registered", plugin.ID)
+	//}
+	//r.capabilities[plugin.ID] = capability
+	//
+	//if err := r.registerCustomCredentialTypes(capability); err != nil {
+	//	return fmt.Errorf("failed to register custom credential types: %w", err)
+	//}
 
 	return nil
 }

--- a/bindings/go/plugin/manager/registries/credentialtyperepository/registry.go
+++ b/bindings/go/plugin/manager/registries/credentialtyperepository/registry.go
@@ -1,0 +1,111 @@
+package credentialtyperepository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"ocm.software/open-component-model/bindings/go/credentials"
+	credentialsv1 "ocm.software/open-component-model/bindings/go/plugin/manager/contracts/credentials/v1"
+	mtypes "ocm.software/open-component-model/bindings/go/plugin/manager/types"
+	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+type CredentialTypeRegistry struct {
+	ctx      context.Context
+	mu       sync.Mutex
+	registry map[runtime.Type]mtypes.Plugin
+
+	scheme *runtime.Scheme
+}
+
+func NewCredentialTypeRegistry(ctx context.Context) *CredentialTypeRegistry {
+	return &CredentialTypeRegistry{
+		ctx:                                 ctx,
+		capabilities:                        make(map[string]credentialsv1.CapabilitySpec),
+		registry:                            make(map[runtime.Type]mtypes.Plugin),
+		constructedPlugins:                  make(map[string]*constructedPlugin), // running plugins
+		consumerTypeRegistrations:           make(map[runtime.Type]runtime.Type),
+		internalCredentialRepositoryPlugins: make(map[runtime.Type]credentials.RepositoryPlugin),
+		scheme:                              runtime.NewScheme(),
+	}
+}
+
+// Register merges a pre-built scheme of built-in credential types into the registry.
+// Call this during startup to make built-in types (e.g. OCICredentials, HelmHTTPCredentials)
+// known before any plugin is loaded.
+func (r *CredentialTypeRegistry) Register(scheme *runtime.Scheme) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.scheme.MustRegisterScheme(scheme)
+}
+
+// GetCredentialTypeScheme returns the runtime scheme containing all registered
+// credential types, including built-in and plugin-declared custom types.
+func (r *CredentialTypeRegistry) GetCredentialTypeScheme() *runtime.Scheme {
+	return r.scheme
+}
+
+func (r *CredentialTypeRegistry) registerCustomCredentialTypes(capability credentialsv1.CapabilitySpec) error {
+	var errs []error
+	for _, t := range capability.CustomCredentialTypes {
+		typed := &runtime.Raw{}
+		typed.SetType(t.Type)
+		allTypes := append([]runtime.Type{t.Type}, t.Aliases...)
+		conflict := false
+		for _, alias := range allTypes {
+			if r.scheme.IsRegistered(alias) {
+				errs = append(errs, fmt.Errorf("credential type %s already registered", alias))
+				conflict = true
+			}
+		}
+		if conflict {
+			continue
+		}
+		if err := r.scheme.RegisterWithAlias(typed, allTypes...); err != nil {
+			slog.ErrorContext(r.ctx, "failed to build scheme for plugin credential type", "type", t.Type, "error", err)
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// AddPlugin takes a plugin discovered by the manager and adds it to the stored plugin registry.
+// This function will return an error if the given capability + type already has a registered plugin.
+// Multiple plugins for the same cap+typ is not allowed.
+func (r *CredentialTypeRegistry) AddPlugin(plugin mtypes.Plugin, spec runtime.Typed) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	capability := credentialsv1.CapabilitySpec{}
+	if err := credentialsv1.Scheme.Convert(spec, &capability); err != nil {
+		return fmt.Errorf("failed to convert object: %w", err)
+	}
+	if _, ok := r.capabilities[plugin.ID]; ok {
+		return fmt.Errorf("plugin with ID %s already registered", plugin.ID)
+	}
+	r.capabilities[plugin.ID] = capability
+
+	if err := r.registerCustomCredentialTypes(capability); err != nil {
+		return fmt.Errorf("failed to register custom credential types: %w", err)
+	}
+
+	return nil
+}
+
+// RegisterInternalCredentialTypeSchemeProvider can be called by actual implementations in the source.
+// It will register any implementations directly for a given type and capability.
+func (r *CredentialTypeRegistry) RegisterInternalCredentialTypeSchemeProvider(
+	plugin BuiltinCredentialTypeSchemeProviderPlugin,
+) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	scheme := plugin.GetCredentialTypeScheme()
+
+	r.Register(scheme)
+
+	return nil
+}

--- a/bindings/go/plugin/manager/registries/credentialtyperepository/registry_test.go
+++ b/bindings/go/plugin/manager/registries/credentialtyperepository/registry_test.go
@@ -1,0 +1,161 @@
+package credentialtyperepository_test
+
+// Tests for merging built-in credential type schemes into the registry.
+// These moved here from the credentialrepository package, which no longer owns a
+// credential type scheme.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"ocm.software/open-component-model/bindings/go/plugin/internal/dummytype"
+	dummyv1 "ocm.software/open-component-model/bindings/go/plugin/internal/dummytype/v1"
+	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialtyperepository"
+	"ocm.software/open-component-model/bindings/go/runtime"
+)
+
+func newRegistry(t *testing.T) *credentialtyperepository.CredentialTypeRegistry {
+	t.Helper()
+	return credentialtyperepository.NewCredentialTypeRegistry(t.Context())
+}
+
+func TestRegister_BuiltinScheme(t *testing.T) {
+	r := require.New(t)
+	reg := newRegistry(t)
+
+	r.NoError(reg.Register(dummytype.Scheme))
+
+	scheme := reg.GetCredentialTypeScheme()
+	r.True(scheme.IsRegistered(runtime.NewVersionedType(dummyv1.Type, dummyv1.Version)))
+	r.True(scheme.IsRegistered(runtime.NewUnversionedType(dummyv1.Type)))
+	r.True(scheme.IsRegistered(runtime.NewVersionedType(dummyv1.ShortType, dummyv1.Version)))
+	r.True(scheme.IsRegistered(runtime.NewUnversionedType(dummyv1.ShortType)))
+}
+
+func TestRegister_MultipleSchemesAreMerged(t *testing.T) {
+	r := require.New(t)
+	reg := newRegistry(t)
+
+	schemeA := runtime.NewScheme()
+	schemeA.MustRegisterWithAlias(&runtime.Raw{}, runtime.NewVersionedType("CredA", "v1"))
+
+	schemeB := runtime.NewScheme()
+	schemeB.MustRegisterWithAlias(&runtime.Raw{}, runtime.NewVersionedType("CredB", "v1"))
+
+	r.NoError(reg.Register(schemeA))
+	r.NoError(reg.Register(schemeB))
+
+	scheme := reg.GetCredentialTypeScheme()
+	r.True(scheme.IsRegistered(runtime.NewVersionedType("CredA", "v1")))
+	r.True(scheme.IsRegistered(runtime.NewVersionedType("CredB", "v1")))
+}
+
+// TestRegisterInternalCredentialTypeSchemeProvider covers the builtin path: the registry reads
+// the types off the plugin instead of being handed a scheme.
+func TestRegisterInternalCredentialTypeSchemeProvider(t *testing.T) {
+	r := require.New(t)
+	reg := newRegistry(t)
+
+	r.NoError(reg.RegisterInternalCredentialTypeSchemeProvider(&schemeProviderPlugin{scheme: dummytype.Scheme}))
+
+	scheme := reg.GetCredentialTypeScheme()
+	r.True(scheme.IsRegistered(runtime.NewVersionedType(dummyv1.Type, dummyv1.Version)))
+	r.True(scheme.IsRegistered(runtime.NewUnversionedType(dummyv1.Type)))
+}
+
+func TestRegisterInternalCredentialTypeSchemeProvider_NilPlugin(t *testing.T) {
+	reg := newRegistry(t)
+	require.ErrorContains(t, reg.RegisterInternalCredentialTypeSchemeProvider(nil), "nil credential type scheme provider")
+}
+
+// TestRegister_SameSchemeTwice covers more than one plugin of a binding declaring the same
+// credential types, e.g. the wget input method and the wget resource repository.
+func TestRegister_SameSchemeTwice(t *testing.T) {
+	r := require.New(t)
+	reg := newRegistry(t)
+
+	r.NoError(reg.Register(dummytype.Scheme))
+	r.NoError(reg.Register(dummytype.Scheme), "registering the same types again must be a no-op")
+	r.True(reg.GetCredentialTypeScheme().IsRegistered(runtime.NewVersionedType(dummyv1.Type, dummyv1.Version)))
+	r.True(reg.GetCredentialTypeScheme().IsRegistered(runtime.NewUnversionedType(dummyv1.Type)))
+}
+
+// TestRegister_AdditionalAlias verifies that a scheme contributing an additional alias for an
+// already known prototype extends the registration instead of failing.
+func TestRegister_AdditionalAlias(t *testing.T) {
+	r := require.New(t)
+	reg := newRegistry(t)
+
+	versioned := runtime.NewVersionedType(dummyv1.Type, dummyv1.Version)
+	alias := runtime.NewUnversionedType(dummyv1.Type)
+
+	first := runtime.NewScheme()
+	first.MustRegisterWithAlias(&dummyv1.Repository{}, versioned)
+	second := runtime.NewScheme()
+	second.MustRegisterWithAlias(&dummyv1.Repository{}, versioned, alias)
+
+	r.NoError(reg.Register(first))
+	r.NoError(reg.Register(second))
+	r.True(reg.GetCredentialTypeScheme().IsRegistered(alias))
+}
+
+// TestRegister_ConflictingPrototype guards the case idempotency must not paper over: two bindings
+// claiming the same type for different Go structs.
+func TestRegister_ConflictingPrototype(t *testing.T) {
+	r := require.New(t)
+	reg := newRegistry(t)
+
+	typ := runtime.NewVersionedType("CredA", "v1")
+
+	first := runtime.NewScheme()
+	first.MustRegisterWithAlias(&dummyv1.Repository{}, typ)
+	second := runtime.NewScheme()
+	second.MustRegisterWithAlias(&runtime.Raw{}, typ)
+
+	r.NoError(reg.Register(first))
+	r.ErrorContains(reg.Register(second), "already registered")
+}
+
+func TestRegister_NilScheme(t *testing.T) {
+	require.NoError(t, newRegistry(t).Register(nil))
+}
+
+// TestRegisterInternalCredentialTypeSchemeProvider_ConflictNamesPlugin keeps the declaring plugin
+// in the error, so a conflict points at the plugin that has to be fixed.
+func TestRegisterInternalCredentialTypeSchemeProvider_ConflictNamesPlugin(t *testing.T) {
+	r := require.New(t)
+	reg := newRegistry(t)
+
+	typ := runtime.NewVersionedType("CredA", "v1")
+
+	first := runtime.NewScheme()
+	first.MustRegisterWithAlias(&dummyv1.Repository{}, typ)
+	second := runtime.NewScheme()
+	second.MustRegisterWithAlias(&runtime.Raw{}, typ)
+
+	r.NoError(reg.RegisterInternalCredentialTypeSchemeProvider(&schemeProviderPlugin{scheme: first}))
+	err := reg.RegisterInternalCredentialTypeSchemeProvider(&schemeProviderPlugin{scheme: second})
+	r.ErrorContains(err, "credentialtyperepository_test.schemeProviderPlugin")
+}
+
+// TestRegisterInternalCredentialTypeSchemeProvider_SamePluginTwice covers a binding that hands the
+// same provider over twice, e.g. the wget resource repository registered as resource plugin and as
+// digest processor.
+func TestRegisterInternalCredentialTypeSchemeProvider_SamePluginTwice(t *testing.T) {
+	r := require.New(t)
+	reg := newRegistry(t)
+
+	plugin := &schemeProviderPlugin{scheme: dummytype.Scheme}
+	r.NoError(reg.RegisterInternalCredentialTypeSchemeProvider(plugin))
+	r.NoError(reg.RegisterInternalCredentialTypeSchemeProvider(plugin))
+}
+
+// schemeProviderPlugin is a builtin plugin declaring the credential types it consumes.
+type schemeProviderPlugin struct {
+	scheme *runtime.Scheme
+}
+
+func (p *schemeProviderPlugin) GetCredentialTypeScheme() *runtime.Scheme {
+	return p.scheme
+}

--- a/bindings/go/rsa/signing/handler/handler.go
+++ b/bindings/go/rsa/signing/handler/handler.go
@@ -25,6 +25,7 @@ import (
 	rsasignature "ocm.software/open-component-model/bindings/go/rsa/signing/handler/internal/pem"
 	"ocm.software/open-component-model/bindings/go/rsa/signing/handler/internal/rfc2253"
 	"ocm.software/open-component-model/bindings/go/rsa/signing/v1alpha1"
+	rsacredentialspec "ocm.software/open-component-model/bindings/go/rsa/spec/credentials"
 	rsacredentialsv1 "ocm.software/open-component-model/bindings/go/rsa/spec/credentials/v1"
 	identityv1 "ocm.software/open-component-model/bindings/go/rsa/spec/identity/v1"
 	"ocm.software/open-component-model/bindings/go/runtime"
@@ -432,4 +433,8 @@ func rsaIdentityToMap(id *identityv1.RSAIdentity) runtime.Identity {
 	}
 	m.SetType(id.Type)
 	return m
+}
+
+func (h *Handler) GetCredentialTypeScheme() *runtime.Scheme {
+	return rsacredentialspec.Scheme
 }

--- a/bindings/go/sigstore/signing/handler/handler.go
+++ b/bindings/go/sigstore/signing/handler/handler.go
@@ -21,7 +21,9 @@ import (
 	"ocm.software/open-component-model/bindings/go/signing"
 	"ocm.software/open-component-model/bindings/go/sigstore/signing/handler/internal"
 	"ocm.software/open-component-model/bindings/go/sigstore/signing/v1alpha1"
+	"ocm.software/open-component-model/bindings/go/sigstore/spec/credentials/oidcidentitytoken"
 	oidcv1 "ocm.software/open-component-model/bindings/go/sigstore/spec/credentials/oidcidentitytoken/v1alpha1"
+	"ocm.software/open-component-model/bindings/go/sigstore/spec/credentials/trustedroot"
 	trustedrootv1 "ocm.software/open-component-model/bindings/go/sigstore/spec/credentials/trustedroot/v1alpha1"
 	signerv1 "ocm.software/open-component-model/bindings/go/sigstore/spec/identity/signer/v1alpha1"
 	verifierv1 "ocm.software/open-component-model/bindings/go/sigstore/spec/identity/verifier/v1alpha1"
@@ -479,4 +481,11 @@ func writeTemp(dir, pattern string, r io.Reader) (path string, err error) {
 		return "", fmt.Errorf("write temp file %q: %w", pattern, err)
 	}
 	return f.Name(), nil
+}
+
+func (h *Handler) GetCredentialTypeScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	oidcidentitytoken.MustRegisterCredentialType(scheme)
+	trustedroot.MustRegisterCredentialType(scheme)
+	return scheme
 }

--- a/bindings/go/wget/input/method.go
+++ b/bindings/go/wget/input/method.go
@@ -12,6 +12,7 @@ import (
 	httpv1alpha1 "ocm.software/open-component-model/bindings/go/http/spec/config/v1alpha1"
 	"ocm.software/open-component-model/bindings/go/runtime"
 	"ocm.software/open-component-model/bindings/go/wget/internal/download"
+	wgetcreds "ocm.software/open-component-model/bindings/go/wget/spec/credentials"
 	identityv1 "ocm.software/open-component-model/bindings/go/wget/spec/identity/v1"
 	"ocm.software/open-component-model/bindings/go/wget/spec/input"
 	v1 "ocm.software/open-component-model/bindings/go/wget/spec/input/v1"
@@ -112,4 +113,8 @@ func (i *InputMethod) ProcessResource(ctx context.Context, resource *constructor
 	return &constructor.ResourceInputMethodResult{
 		ProcessedBlobData: data,
 	}, nil
+}
+
+func (i *InputMethod) GetCredentialTypeScheme() *runtime.Scheme {
+	return wgetcreds.Scheme
 }

--- a/bindings/go/wget/repository/resource_repository.go
+++ b/bindings/go/wget/repository/resource_repository.go
@@ -16,6 +16,7 @@ import (
 	"ocm.software/open-component-model/bindings/go/wget/internal/download"
 	accessspec "ocm.software/open-component-model/bindings/go/wget/spec/access"
 	"ocm.software/open-component-model/bindings/go/wget/spec/access/v1"
+	wgetcreds "ocm.software/open-component-model/bindings/go/wget/spec/credentials"
 	identityv1 "ocm.software/open-component-model/bindings/go/wget/spec/identity/v1"
 )
 
@@ -196,4 +197,8 @@ func (r *ResourceRepository) ProcessResourceDigest(ctx context.Context, resource
 	}
 
 	return resource, nil
+}
+
+func (r *ResourceRepository) GetCredentialTypeScheme() *runtime.Scheme {
+	return wgetcreds.Scheme
 }

--- a/cli/cmd/setup/setup.go
+++ b/cli/cmd/setup/setup.go
@@ -121,7 +121,7 @@ func CredentialGraph(cmd *cobra.Command) error {
 		RepositoryPluginProvider:       pluginManager.CredentialRepositoryRegistry,
 		CredentialPluginProvider:       pluginManager.CredentialPluginRegistry,
 		CredentialRepositoryTypeScheme: pluginManager.CredentialRepositoryRegistry.RepositoryScheme(),
-		CredentialTypeSchemeProvider:   pluginManager.CredentialRepositoryRegistry,
+		CredentialTypeSchemeProvider:   pluginManager.CredentialTypeRegistry,
 	}
 
 	var credCfg *credentialsRuntime.Config

--- a/cli/cmd/setup/setup_credentials_test.go
+++ b/cli/cmd/setup/setup_credentials_test.go
@@ -36,7 +36,7 @@ func TestCredentialTypeSchemePopulatedByBuiltinRegister(t *testing.T) {
 	pm := manager.NewPluginManager(context.Background())
 	require.NoError(t, builtin.Register(pm, &filesystemv1alpha1.Config{}, &httpv1alpha1.Config{}, slog.Default()))
 
-	scheme := pm.CredentialRepositoryRegistry.GetCredentialTypeScheme()
+	scheme := pm.CredentialTypeRegistry.GetCredentialTypeScheme()
 	require.NotNil(t, scheme)
 
 	tests := []struct {
@@ -208,7 +208,7 @@ func TestCredentialGraphResolvesTypedCredentials(t *testing.T) {
 			}
 
 			graph, err := credentials.ToGraph(ctx, cfg, credentials.Options{
-				CredentialTypeSchemeProvider: pm.CredentialRepositoryRegistry,
+				CredentialTypeSchemeProvider: pm.CredentialTypeRegistry,
 			})
 			require.NoError(t, err)
 

--- a/cli/internal/plugin/builtin/builtin.go
+++ b/cli/internal/plugin/builtin/builtin.go
@@ -23,7 +23,7 @@ import (
 )
 
 func Register(manager *manager.PluginManager, filesystemConfig *filesystemv1alpha1.Config, httpConfig *httpv1alpha1.Config, logger *slog.Logger) error {
-	if err := ocicredentialplugin.Register(manager.CredentialRepositoryRegistry, manager.CredentialTypeRegistry); err != nil {
+	if err := ocicredentialplugin.Register(manager.CredentialRepositoryRegistry); err != nil {
 		return fmt.Errorf("could not register OCI inbuilt credential plugin: %w", err)
 	}
 
@@ -83,16 +83,16 @@ func Register(manager *manager.PluginManager, filesystemConfig *filesystemv1alph
 	); err != nil {
 		return fmt.Errorf("could not register helm resource repository plugin: %w", err)
 	}
-	if err := rsa.Register(manager.SigningRegistry, manager.CredentialRepositoryRegistry, filesystemConfig); err != nil {
+	if err := rsa.Register(manager.SigningRegistry, manager.CredentialTypeRegistry, filesystemConfig); err != nil {
 		return fmt.Errorf("could not register RSA signing plugin: %w", err)
 	}
-	if err := oidc.Register(manager.SigningRegistry, manager.CredentialRepositoryRegistry, filesystemConfig); err != nil {
+	if err := oidc.Register(manager.SigningRegistry, manager.CredentialTypeRegistry, filesystemConfig); err != nil {
 		return fmt.Errorf("could not register Sigstore signing plugin: %w", err)
 	}
 	if err := oidc.RegisterCredentialPlugin(manager.CredentialPluginRegistry); err != nil {
 		return fmt.Errorf("could not register OIDC credential plugin: %w", err)
 	}
-	if err := gpg.Register(manager.SigningRegistry, manager.CredentialRepositoryRegistry, filesystemConfig); err != nil {
+	if err := gpg.Register(manager.SigningRegistry, manager.CredentialTypeRegistry); err != nil {
 		return fmt.Errorf("could not register GPG signing plugin: %w", err)
 	}
 

--- a/cli/internal/plugin/builtin/builtin.go
+++ b/cli/internal/plugin/builtin/builtin.go
@@ -23,7 +23,7 @@ import (
 )
 
 func Register(manager *manager.PluginManager, filesystemConfig *filesystemv1alpha1.Config, httpConfig *httpv1alpha1.Config, logger *slog.Logger) error {
-	if err := ocicredentialplugin.Register(manager.CredentialRepositoryRegistry); err != nil {
+	if err := ocicredentialplugin.Register(manager.CredentialRepositoryRegistry, manager.CredentialTypeRegistry); err != nil {
 		return fmt.Errorf("could not register OCI inbuilt credential plugin: %w", err)
 	}
 
@@ -33,6 +33,7 @@ func Register(manager *manager.PluginManager, filesystemConfig *filesystemv1alph
 		manager.DigestProcessorRegistry,
 		manager.BlobTransformerRegistry,
 		manager.ComponentListerRegistry,
+		manager.CredentialTypeRegistry,
 		filesystemConfig,
 		httpConfig,
 		logger,
@@ -49,14 +50,17 @@ func Register(manager *manager.PluginManager, filesystemConfig *filesystemv1alph
 	if err := dir.Register(manager.InputRegistry, filesystemConfig); err != nil {
 		return fmt.Errorf("could not register dir input plugin: %w", err)
 	}
-	if err := helm.Register(manager.InputRegistry, manager.CredentialRepositoryRegistry, filesystemConfig, httpConfig); err != nil {
+	if err := helm.Register(manager.InputRegistry,
+		manager.CredentialTypeRegistry,
+		filesystemConfig,
+		httpConfig); err != nil {
 		return fmt.Errorf("could not register helm input plugin: %w", err)
 	}
 
 	if err := wget.Register(manager.InputRegistry,
 		manager.ResourcePluginRegistry,
 		manager.DigestProcessorRegistry,
-		manager.CredentialRepositoryRegistry,
+		manager.CredentialTypeRegistry,
 		httpConfig,
 		filesystemConfig); err != nil {
 		return fmt.Errorf("could not register wget inbuilt plugin: %w", err)
@@ -64,7 +68,7 @@ func Register(manager *manager.PluginManager, filesystemConfig *filesystemv1alph
 
 	if err := github.Register(manager.ResourcePluginRegistry,
 		manager.DigestProcessorRegistry,
-		manager.CredentialRepositoryRegistry,
+		manager.CredentialTypeRegistry,
 		httpConfig); err != nil {
 		return fmt.Errorf("could not register github inbuilt plugin: %w", err)
 	}

--- a/cli/internal/plugin/builtin/credentials/oci/plugin.go
+++ b/cli/internal/plugin/builtin/credentials/oci/plugin.go
@@ -2,18 +2,12 @@ package oci
 
 import (
 	ocicredentials "ocm.software/open-component-model/bindings/go/oci/credentials"
-	ocicredentialsspec "ocm.software/open-component-model/bindings/go/oci/spec/credentials"
 	ociidentity "ocm.software/open-component-model/bindings/go/oci/spec/identity/v1"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialrepository"
-	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialtyperepository"
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
-func Register(registry *credentialrepository.RepositoryRegistry, credTypeRegistry *credentialtyperepository.CredentialTypeRegistry) error {
-	registry.Register(ocicredentialsspec.CredentialTypeScheme)
-	// TODO(matthiasbruns): register
-	credTypeRegistry.RegisterInternalCredentialTypeSchemeProvider()
-
+func Register(registry *credentialrepository.RepositoryRegistry) error {
 	return registry.RegisterInternalCredentialRepositoryPlugin(
 		&ocicredentials.OCICredentialRepository{},
 		[]runtime.Type{ociidentity.Type},

--- a/cli/internal/plugin/builtin/credentials/oci/plugin.go
+++ b/cli/internal/plugin/builtin/credentials/oci/plugin.go
@@ -5,11 +5,14 @@ import (
 	ocicredentialsspec "ocm.software/open-component-model/bindings/go/oci/spec/credentials"
 	ociidentity "ocm.software/open-component-model/bindings/go/oci/spec/identity/v1"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialrepository"
+	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialtyperepository"
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
-func Register(registry *credentialrepository.RepositoryRegistry) error {
+func Register(registry *credentialrepository.RepositoryRegistry, credTypeRegistry *credentialtyperepository.CredentialTypeRegistry) error {
 	registry.Register(ocicredentialsspec.CredentialTypeScheme)
+	// TODO(matthiasbruns): register
+	credTypeRegistry.RegisterInternalCredentialTypeSchemeProvider()
 
 	return registry.RegisterInternalCredentialRepositoryPlugin(
 		&ocicredentials.OCICredentialRepository{},

--- a/cli/internal/plugin/builtin/github/register.go
+++ b/cli/internal/plugin/builtin/github/register.go
@@ -25,15 +25,16 @@ func Register(resourcePluginRegistry *resource.ResourceRegistry,
 	if err := resourcePluginRegistry.RegisterInternalResourcePlugin(repository); err != nil {
 		return fmt.Errorf("could not register github resource repository plugin: %w", err)
 	}
-
-	// TODO(matthiasbruns): digest processor vs resource repo - two entry points - what to pick?
 	if err := credTypeRegistry.RegisterInternalCredentialTypeSchemeProvider(repository); err != nil {
-		return fmt.Errorf("could not register github credential repository plugin: %w", err)
+		return fmt.Errorf("could not register github credential type plugin: %w", err)
 	}
 
 	digestProcessor := githubdigest.NewDigestProcessor(githubrepository.WithHTTPClient(httpClient))
 	if err := digestProcessorRegistry.RegisterInternalDigestProcessorPlugin(digestProcessor); err != nil {
 		return fmt.Errorf("could not register github digest processor plugin: %w", err)
+	}
+	if err := credTypeRegistry.RegisterInternalCredentialTypeSchemeProvider(digestProcessor); err != nil {
+		return fmt.Errorf("could not register github credential type plugin: %w", err)
 	}
 
 	return nil

--- a/cli/internal/plugin/builtin/github/register.go
+++ b/cli/internal/plugin/builtin/github/register.go
@@ -5,10 +5,9 @@ import (
 
 	githubdigest "ocm.software/open-component-model/bindings/go/github/digest"
 	githubrepository "ocm.software/open-component-model/bindings/go/github/repository/resource"
-	githubcreds "ocm.software/open-component-model/bindings/go/github/spec/credentials"
 	httpclient "ocm.software/open-component-model/bindings/go/http"
 	httpv1alpha1 "ocm.software/open-component-model/bindings/go/http/spec/config/v1alpha1"
-	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialrepository"
+	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialtyperepository"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/digestprocessor"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/resource"
 )
@@ -17,16 +16,19 @@ import (
 // credential scheme into the CLI plugin registries.
 func Register(resourcePluginRegistry *resource.ResourceRegistry,
 	digestProcessorRegistry *digestprocessor.RepositoryRegistry,
-	credentialRepository *credentialrepository.RepositoryRegistry,
+	credTypeRegistry *credentialtyperepository.CredentialTypeRegistry,
 	httpConfig *httpv1alpha1.Config,
 ) error {
 	httpClient := httpclient.New(httpclient.WithConfig(httpConfig))
 
-	credentialRepository.Register(githubcreds.Scheme)
-
 	repository := githubrepository.NewResourceRepository(githubrepository.WithHTTPClient(httpClient))
 	if err := resourcePluginRegistry.RegisterInternalResourcePlugin(repository); err != nil {
 		return fmt.Errorf("could not register github resource repository plugin: %w", err)
+	}
+
+	// TODO(matthiasbruns): digest processor vs resource repo - two entry points - what to pick?
+	if err := credTypeRegistry.RegisterInternalCredentialTypeSchemeProvider(repository); err != nil {
+		return fmt.Errorf("could not register github credential repository plugin: %w", err)
 	}
 
 	digestProcessor := githubdigest.NewDigestProcessor(githubrepository.WithHTTPClient(httpClient))

--- a/cli/internal/plugin/builtin/gpg/register.go
+++ b/cli/internal/plugin/builtin/gpg/register.go
@@ -21,6 +21,8 @@ func Register(
 	// has no scheme in released bindings yet
 	gpgCredScheme := runtime.NewScheme()
 	gpgcredsv1alpha1.MustRegisterCredentialType(gpgCredScheme)
+
+	// TODO(matthiasbruns): where do I implement the credential type getter here?
 	repositoryRegistry.Register(gpgCredScheme)
 
 	hdlr, err := handler.New(nil)

--- a/cli/internal/plugin/builtin/gpg/register.go
+++ b/cli/internal/plugin/builtin/gpg/register.go
@@ -5,29 +5,30 @@
 package gpg
 
 import (
-	filesystemv1alpha1 "ocm.software/open-component-model/bindings/go/configuration/filesystem/v1alpha1/spec"
+	"fmt"
+
 	"ocm.software/open-component-model/bindings/go/gpg/signing/handler"
 	gpgcredsv1alpha1 "ocm.software/open-component-model/bindings/go/gpg/spec/credentials/v1alpha1"
-	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialrepository"
+	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialtyperepository"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/signinghandler"
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
 func Register(
 	signingHandlerRegistry *signinghandler.SigningRegistry,
-	repositoryRegistry *credentialrepository.RepositoryRegistry,
-	_ *filesystemv1alpha1.Config,
+	credTypeRegistry *credentialtyperepository.CredentialTypeRegistry,
 ) error {
 	// has no scheme in released bindings yet
 	gpgCredScheme := runtime.NewScheme()
 	gpgcredsv1alpha1.MustRegisterCredentialType(gpgCredScheme)
 
-	// TODO(matthiasbruns): where do I implement the credential type getter here?
-	repositoryRegistry.Register(gpgCredScheme)
-
 	hdlr, err := handler.New(nil)
 	if err != nil {
 		return err
+	}
+
+	if err := credTypeRegistry.RegisterInternalCredentialTypeSchemeProvider(hdlr); err != nil {
+		return fmt.Errorf("could not register GPG credential type plugin: %w", err)
 	}
 
 	return signingHandlerRegistry.RegisterInternalComponentSignatureHandler(hdlr)

--- a/cli/internal/plugin/builtin/input/helm/method.go
+++ b/cli/internal/plugin/builtin/input/helm/method.go
@@ -5,14 +5,13 @@ import (
 
 	filesystemv1alpha1 "ocm.software/open-component-model/bindings/go/configuration/filesystem/v1alpha1/spec"
 	helminput "ocm.software/open-component-model/bindings/go/helm/input"
-	helm "ocm.software/open-component-model/bindings/go/helm/spec/credentials"
 	httpv1alpha1 "ocm.software/open-component-model/bindings/go/http/spec/config/v1alpha1"
-	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialrepository"
+	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialtyperepository"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/input"
 )
 
 func Register(inputRegistry *input.RepositoryRegistry,
-	repositoryRegistry *credentialrepository.RepositoryRegistry,
+	credTypeRegistry *credentialtyperepository.CredentialTypeRegistry,
 	filesystemConfig *filesystemv1alpha1.Config,
 	httpConfig *httpv1alpha1.Config,
 ) error {
@@ -21,7 +20,9 @@ func Register(inputRegistry *input.RepositoryRegistry,
 		HTTPConfig: httpConfig,
 	}
 
-	repositoryRegistry.Register(helm.Scheme)
+	if err := credTypeRegistry.RegisterInternalCredentialTypeSchemeProvider(method); err != nil {
+		return fmt.Errorf("could not register helm credential repository plugin: %w", err)
+	}
 
 	if err := inputRegistry.RegisterInternalResourceInputPlugin(method); err != nil {
 		return fmt.Errorf("could not register helm resource input method: %w", err)

--- a/cli/internal/plugin/builtin/input/helm/method_test.go
+++ b/cli/internal/plugin/builtin/input/helm/method_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialtyperepository"
 
 	filesystemv1alpha1 "ocm.software/open-component-model/bindings/go/configuration/filesystem/v1alpha1/spec"
 	helmv1 "ocm.software/open-component-model/bindings/go/helm/spec/input/v1"
 	httpv1alpha1 "ocm.software/open-component-model/bindings/go/http/spec/config/v1alpha1"
-	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialrepository"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/input"
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
@@ -16,7 +16,7 @@ import (
 func TestRegister(t *testing.T) {
 	ctx := t.Context()
 	registry := input.NewInputRepositoryRegistry(ctx)
-	credentialsRegistry := credentialrepository.NewCredentialRepositoryRegistry(ctx)
+	credentialsRegistry := credentialtyperepository.NewCredentialTypeRegistry(ctx)
 	cfg := &filesystemv1alpha1.Config{
 		TempFolder: t.TempDir(),
 	}

--- a/cli/internal/plugin/builtin/oci/register.go
+++ b/cli/internal/plugin/builtin/oci/register.go
@@ -12,6 +12,7 @@ import (
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/blobtransformer"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/componentlister"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/componentversionrepository"
+	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialtyperepository"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/digestprocessor"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/resource"
 )
@@ -24,6 +25,7 @@ func Register(
 	digRegistry *digestprocessor.RepositoryRegistry,
 	blobTransformerRegistry *blobtransformer.Registry,
 	compListRegistry *componentlister.ComponentListerRegistry,
+	credTypeRegistry *credentialtyperepository.CredentialTypeRegistry,
 	filesystemConfig *filesystemv1alpha1.Config,
 	httpConfig *httpv1alpha1.Config,
 	logger *slog.Logger,
@@ -45,6 +47,9 @@ func Register(
 			resourceRepoPlugin,
 		),
 		digRegistry.RegisterInternalDigestProcessorPlugin(
+			resourceRepoPlugin,
+		),
+		credTypeRegistry.RegisterInternalCredentialTypeSchemeProvider(
 			resourceRepoPlugin,
 		),
 		blobTransformerRegistry.RegisterInternalBlobTransformerPlugin(

--- a/cli/internal/plugin/builtin/oidc/register.go
+++ b/cli/internal/plugin/builtin/oidc/register.go
@@ -1,28 +1,29 @@
 package oidc
 
 import (
+	"fmt"
+
 	filesystemv1alpha1 "ocm.software/open-component-model/bindings/go/configuration/filesystem/v1alpha1/spec"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialplugin"
-	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialrepository"
+	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialtyperepository"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/signinghandler"
 	"ocm.software/open-component-model/bindings/go/sigstore/signing/handler"
-	oidcidentitytoken "ocm.software/open-component-model/bindings/go/sigstore/spec/credentials/oidcidentitytoken"
-	trustedroot "ocm.software/open-component-model/bindings/go/sigstore/spec/credentials/trustedroot"
 )
 
 // Register registers the Sigstore signing handler with the signing registry and
 // registers OIDCIdentityToken/v1alpha1 and TrustedRoot/v1alpha1 credential types.
 func Register(
 	signingHandlerRegistry *signinghandler.SigningRegistry,
-	repositoryRegistry *credentialrepository.RepositoryRegistry,
+	credTypeRegistry *credentialtyperepository.CredentialTypeRegistry,
 	filesystemConfig *filesystemv1alpha1.Config,
 ) error {
-	// TODO(matthiasbruns): what about them?
-	repositoryRegistry.Register(oidcidentitytoken.Scheme)
-	repositoryRegistry.Register(trustedroot.Scheme)
+	hldr := handler.New(handler.WithTempDir(filesystemConfig.TempFolder))
+	if err := credTypeRegistry.RegisterInternalCredentialTypeSchemeProvider(hldr); err != nil {
+		return fmt.Errorf("could not register OIDC credential type plugin: %w", err)
+	}
 
 	return signingHandlerRegistry.RegisterInternalComponentSignatureHandler(
-		handler.New(handler.WithTempDir(filesystemConfig.TempFolder)),
+		hldr,
 	)
 }
 

--- a/cli/internal/plugin/builtin/oidc/register.go
+++ b/cli/internal/plugin/builtin/oidc/register.go
@@ -17,6 +17,7 @@ func Register(
 	repositoryRegistry *credentialrepository.RepositoryRegistry,
 	filesystemConfig *filesystemv1alpha1.Config,
 ) error {
+	// TODO(matthiasbruns): what about them?
 	repositoryRegistry.Register(oidcidentitytoken.Scheme)
 	repositoryRegistry.Register(trustedroot.Scheme)
 

--- a/cli/internal/plugin/builtin/rsa/register.go
+++ b/cli/internal/plugin/builtin/rsa/register.go
@@ -15,7 +15,7 @@ import (
 func Register(
 	signingHandlerRegistry *signinghandler.SigningRegistry,
 	repositoryRegistry *credentialrepository.RepositoryRegistry,
-	// TODO add filesystem and logging awareness to rsa handler
+// TODO add filesystem and logging awareness to rsa handler
 	_ *filesystemv1alpha1.Config,
 ) error {
 	scheme := runtime.NewScheme()
@@ -28,6 +28,7 @@ func Register(
 		return err
 	}
 
+	// same here - what plugin??
 	repositoryRegistry.Register(rsacredentials.Scheme)
 
 	return errors.Join(

--- a/cli/internal/plugin/builtin/rsa/register.go
+++ b/cli/internal/plugin/builtin/rsa/register.go
@@ -2,20 +2,20 @@ package rsa
 
 import (
 	"errors"
+	"fmt"
 
 	filesystemv1alpha1 "ocm.software/open-component-model/bindings/go/configuration/filesystem/v1alpha1/spec"
-	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialrepository"
+	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialtyperepository"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/signinghandler"
 	"ocm.software/open-component-model/bindings/go/rsa/signing/handler"
 	"ocm.software/open-component-model/bindings/go/rsa/signing/v1alpha1"
-	rsacredentials "ocm.software/open-component-model/bindings/go/rsa/spec/credentials"
 	"ocm.software/open-component-model/bindings/go/runtime"
 )
 
 func Register(
 	signingHandlerRegistry *signinghandler.SigningRegistry,
-	repositoryRegistry *credentialrepository.RepositoryRegistry,
-// TODO add filesystem and logging awareness to rsa handler
+	credTypeRegistry *credentialtyperepository.CredentialTypeRegistry,
+	// TODO add filesystem and logging awareness to rsa handler
 	_ *filesystemv1alpha1.Config,
 ) error {
 	scheme := runtime.NewScheme()
@@ -28,8 +28,9 @@ func Register(
 		return err
 	}
 
-	// same here - what plugin??
-	repositoryRegistry.Register(rsacredentials.Scheme)
+	if err := credTypeRegistry.RegisterInternalCredentialTypeSchemeProvider(hdlr); err != nil {
+		return fmt.Errorf("could not register rsa credential type plugin: %w", err)
+	}
 
 	return errors.Join(
 		signingHandlerRegistry.RegisterInternalComponentSignatureHandler(hdlr),

--- a/cli/internal/plugin/builtin/wget/register.go
+++ b/cli/internal/plugin/builtin/wget/register.go
@@ -6,20 +6,19 @@ import (
 	filesystemv1alpha1 "ocm.software/open-component-model/bindings/go/configuration/filesystem/v1alpha1/spec"
 	httpclient "ocm.software/open-component-model/bindings/go/http"
 	httpv1alpha1 "ocm.software/open-component-model/bindings/go/http/spec/config/v1alpha1"
-	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialrepository"
+	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialtyperepository"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/digestprocessor"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/input"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/resource"
 	wgetinput "ocm.software/open-component-model/bindings/go/wget/input"
 	wgetrepository "ocm.software/open-component-model/bindings/go/wget/repository"
-	wgetcreds "ocm.software/open-component-model/bindings/go/wget/spec/credentials"
 )
 
 // Register wires the wget input method and its credential scheme into the CLI plugin registries.
 func Register(inputRegistry *input.RepositoryRegistry,
 	resourcePluginRegistry *resource.ResourceRegistry,
 	digestProcessorRegistry *digestprocessor.RepositoryRegistry,
-	credentialRepository *credentialrepository.RepositoryRegistry,
+	credTypeRegistry *credentialtyperepository.CredentialTypeRegistry,
 	httpConfig *httpv1alpha1.Config,
 	filesystemConfig *filesystemv1alpha1.Config,
 ) error {
@@ -28,7 +27,9 @@ func Register(inputRegistry *input.RepositoryRegistry,
 		HTTPConfig: httpConfig,
 	}
 
-	credentialRepository.Register(wgetcreds.Scheme)
+	if err := credTypeRegistry.RegisterInternalCredentialTypeSchemeProvider(method); err != nil {
+		return fmt.Errorf("could not register helm credential repository plugin: %w", err)
+	}
 
 	if err := inputRegistry.RegisterInternalResourceInputPlugin(method); err != nil {
 		return fmt.Errorf("could not register wget resource input method: %w", err)

--- a/cli/internal/plugin/builtin/wget/register.go
+++ b/cli/internal/plugin/builtin/wget/register.go
@@ -26,13 +26,11 @@ func Register(inputRegistry *input.RepositoryRegistry,
 		TempFolder: filesystemConfig.TempFolder,
 		HTTPConfig: httpConfig,
 	}
-
-	if err := credTypeRegistry.RegisterInternalCredentialTypeSchemeProvider(method); err != nil {
-		return fmt.Errorf("could not register helm credential repository plugin: %w", err)
-	}
-
 	if err := inputRegistry.RegisterInternalResourceInputPlugin(method); err != nil {
 		return fmt.Errorf("could not register wget resource input method: %w", err)
+	}
+	if err := credTypeRegistry.RegisterInternalCredentialTypeSchemeProvider(method); err != nil {
+		return fmt.Errorf("could not register helm credential type plugin: %w", err)
 	}
 
 	wgetResourceRepository := wgetrepository.NewResourceRepository(
@@ -45,6 +43,8 @@ func Register(inputRegistry *input.RepositoryRegistry,
 	if err := digestProcessorRegistry.RegisterInternalDigestProcessorPlugin(wgetResourceRepository); err != nil {
 		return fmt.Errorf("could not register wget digest processor plugin: %w", err)
 	}
-
+	if err := credTypeRegistry.RegisterInternalCredentialTypeSchemeProvider(wgetResourceRepository); err != nil {
+		return fmt.Errorf("could not register wget credential type plugin: %w", err)
+	}
 	return nil
 }

--- a/cli/internal/plugin/builtin/wget/register_test.go
+++ b/cli/internal/plugin/builtin/wget/register_test.go
@@ -7,7 +7,7 @@ import (
 
 	filesystemv1alpha1 "ocm.software/open-component-model/bindings/go/configuration/filesystem/v1alpha1/spec"
 	httpv1alpha1 "ocm.software/open-component-model/bindings/go/http/spec/config/v1alpha1"
-	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialrepository"
+	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/credentialtyperepository"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/digestprocessor"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/input"
 	"ocm.software/open-component-model/bindings/go/plugin/manager/registries/resource"
@@ -28,7 +28,7 @@ func TestRegister_InputMethodUsesConfiguredTempFolder(t *testing.T) {
 		inputRegistry,
 		resource.NewResourceRegistry(ctx),
 		digestprocessor.NewDigestProcessorRegistry(ctx),
-		credentialrepository.NewCredentialRepositoryRegistry(ctx),
+		credentialtyperepository.NewCredentialTypeRegistry(ctx),
 		&httpv1alpha1.Config{},
 		&filesystemv1alpha1.Config{TempFolder: tempFolder},
 	))

--- a/cli/internal/subsystem/core.go
+++ b/cli/internal/subsystem/core.go
@@ -49,7 +49,7 @@ func NewRegistryFromPluginManager(pm *manager.PluginManager) (*Registry, error) 
 		input.Scheme.RegisterScheme(pm.InputRegistry.InputRepositoryScheme()),
 		credentialRepository.Scheme.RegisterScheme(pm.CredentialRepositoryRegistry.RepositoryScheme()),
 		signingHandler.Scheme.RegisterScheme(pm.SigningRegistry.ResourceScheme()),
-		credentials.Scheme.RegisterScheme(pm.CredentialRepositoryRegistry.GetCredentialTypeScheme()),
+		credentials.Scheme.RegisterScheme(pm.CredentialTypeRegistry.GetCredentialTypeScheme()),
 	); err != nil {
 		return nil, err
 	}

--- a/docs/adr/0021_typed_credentials.md
+++ b/docs/adr/0021_typed_credentials.md
@@ -169,9 +169,14 @@ credentialTypeScheme.MustRegisterWithAlias(&HelmHTTPCredentials{}, HelmHTTPCrede
 ```
 
 External plugins (separate binaries) declare custom credential types they introduce in the `customCredentialTypes`
-field of their JSON capability spec. The `PluginManager` registers these into the credential type scheme during
-plugin discovery — no manual CLI aggregation needed. Built-in types (e.g., `HelmHTTPCredentials/v1`,
-`OCICredentials/v1`) are already registered by the built-in bindings at startup and must not be re-declared here.
+field of their JSON capability spec — supported on both the credential repository and the credential plugin
+capability. The `PluginManager` extracts them at discovery time and registers them in the credential type registry,
+while the registry owning that capability runs the plugin — no manual CLI aggregation needed. Built-in types (e.g.,
+`HelmHTTPCredentials/v1`, `OCICredentials/v1`) are already registered by the built-in plugins at startup and must not
+be re-declared here.
+
+A type is remembered together with the plugin that declared it: the same plugin may declare a type in more than one
+of its capability specs, while a second plugin claiming a type that is already taken is rejected at startup.
 
 #### Graph Consumption
 
@@ -241,8 +246,9 @@ signature** to `credentials runtime.Typed`, with `scheme.Convert(typed, *runtime
 way — only the Go API shape changes.
 
 **At discovery time:** The plugin manager runs each plugin binary with `capabilities` and reads the capability JSON.
-The plugin manager registers any types listed in `customCredentialTypes` into the credential type scheme — covering
-only custom types the plugin introduces, not built-ins already registered at startup.
+The plugin manager registers any types listed in `customCredentialTypes` — on the credential repository or the
+credential plugin capability — into the credential type registry, covering only custom types the plugin introduces,
+not built-ins already registered at startup.
 
 **At the plugin boundary (post Phase 3):** The graph hands the resolved `runtime.Typed` directly to the plugin
 contract; the plugin transport marshals it to canonical JSON via the scheme and the plugin-side handler unmarshals

--- a/docs/adr/0021_typed_credentials.md
+++ b/docs/adr/0021_typed_credentials.md
@@ -169,14 +169,9 @@ credentialTypeScheme.MustRegisterWithAlias(&HelmHTTPCredentials{}, HelmHTTPCrede
 ```
 
 External plugins (separate binaries) declare custom credential types they introduce in the `customCredentialTypes`
-field of their JSON capability spec — supported on both the credential repository and the credential plugin
-capability. The `PluginManager` extracts them at discovery time and registers them in the credential type registry,
-while the registry owning that capability runs the plugin — no manual CLI aggregation needed. Built-in types (e.g.,
-`HelmHTTPCredentials/v1`, `OCICredentials/v1`) are already registered by the built-in plugins at startup and must not
-be re-declared here.
-
-A type is remembered together with the plugin that declared it: the same plugin may declare a type in more than one
-of its capability specs, while a second plugin claiming a type that is already taken is rejected at startup.
+field of their JSON capability spec. The `PluginManager` registers these into the credential type scheme during
+plugin discovery — no manual CLI aggregation needed. Built-in types (e.g., `HelmHTTPCredentials/v1`,
+`OCICredentials/v1`) are already registered by the built-in bindings at startup and must not be re-declared here.
 
 #### Graph Consumption
 
@@ -246,9 +241,8 @@ signature** to `credentials runtime.Typed`, with `scheme.Convert(typed, *runtime
 way — only the Go API shape changes.
 
 **At discovery time:** The plugin manager runs each plugin binary with `capabilities` and reads the capability JSON.
-The plugin manager registers any types listed in `customCredentialTypes` — on the credential repository or the
-credential plugin capability — into the credential type registry, covering only custom types the plugin introduces,
-not built-ins already registered at startup.
+The plugin manager registers any types listed in `customCredentialTypes` into the credential type scheme — covering
+only custom types the plugin introduces, not built-ins already registered at startup.
 
 **At the plugin boundary (post Phase 3):** The graph hands the resolved `runtime.Typed` directly to the plugin
 contract; the plugin transport marshals it to canonical JSON via the scheme and the plugin-side handler unmarshals

--- a/kubernetes/controller/cmd/main.go
+++ b/kubernetes/controller/cmd/main.go
@@ -28,18 +28,15 @@ import (
 
 	filesystemv1alpha1 "ocm.software/open-component-model/bindings/go/configuration/filesystem/v1alpha1/spec"
 	helmdigest "ocm.software/open-component-model/bindings/go/helm/digest"
-	helmcredspec "ocm.software/open-component-model/bindings/go/helm/spec/credentials"
 	ocicredentials "ocm.software/open-component-model/bindings/go/oci/credentials"
 	"ocm.software/open-component-model/bindings/go/oci/repository/provider"
 	ocires "ocm.software/open-component-model/bindings/go/oci/repository/resource"
-	ocicredspec "ocm.software/open-component-model/bindings/go/oci/spec/credentials"
 	v1 "ocm.software/open-component-model/bindings/go/oci/spec/identity/v1"
 	ocirepository "ocm.software/open-component-model/bindings/go/oci/spec/repository"
 	"ocm.software/open-component-model/bindings/go/oci/transformer"
 	"ocm.software/open-component-model/bindings/go/plugin/manager"
 	"ocm.software/open-component-model/bindings/go/rsa/signing/handler"
 	signingv1alpha1 "ocm.software/open-component-model/bindings/go/rsa/signing/v1alpha1"
-	rsacredspec "ocm.software/open-component-model/bindings/go/rsa/spec/credentials"
 	ocmruntime "ocm.software/open-component-model/bindings/go/runtime"
 	"ocm.software/open-component-model/kubernetes/controller/api/v1alpha1"
 	"ocm.software/open-component-model/kubernetes/controller/internal/controller/component"
@@ -232,7 +229,10 @@ func main() {
 		setupLog.Error(err, "failed to register internal signing plugin")
 		os.Exit(1)
 	}
-	pm.CredentialRepositoryRegistry.Register(rsacredspec.Scheme)
+	if err := pm.CredentialTypeRegistry.RegisterInternalCredentialTypeSchemeProvider(signingHandler); err != nil {
+		setupLog.Error(err, "failed to register RSA credential types")
+		os.Exit(1)
+	}
 
 	if err := pm.CredentialRepositoryRegistry.RegisterInternalCredentialRepositoryPlugin(
 		&ocicredentials.OCICredentialRepository{},
@@ -241,11 +241,13 @@ func main() {
 		setupLog.Error(err, "failed to register internal credential repository plugin")
 		os.Exit(1)
 	}
-	pm.CredentialRepositoryRegistry.Register(ocicredspec.Scheme)
-
 	ociResourceRepoPlugin := ocires.NewResourceRepository(&filesystemv1alpha1.Config{}, ocires.WithUserAgent(creator))
 	if err := pm.ResourcePluginRegistry.RegisterInternalResourcePlugin(ociResourceRepoPlugin); err != nil {
 		setupLog.Error(err, "failed to register internal resource repository plugin")
+		os.Exit(1)
+	}
+	if err := pm.CredentialTypeRegistry.RegisterInternalCredentialTypeSchemeProvider(ociResourceRepoPlugin); err != nil {
+		setupLog.Error(err, "failed to register OCI credential types")
 		os.Exit(1)
 	}
 
@@ -254,11 +256,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := pm.DigestProcessorRegistry.RegisterInternalDigestProcessorPlugin(helmdigest.NewDigestProcessor("")); err != nil {
+	helmDigestProcessor := helmdigest.NewDigestProcessor("")
+	if err := pm.DigestProcessorRegistry.RegisterInternalDigestProcessorPlugin(helmDigestProcessor); err != nil {
 		setupLog.Error(err, "failed to register helm digest processor plugin")
 		os.Exit(1)
 	}
-	pm.CredentialRepositoryRegistry.Register(helmcredspec.Scheme)
+	if err := pm.CredentialTypeRegistry.RegisterInternalCredentialTypeSchemeProvider(helmDigestProcessor); err != nil {
+		setupLog.Error(err, "failed to register helm credential types")
+		os.Exit(1)
+	}
 
 	logHandler := logr.ToSlogHandler(setupLog)
 	ociBlobTransformerPlugin := transformer.New(slog.New(logHandler))

--- a/kubernetes/controller/internal/setup/credentials.go
+++ b/kubernetes/controller/internal/setup/credentials.go
@@ -43,7 +43,7 @@ func NewCredentialGraph(ctx context.Context, config *genericv1.Config, opts Cred
 			},
 		),
 		CredentialRepositoryTypeScheme: opts.PluginManager.CredentialRepositoryRegistry.RepositoryScheme(),
-		CredentialTypeSchemeProvider:   opts.PluginManager.CredentialRepositoryRegistry,
+		CredentialTypeSchemeProvider:   opts.PluginManager.CredentialTypeRegistry,
 	}
 
 	graph, err := credentials.ToGraph(ctx, credCfg, credOpts)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Refactors the way we can register custom credential types in ocm.
Before this change the cli and controller had to manually access `scheme` and add it to its credential type registry.
Now we inverse the call chain and expect the implementation of `credentials.CredentialTypeSchemeProvider` through the `BuiltinCredentialTypeSchemeProviderPlugin` for built-in bindings/types-

For external plugins, use `credentialpluginv1.CapabilitySpec`'s `CustomCredentialTypes` field, which is being consumes by the same registry.

#### Which issue(s) this PR fixes
Contributes: https://github.com/open-component-model/ocm-project/issues/1146

Followup of  https://github.com/open-component-model/open-component-model/pull/3398

#### Testing

##### How to test the changes

All the existing tests execute as is. I added new tests to test the new registry and credential conflict handling.

##### Verification

- [x] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [x] Tests pass locally (`task test` and `task test/integration` if applicable)
- [x] If touching multiple modules, `go work` is enabled (see `go.work`)
- [x] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
