### PR TITLE
chore: add dependency check to completion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: |
+            Taskfile.yml
+            tools.Taskfile.yml
             golangci.yml
             docs/dependency-table.md
             .github/scripts/dependency-table.js
@@ -274,10 +276,14 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
-      - run: npm ci --prefix .github/scripts
+      - name: Install Task
+        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify dependency table is in sync
         run: |
-          node .github/scripts/dependency-table.js generate | diff - docs/dependency-table.md || {
+          task tools:dependency-table/verify || {
             echo "::error::docs/dependency-table.md is out of sync. Run 'task tools:dependency-table/generate' and commit the result."
             exit 1
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,6 +458,7 @@ jobs:
       - run_integration_tests
       - run_sigstore_integration
       - golangci_lint
+      - dependency_table_verify
     if: ${{ failure() }}
     steps:
       - name: Some CI step failed or was cancelled!

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,7 +275,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: 24
+          node-version: 26
       - name: Install Task
         uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
         with:

--- a/tools.Taskfile.yml
+++ b/tools.Taskfile.yml
@@ -115,9 +115,19 @@ tasks:
 
   dependency-table/generate:
     desc: "Regenerate docs/dependency-table.md from golangci.yml depguard rules"
+    deps: [dependency-table/install]
     cmd: node {{ .ROOT_DIR }}/.github/scripts/dependency-table.js generate > {{ .ROOT_DIR }}/docs/dependency-table.md
 
   dependency-table/verify:
     desc: "Verify docs/dependency-table.md is in sync with golangci.yml depguard rules"
+    deps: [dependency-table/install]
     cmd: |
       node {{ .ROOT_DIR }}/.github/scripts/dependency-table.js generate | diff - {{ .ROOT_DIR }}/docs/dependency-table.md
+
+  dependency-table/install:
+    internal: true
+    dir: '{{ .ROOT_DIR }}/.github/scripts'
+    sources:
+      - package.json
+      - package-lock.json
+    cmd: npm ci --omit=dev


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

https://github.com/open-component-model/open-component-model/pull/3286 introduced the workflow step `dependency_table_verify` to make sure the dependency table is updated if any dependency changes. However, this step is not required yet. We cannot add the step as required as the step is only executed when `${{ needs.discover_modules.outputs.dependency_table_changed == 'true' }}`.

