### PR TITLE
fix: Thread http config through to resource repository [1/2]

### DIFF
--- a/bindings/go/oci/repository/resource/resource_repository.go
+++ b/bindings/go/oci/repository/resource/resource_repository.go
@@ -3,13 +3,15 @@ package resource
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"oras.land/oras-go/v2/registry/remote/auth"
-	"oras.land/oras-go/v2/registry/remote/retry"
 
 	"ocm.software/open-component-model/bindings/go/blob"
 	filesystemv1alpha1 "ocm.software/open-component-model/bindings/go/configuration/filesystem/v1alpha1/spec"
 	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+	ocmhttp "ocm.software/open-component-model/bindings/go/http"
+	httpv1alpha1 "ocm.software/open-component-model/bindings/go/http/spec/config/v1alpha1"
 	"ocm.software/open-component-model/bindings/go/oci"
 	ocicredentials "ocm.software/open-component-model/bindings/go/oci/credentials"
 	"ocm.software/open-component-model/bindings/go/oci/looseref"
@@ -30,6 +32,13 @@ type Options struct {
 	// UserAgent is the User-Agent string to be used in HTTP requests by all the
 	// repositories provided by the provider.
 	UserAgent string
+
+	// HTTPConfig is the HTTP client configuration (timeouts, per-host overrides)
+	// used to build the repositories's internal HTTP client. When nil, default
+	// transport timeouts and retry behaviour are used.
+	// Accepts the serialisable config type so that external plugins can
+	// round-trip it over the wire and reconstruct an equivalent client.
+	HTTPConfig *httpv1alpha1.Config
 }
 
 type Option func(*Options)
@@ -41,9 +50,20 @@ func WithUserAgent(userAgent string) Option {
 	}
 }
 
+// WithHTTPConfig sets the HTTP client configuration used for OCI registry
+// traffic. The repository builds its internal client from cfg on construction,
+// applying timeouts and per-host overrides.
+// When nil, the default ocmhttp transport timeouts and retry behaviour are used.
+func WithHTTPConfig(cfg *httpv1alpha1.Config) Option {
+	return func(o *Options) {
+		o.HTTPConfig = cfg
+	}
+}
+
 type ResourceRepository struct {
 	filesystemConfig *filesystemv1alpha1.Config
 	userAgent        string
+	httpClient       *http.Client
 }
 
 // make sure that ResourceRepository implements the oci ResourceRepository interface
@@ -65,6 +85,10 @@ func NewResourceRepository(filesystemConfig *filesystemv1alpha1.Config, opts ...
 	return &ResourceRepository{
 		filesystemConfig: filesystemConfig,
 		userAgent:        options.UserAgent,
+		httpClient: ocmhttp.New(
+			ocmhttp.WithConfig(options.HTTPConfig),
+			ocmhttp.WithUserAgent(options.UserAgent),
+		),
 	}
 }
 
@@ -188,7 +212,7 @@ func (p *ResourceRepository) UploadResource(ctx context.Context, resource *descr
 }
 
 func (p *ResourceRepository) getRepository(spec *ociv1.Repository, credentials *ocicredsv1.OCICredentials) (*oci.Repository, error) {
-	repo, err := createRepository(spec, credentials, p.filesystemConfig, p.userAgent)
+	repo, err := createRepository(spec, credentials, p.filesystemConfig, p.userAgent, p.httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("error creating repository: %w", err)
 	}
@@ -210,6 +234,7 @@ func createRepository(
 	credentials *ocicredsv1.OCICredentials,
 	filesystemConfig *filesystemv1alpha1.Config,
 	userAgent string,
+	httpClient *http.Client,
 ) (*oci.Repository, error) {
 	url, err := runtime.ParseURLAndAllowNoScheme(spec.BaseUrl)
 	if err != nil {
@@ -220,7 +245,7 @@ func createRepository(
 	urlResolver, err := urlresolver.New(
 		urlresolver.WithBaseURL(urlString),
 		urlresolver.WithBaseClient(&auth.Client{
-			Client: retry.DefaultClient,
+			Client: httpClient,
 			Header: map[string][]string{
 				"User-Agent": {userAgent},
 			},

--- a/bindings/go/oci/repository/resource/resource_repository_test.go
+++ b/bindings/go/oci/repository/resource/resource_repository_test.go
@@ -1,12 +1,16 @@
 package resource
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	filesystemv1alpha1 "ocm.software/open-component-model/bindings/go/configuration/filesystem/v1alpha1/spec"
 	descriptor "ocm.software/open-component-model/bindings/go/descriptor/runtime"
+	httpv1alpha1 "ocm.software/open-component-model/bindings/go/http/spec/config/v1alpha1"
 	ociaccess "ocm.software/open-component-model/bindings/go/oci/spec/access"
 	v1 "ocm.software/open-component-model/bindings/go/oci/spec/access/v1"
 	ocicredsv1 "ocm.software/open-component-model/bindings/go/oci/spec/credentials/v1"
@@ -99,7 +103,7 @@ func TestCreateRepositoryWithFilesystemConfig(t *testing.T) {
 			}
 			credentials := ocicredsv1.OCICredentials{}
 
-			repo, err := createRepository(spec, &credentials, tt.filesystemConfig, "test")
+			repo, err := createRepository(spec, &credentials, tt.filesystemConfig, "test", http.DefaultClient)
 
 			if tt.expectError {
 				r.Error(err, "expected error")
@@ -108,6 +112,76 @@ func TestCreateRepositoryWithFilesystemConfig(t *testing.T) {
 				r.NoError(err, "should not error")
 				r.NotNil(repo, "repository should not be nil")
 			}
+		})
+	}
+}
+
+func TestNewResourceRepositoryHTTPConfig_InsecureSkipVerify(t *testing.T) {
+	var serverHit bool
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serverHit = true
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	host := strings.TrimPrefix(server.URL, "https://")
+	tr := true
+
+	tests := []struct {
+		name                 string
+		httpConfig           *httpv1alpha1.Config
+		expectHit            bool
+		expectErrMsgContains string
+	}{
+		{
+			name:                 "without config the self-signed cert is rejected",
+			expectErrMsgContains: "certificate",
+		},
+		{
+			name: "per-host insecureSkipVerify reaches the registry",
+			httpConfig: &httpv1alpha1.Config{
+				Hosts: map[string]*httpv1alpha1.HostConfig{
+					host: {
+						TLSConfig: httpv1alpha1.TLSConfig{
+							InsecureSkipVerify: &tr,
+						},
+					},
+				},
+			},
+			expectHit: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			serverHit = false
+
+			raw := &runtime.Raw{}
+			require.NoError(t, ociaccess.Scheme.Convert(
+				&v1.OCIImage{
+					Type:           runtime.NewVersionedType(v1.OCIImageType, v1.Version),
+					ImageReference: "https://" + host + "/test/img:v1.0.0",
+				},
+				raw,
+			))
+
+			res := &descriptor.Resource{
+				Type:   "ociArtifact",
+				Access: raw,
+				ElementMeta: descriptor.ElementMeta{
+					ObjectMeta: descriptor.ObjectMeta{
+						Name:    "test",
+						Version: "1.0.0",
+					},
+				},
+			}
+
+			repo := NewResourceRepository(nil, WithHTTPConfig(tt.httpConfig))
+			_, err := repo.DownloadResource(t.Context(), res, nil)
+			if tt.expectErrMsgContains != "" {
+				require.ErrorContains(t, err, tt.expectErrMsgContains)
+			}
+			require.Equal(t, tt.expectHit, serverHit, "expected HTTP request to reach test server")
 		})
 	}
 }

--- a/bindings/go/transfer/builder.go
+++ b/bindings/go/transfer/builder.go
@@ -2,10 +2,33 @@ package transfer
 
 import (
 	"ocm.software/open-component-model/bindings/go/credentials"
+	httpv1alpha1 "ocm.software/open-component-model/bindings/go/http/spec/config/v1alpha1"
 	"ocm.software/open-component-model/bindings/go/repository"
 	"ocm.software/open-component-model/bindings/go/transfer/internal"
 	"ocm.software/open-component-model/bindings/go/transform/graph/builder"
 )
+
+// Options holds configuration options for the default transformation builder.
+type Options struct {
+	// HTTPConfig is the HTTP client configuration (timeouts, per-host overrides)
+	// used to build the repositories's internal HTTP client. When nil, default
+	// transport timeouts and oras-go's retry behaviour are used.
+	// Accepts the serialisable config type so that external plugins can
+	// round-trip it over the wire and reconstruct an equivalent client.
+	HTTPConfig *httpv1alpha1.Config
+}
+
+type Option func(*Options)
+
+// WithHTTPConfig sets the HTTP client configuration used for OCI registry
+// traffic. The repository builds its internal client from cfg on construction,
+// applying timeouts and per-host overrides. When nil, default transport
+// timeouts and oras-go's retry behaviour are used.
+func WithHTTPConfig(cfg *httpv1alpha1.Config) Option {
+	return func(o *Options) {
+		o.HTTPConfig = cfg
+	}
+}
 
 // NewDefaultBuilder creates a builder.Builder pre-configured with all standard OCI, CTF, and Helm transformers.
 // It accepts the repository provider, resource repository, and credential resolver interfaces
@@ -14,6 +37,17 @@ func NewDefaultBuilder(
 	repoProvider repository.ComponentVersionRepositoryProvider,
 	resourceRepo repository.ResourceRepository,
 	credentialProvider credentials.Resolver,
+	opts ...Option,
 ) *builder.Builder {
-	return internal.NewDefaultBuilder(repoProvider, resourceRepo, credentialProvider)
+	options := &Options{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	return internal.NewDefaultBuilder(
+		repoProvider,
+		resourceRepo,
+		credentialProvider,
+		options.HTTPConfig,
+	)
 }

--- a/bindings/go/transfer/internal/builder.go
+++ b/bindings/go/transfer/internal/builder.go
@@ -7,6 +7,7 @@ import (
 	githubv1alpha1 "ocm.software/open-component-model/bindings/go/github/transformation/spec/v1alpha1"
 	helmtransformer "ocm.software/open-component-model/bindings/go/helm/transformation"
 	helmv1alpha1 "ocm.software/open-component-model/bindings/go/helm/transformation/spec/v1alpha1"
+	httpv1alpha1 "ocm.software/open-component-model/bindings/go/http/spec/config/v1alpha1"
 	"ocm.software/open-component-model/bindings/go/oci/repository/resource"
 	ociaccess "ocm.software/open-component-model/bindings/go/oci/spec/access"
 	ociv1alpha1 "ocm.software/open-component-model/bindings/go/oci/spec/transformation/v1alpha1"
@@ -26,6 +27,7 @@ func NewDefaultBuilder(
 	repoProvider repository.ComponentVersionRepositoryProvider,
 	resourceRepo repository.ResourceRepository,
 	credentialProvider credentials.Resolver,
+	httpConfig *httpv1alpha1.Config,
 ) *builder.Builder {
 	transformerScheme := runtime.NewScheme()
 	transformerScheme.MustRegisterScheme(ociv1alpha1.Scheme)
@@ -85,7 +87,10 @@ func NewDefaultBuilder(
 		// from the CLI or upstream.
 		//
 		// Filesystem config can be empty here because a streaming transfer does not need working dir or temp dir.
-		Repository:         resource.NewResourceRepository(&filesystemv1alpha1.Config{}),
+		Repository: resource.NewResourceRepository(
+			&filesystemv1alpha1.Config{},
+			resource.WithHTTPConfig(httpConfig),
+		),
 		CredentialProvider: credentialProvider,
 	}
 

--- a/bindings/go/transfer/internal/builder_test.go
+++ b/bindings/go/transfer/internal/builder_test.go
@@ -25,7 +25,7 @@ type stubCredResolver struct {
 }
 
 func TestNewBuilder(t *testing.T) {
-	b := NewDefaultBuilder(&stubRepoProvider{}, &stubResourceRepo{}, &stubCredResolver{})
+	b := NewDefaultBuilder(&stubRepoProvider{}, &stubResourceRepo{}, &stubCredResolver{}, nil)
 	assert.NotNil(t, b)
 }
 
@@ -45,6 +45,6 @@ func TestNewDefaultBuilder_CanBuildGitHubGraph(t *testing.T) {
 
 	// BuildAndCheck resolves a transformer for every node type. Providers are only used at
 	// Process time, so nil is fine here.
-	_, err = NewDefaultBuilder(nil, nil, nil).BuildAndCheck(tgd)
+	_, err = NewDefaultBuilder(nil, nil, nil, nil).BuildAndCheck(tgd)
 	require.NoError(t, err, "default builder must resolve the GetGitHubCommit transformer")
 }

--- a/docs/dependency-table.md
+++ b/docs/dependency-table.md
@@ -21,4 +21,4 @@
 | 6 | `wget` | `blob`, `configuration`, `constructor`, `credentials`, `descriptor/runtime`, `descriptor/v2`, `http`, `repository`, `runtime` |
 | 7 | `github` | `blob`, `credentials`, `descriptor/runtime`, `descriptor/v2`, `http`, `plugin`, `repository`, `runtime` |
 | 7 | `helm` | `blob`, `configuration`, `constructor`, `credentials`, `descriptor/runtime`, `descriptor/v2`, `http`, `oci`, `plugin`, `repository`, `runtime` |
-| 8 | `transfer` | `blob`, `configuration`, `credentials`, `ctf`, `dag`, `descriptor/runtime`, `descriptor/v2`, `github`, `helm`, `oci`, `repository`, `runtime`, `signing`, `transform`, `wget` |
+| 8 | `transfer` | `blob`, `configuration`, `credentials`, `ctf`, `dag`, `descriptor/runtime`, `descriptor/v2`, `github`, `helm`, `http`, `oci`, `repository`, `runtime`, `signing`, `transform`, `wget` |

--- a/golangci.yml
+++ b/golangci.yml
@@ -465,6 +465,7 @@ linters:
             - "ocm.software/open-component-model/bindings/go/descriptor/v2"
             - "ocm.software/open-component-model/bindings/go/github"
             - "ocm.software/open-component-model/bindings/go/helm"
+            - "ocm.software/open-component-model/bindings/go/http"
             - "ocm.software/open-component-model/bindings/go/oci"
             - "ocm.software/open-component-model/bindings/go/repository"
             - "ocm.software/open-component-model/bindings/go/runtime"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

When localizing an OCM CV into an OCI registry with untrusted TLS but having `ignoreSkipVerify` enabled still fails:

```text
> ocm cv \
        --config ./ocm.yaml \
        --upload-as ociArtifact \
        ctf::./ctf//ocm.software/maestro-demo:1.4.1 \
        https://localhost:5000/ 
time=2026-08-18T17:06:38.553+02:00 level=WARN msg="HTTP transport built with InsecureSkipVerify=true; TLS certificate verification is disabled — connections are vulnerable to MITM attacks"
time=2026-08-18T17:06:38.553+02:00 level=WARN msg="HTTP transport built with InsecureSkipVerify=true; TLS certificate verification is disabled — connections are vulnerable to MITM attacks"
time=2026-08-18T17:06:38.553+02:00 level=WARN msg="HTTP transport built with InsecureSkipVerify=true; TLS certificate verification is disabled — connections are vulnerable to MITM attacks"
✓ Resolving component versions...
✗ Transferring component versions...
    ✓ transformOcmSoftwareMaestroDemo141GettransformResourceGraphDefinition141 [CTFGetLocalResource]
    ✗ transformOcmSoftwareMaestroDemo141TransfertransformHelmResource671 [TransferOCIArtifact]
    ⊘ transformOcmSoftwareMaestroDemo141TransfertransformImageResource671 [TransferOCIArtifact]

  [██████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░]  16% 1/6 (1 failed) (1 cancelled)

Errors:
  ✗ transformOcmSoftwareMaestroDemo141TransfertransformHelmResource671
│    ↳ failed to transform transformation "transformOcmSoftwareMaestroDemo141TransfertransformHelmResource671"
│      ↳ failed streaming OCI artifact name=helm-resource,version=6.7.1
│        ↳ error streaming resource upload
│          ↳ failed to stream resource via copy
│            ↳ failed to perform "Exists" on destination
│              ↳ Head "https://localhost:5000/v2/stefanprodan/charts/podinfo/manifests/sha256:592b72908a7377b4951c4aa49b5c7fc810ec46fa3599936abc1ec7a65f689333"
│                ↳ tls
│                  ↳ failed to verify certificate
│                    ↳ x509
│                      ↳ certificate signed by unknown authority
    ▶ Transformation "transformOcmSoftwareMaestroDemo141TransfertransformHelmResource671" of type TransferOCIArtifact/v1alpha1 failed.
      Spec data shown below for debugging.
    ┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
    │ {                                                                                                                                            │
    │   "resource": {                                                                                                                              │
    │     "access": {                                                                                                                              │
    │       "imageReference": "ghcr.io/stefanprodan/charts/podinfo:6.7.1@sha256:4d5bd3562f0b150bd6cdfdbfb149e7e4ac36e555e25baa1da9f511f4d9fb7391", │
    │       "type": "ociArtifact"                                                                                                                  │
    │     },                                                                                                                                       │
    │     "digest": {                                                                                                                              │
    │       "hashAlgorithm": "SHA-256",                                                                                                            │
    │       "normalisationAlgorithm": "genericBlobDigest/v1",                                                                                      │
    │       "value": "4d5bd3562f0b150bd6cdfdbfb149e7e4ac36e555e25baa1da9f511f4d9fb7391"                                                            │
    │     },                                                                                                                                       │
    │     "name": "helm-resource",                                                                                                                 │
    │     "relation": "external",                                                                                                                  │
    │     "type": "helmChart",                                                                                                                     │
    │     "version": "6.7.1"                                                                                                                       │
    │   },                                                                                                                                         │
    │   "targetResource": {                                                                                                                        │
    │     "access": {                                                                                                                              │
    │       "imageReference": "https://localhost:5000/stefanprodan/charts/podinfo:6.7.1",                                                          │
    │       "type": "ociArtifact/v1"                                                                                                               │
    │     },                                                                                                                                       │
    │     "digest": {                                                                                                                              │
    │       "hashAlgorithm": "SHA-256",                                                                                                            │
    │       "normalisationAlgorithm": "genericBlobDigest/v1",                                                                                      │
    │       "value": "4d5bd3562f0b150bd6cdfdbfb149e7e4ac36e555e25baa1da9f511f4d9fb7391"                                                            │
    │     },                                                                                                                                       │
    │     "name": "helm-resource",                                                                                                                 │
    │     "relation": "external",                                                                                                                  │
    │     "type": "helmChart",                                                                                                                     │
    │     "version": "6.7.1"                                                                                                                       │
    │   }                                                                                                                                          │
    │ }                                                                                                                                            │
    └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

Error: graph execution failed: failed to process value for node transformOcmSoftwareMaestroDemo141TransfertransformHelmResource671 in graph: failed to transform transformation "transformOcmSoftwareMaestroDemo141TransfertransformHelmResource671": failed streaming OCI artifact name=helm-resource,version=6.7.1: error streaming resource upload: failed to stream resource via copy: failed to perform "Exists" on destination: Head "https://localhost:5000/v2/stefanprodan/charts/podinfo/manifests/sha256:592b72908a7377b4951c4aa49b5c7fc810ec46fa3599936abc1ec7a65f689333": tls: failed to verify certificate: x509: certificate signed by unknown authority
exit status 1
```

I largely followed what the provider does to thread the http config through: 
https://github.com/open-component-model/open-component-model/blob/cc1debdf10158a754655744c17575bb9d3693184/bindings/go/oci/repository/provider/provider.go#L54-L55

This will change the default client from oras' default client to the ocmhttp client, also like the provider.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Testing

##### How to test the changes

Deploy an oci registry:

```sh
mkdir -p certs
openssl req -x509 -newkey rsa:4096 -sha256 -days 365 -nodes \
        -keyout "certs/domain.key" \
        -out "certs/domain.crt" \
        -subj '/CN=localhost' \
        -addext 'subjectAltName=DNS:localhost,IP:127.0.0.1' 

docker run -d --name "registry" -p "5000:5000" \
        -v "./certs:/certs:ro" \
        -e REGISTRY_HTTP_ADDR=0.0.0.0:5000 \
        -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
        -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
        "registry:3"
```

.ocmconfig
```yaml
type: generic.config.ocm.software/v1
configurations:
  - type: http.config.ocm.software/v1alpha1
    hosts:
      "localhost:5000":
        insecureSkipVerify: true
```

Commands that test the change:

```bash
ocm transfer cv \
        --config ./ocm.yaml \
        --copy-resources \
        --recursive \
        --upload-as ociArtifact \
        ctf::./ctf//ocm.software/maestro-demo:1.4.1 \
        https://localhost:5000/ 
```

##### Verification

- [x] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [x] Tests pass locally (`task test` and `task test/integration` if applicable)
- [x] If touching multiple modules, `go work` is enabled (see `go.work`)
- [ ] My changes do not decrease test coverage
- [x] I have tested the changes locally by running `ocm`
