### PR TITLE
chore: Add `eslint` rules for `braces`, `indent`, and  `curly`

### DIFF
--- a/website/assets/js/custom.js
+++ b/website/assets/js/custom.js
@@ -37,7 +37,7 @@ document.addEventListener('click', (e) => {
     // If already on this page, let the native <summary> toggle through
     // by NOT calling preventDefault — just stop the link from navigating.
     const onSamePage =
-    link.getAttribute('aria-current') === 'page' ||
+        link.getAttribute('aria-current') === 'page' ||
     new URL(link.href, location.href).pathname === location.pathname;
 
     if (onSamePage) {

--- a/website/assets/js/custom.js
+++ b/website/assets/js/custom.js
@@ -16,40 +16,48 @@ import 'bootstrap/js/src/offcanvas.js';
 // during navigation.
 
 document.addEventListener('click', (e) => {
-  const link = e.target.closest('.section-nav details > summary a.docs-link');
-  if (!link) return;
+    const link = e.target.closest('.section-nav details > summary a.docs-link');
+    if (!link) {
+        return;
+    }
 
-  // Let the browser handle modifier-clicks (new tab, new window, etc.)
-  if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
-  if (link.target && link.target !== '_self') return;
-  if (link.hasAttribute('download')) return;
+    // Let the browser handle modifier-clicks (new tab, new window, etc.)
+    if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+        return;
+    }
+    if (link.target && link.target !== '_self') {
+        return;
+    }
+    if (link.hasAttribute('download')) {
+        return;
+    }
 
-  const details = link.closest('details');
+    const details = link.closest('details');
 
-  // If already on this page, let the native <summary> toggle through
-  // by NOT calling preventDefault — just stop the link from navigating.
-  const onSamePage =
+    // If already on this page, let the native <summary> toggle through
+    // by NOT calling preventDefault — just stop the link from navigating.
+    const onSamePage =
     link.getAttribute('aria-current') === 'page' ||
     new URL(link.href, location.href).pathname === location.pathname;
 
-  if (onSamePage) {
+    if (onSamePage) {
     // Don't navigate, but allow the native <details> toggle to happen.
     // We only need to prevent the <a> default (navigation).
     // Since we're in capture phase, preventDefault here stops BOTH the
     // link navigation AND the summary toggle. So instead, we toggle manually.
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        if (details) {
+            details.open = !details.open;
+        }
+        return;
+    }
+
+    // Navigating to a different page: prevent both toggle and link default,
+    // then navigate programmatically.
     e.preventDefault();
     e.stopImmediatePropagation();
-    if (details) {
-      details.open = !details.open;
-    }
-    return;
-  }
-
-  // Navigating to a different page: prevent both toggle and link default,
-  // then navigate programmatically.
-  e.preventDefault();
-  e.stopImmediatePropagation();
-  window.location.href = link.href;
+    window.location.href = link.href;
 }, true); // <-- capture phase
 
 // Deep links into tab panes: anchors inside a non-active Bootstrap tab pane
@@ -58,36 +66,42 @@ document.addEventListener('click', (e) => {
 // ancestor tab pane of the target, then scroll to it. Works stateless on a
 // first visit: the URL fragment is the only input.
 function revealHashTarget() {
-  let id;
-  try {
-    id = decodeURIComponent(window.location.hash.slice(1));
-  } catch {
-    return;
-  }
-  if (!id) return;
-  const target = document.getElementById(id);
-  if (!target) return;
-
-  let shown = false;
-  // closest() includes the target itself, so linking to a pane id
-  // (e.g. #tabs-mygroup-1) activates that tab as well.
-  for (let pane = target.closest('.tab-pane'); pane; pane = pane.parentElement?.closest('.tab-pane')) {
-    if (pane.classList.contains('active') || !pane.id) continue;
-    const trigger = document.querySelector(`[data-bs-target="#${CSS.escape(pane.id)}"]`);
-    if (trigger) {
-      Tab.getOrCreateInstance(trigger).show();
-      shown = true;
+    let id;
+    try {
+        id = decodeURIComponent(window.location.hash.slice(1));
+    } catch {
+        return;
     }
-  }
-  if (shown) {
+    if (!id) {
+        return;
+    }
+    const target = document.getElementById(id);
+    if (!target) {
+        return;
+    }
+
+    let shown = false;
+    // closest() includes the target itself, so linking to a pane id
+    // (e.g. #tabs-mygroup-1) activates that tab as well.
+    for (let pane = target.closest('.tab-pane'); pane; pane = pane.parentElement?.closest('.tab-pane')) {
+        if (pane.classList.contains('active') || !pane.id) {
+            continue;
+        }
+        const trigger = document.querySelector(`[data-bs-target="#${CSS.escape(pane.id)}"]`);
+        if (trigger) {
+            Tab.getOrCreateInstance(trigger).show();
+            shown = true;
+        }
+    }
+    if (shown) {
     // Wait a frame so the pane is rendered (display:block) before scrolling.
-    requestAnimationFrame(() => target.scrollIntoView());
-  }
+        requestAnimationFrame(() => target.scrollIntoView());
+    }
 }
 
 window.addEventListener('hashchange', revealHashTarget);
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', revealHashTarget);
+    document.addEventListener('DOMContentLoaded', revealHashTarget);
 } else {
-  revealHashTarget();
+    revealHashTarget();
 }

--- a/website/assets/js/mermaid-init.js
+++ b/website/assets/js/mermaid-init.js
@@ -18,7 +18,7 @@ import mermaid from 'mermaid';
 // the message differs so systemic failures are not mistaken for one bad diagram.
 const logMermaidError = (prefix) => (err) => {
     const isSyntax =
-    err?.name === 'UnknownDiagramError' ||
+        err?.name === 'UnknownDiagramError' ||
     err?.message?.includes('No diagram type detected') ||
     err?.message?.includes('Parse error');
     if (isSyntax) {

--- a/website/assets/js/mermaid-init.js
+++ b/website/assets/js/mermaid-init.js
@@ -17,15 +17,15 @@ import mermaid from 'mermaid';
 // land in console.error so a single broken diagram doesn't break the page, but
 // the message differs so systemic failures are not mistaken for one bad diagram.
 const logMermaidError = (prefix) => (err) => {
-  const isSyntax =
+    const isSyntax =
     err?.name === 'UnknownDiagramError' ||
     err?.message?.includes('No diagram type detected') ||
     err?.message?.includes('Parse error');
-  if (isSyntax) {
-    console.error(`${prefix} (diagram syntax):`, err);
-  } else {
-    console.error(`${prefix} (unexpected — check initialization):`, err);
-  }
+    if (isSyntax) {
+        console.error(`${prefix} (diagram syntax):`, err);
+    } else {
+        console.error(`${prefix} (unexpected — check initialization):`, err);
+    }
 };
 
 // Why not `startOnLoad: true`:
@@ -35,75 +35,83 @@ const logMermaidError = (prefix) => (err) => {
 //   .mermaid blocks as raw text. Drive run() ourselves and gate on
 //   document.readyState instead.
 const start = () => {
-  const elements = Array.from(document.querySelectorAll('.mermaid'));
-  if (!elements.length) return;
+    const elements = Array.from(document.querySelectorAll('.mermaid'));
+    if (!elements.length) {
+        return;
+    }
 
-  // Cache the diagram source on each element BEFORE the first render, so a
-  // subsequent theme-change re-render can restore the pre-SVG text. Once
-  // mermaid processes an element, its textContent becomes the rendered SVG
-  // and the original source is lost.
-  elements.forEach((el) => {
-    el.setAttribute('data-mermaid-source', el.textContent);
-  });
-
-  const getTheme = () => {
-    const t = document.documentElement.getAttribute('data-bs-theme');
-    if (t === 'dark') return 'dark';
-    if (t === 'light') return 'default';
-    // "auto" - fall back to the OS-level preference so the initial render
-    // matches what doks-core's theme toggle would resolve to.
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'default';
-  };
-
-  const rerender = () => {
-    document.querySelectorAll('.mermaid').forEach((el) => {
-      const src = el.getAttribute('data-mermaid-source');
-      if (src) {
-        // Undo mermaid's "already rendered" guard and restore the source so
-        // mermaid.run() picks the element up again with the new theme.
-        el.removeAttribute('data-processed');
-        el.textContent = src;
-      }
+    // Cache the diagram source on each element BEFORE the first render, so a
+    // subsequent theme-change re-render can restore the pre-SVG text. Once
+    // mermaid processes an element, its textContent becomes the rendered SVG
+    // and the original source is lost.
+    elements.forEach((el) => {
+        el.setAttribute('data-mermaid-source', el.textContent);
     });
-    mermaid.initialize({ theme: getTheme() });
-    // mermaid.run() rejects on invalid diagram syntax; swallow the rejection
-    // to a console.error so a single bad diagram doesn't surface as an
-    // unhandled promise rejection on the page.
-    mermaid.run().catch(logMermaidError('mermaid re-render failed'));
-  };
 
-  mermaid.initialize({ startOnLoad: false, theme: getTheme() });
-  mermaid.run().catch(logMermaidError('mermaid render failed'));
+    const getTheme = () => {
+        const t = document.documentElement.getAttribute('data-bs-theme');
+        if (t === 'dark') {
+            return 'dark';
+        }
+        if (t === 'light') {
+            return 'default';
+        }
+        // "auto" - fall back to the OS-level preference so the initial render
+        // matches what doks-core's theme toggle would resolve to.
+        return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'default';
+    };
 
-  // doks-core's setTheme() writes data-bs-theme AND dispatches 'themeChanged'
-  // for every toggle, so a naive listener + observer pair re-renders twice
-  // per switch. Coalesce both signals through a single requestAnimationFrame
-  // handle - keeping both sources still catches third-party toggles that
-  // bypass one path or the other (belt-and-suspenders), but only one render
-  // happens per frame.
-  let scheduled = 0;
-  const scheduleRerender = () => {
-    if (scheduled) return;
-    scheduled = requestAnimationFrame(() => {
-      scheduled = 0;
-      rerender();
+    const rerender = () => {
+        document.querySelectorAll('.mermaid').forEach((el) => {
+            const src = el.getAttribute('data-mermaid-source');
+            if (src) {
+                // Undo mermaid's "already rendered" guard and restore the source so
+                // mermaid.run() picks the element up again with the new theme.
+                el.removeAttribute('data-processed');
+                el.textContent = src;
+            }
+        });
+        mermaid.initialize({ theme: getTheme() });
+        // mermaid.run() rejects on invalid diagram syntax; swallow the rejection
+        // to a console.error so a single bad diagram doesn't surface as an
+        // unhandled promise rejection on the page.
+        mermaid.run().catch(logMermaidError('mermaid re-render failed'));
+    };
+
+    mermaid.initialize({ startOnLoad: false, theme: getTheme() });
+    mermaid.run().catch(logMermaidError('mermaid render failed'));
+
+    // doks-core's setTheme() writes data-bs-theme AND dispatches 'themeChanged'
+    // for every toggle, so a naive listener + observer pair re-renders twice
+    // per switch. Coalesce both signals through a single requestAnimationFrame
+    // handle - keeping both sources still catches third-party toggles that
+    // bypass one path or the other (belt-and-suspenders), but only one render
+    // happens per frame.
+    let scheduled = 0;
+    const scheduleRerender = () => {
+        if (scheduled) {
+            return;
+        }
+        scheduled = requestAnimationFrame(() => {
+            scheduled = 0;
+            rerender();
+        });
+    };
+
+    document.addEventListener('themeChanged', scheduleRerender);
+
+    // attributeFilter narrows the observation to the one attribute we care
+    // about, so the callback isn't woken for unrelated <html> attribute writes
+    // (lang, class, ...) and no per-record scan is needed.
+    const observer = new MutationObserver(scheduleRerender);
+    observer.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ['data-bs-theme'],
     });
-  };
-
-  document.addEventListener('themeChanged', scheduleRerender);
-
-  // attributeFilter narrows the observation to the one attribute we care
-  // about, so the callback isn't woken for unrelated <html> attribute writes
-  // (lang, class, ...) and no per-record scan is needed.
-  const observer = new MutationObserver(scheduleRerender);
-  observer.observe(document.documentElement, {
-    attributes: true,
-    attributeFilter: ['data-bs-theme'],
-  });
 };
 
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', start, { once: true });
+    document.addEventListener('DOMContentLoaded', start, { once: true });
 } else {
-  start();
+    start();
 }

--- a/website/assets/js/schema/crd-yaml-converter.test.ts
+++ b/website/assets/js/schema/crd-yaml-converter.test.ts
@@ -23,7 +23,7 @@ function crd(kind: string, group: string, versions: Array<{name: string; served?
         openAPIV3Schema:
           type: object
           properties:${Object.entries(v.props || { spec: "object" }).map(
-        ([k, t]) => `\n            ${k}:\n              type: ${t}`).join("")}`).join("");
+                ([k, t]) => `\n            ${k}:\n              type: ${t}`).join("")}`).join("");
 
     return `apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/website/assets/js/schema/crd-yaml-converter.test.ts
+++ b/website/assets/js/schema/crd-yaml-converter.test.ts
@@ -8,14 +8,14 @@ const CRD_YAML_URL = "https://raw.githubusercontent.com/open-component-model/ope
 let crdModels: ReturnType<typeof crdYamlToModels>;
 
 before(async () => {
-  const resp = await fetch(CRD_YAML_URL);
-  assert.ok(resp.ok, `Failed to fetch CRD YAML: ${resp.status}`);
-  crdModels = crdYamlToModels(await resp.text());
+    const resp = await fetch(CRD_YAML_URL);
+    assert.ok(resp.ok, `Failed to fetch CRD YAML: ${resp.status}`);
+    crdModels = crdYamlToModels(await resp.text());
 });
 
 /** Build a minimal CRD YAML string. */
 function crd(kind: string, group: string, versions: Array<{name: string; served?: boolean; storage?: boolean; props?: Record<string, string>}>) {
-  const versionEntries = versions.map((v) => `
+    const versionEntries = versions.map((v) => `
     - name: ${v.name}
       served: ${v.served ?? true}
       storage: ${v.storage ?? true}
@@ -23,9 +23,9 @@ function crd(kind: string, group: string, versions: Array<{name: string; served?
         openAPIV3Schema:
           type: object
           properties:${Object.entries(v.props || { spec: "object" }).map(
-    ([k, t]) => `\n            ${k}:\n              type: ${t}`).join("")}`).join("");
+        ([k, t]) => `\n            ${k}:\n              type: ${t}`).join("")}`).join("");
 
-  return `apiVersion: apiextensions.k8s.io/v1
+    return `apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ${kind.toLowerCase()}s.${group}
@@ -38,71 +38,77 @@ spec:
 }
 
 describe("crdYamlToModels", () => {
-  it("real CRD: correct meta and fields", () => {
-    assert.ok(crdModels.length >= 1);
-    assert.equal(crdModels[0].meta.kind, "Component");
-    assert.ok(crdModels[0].meta.apiVersions[0].includes("delivery.ocm.software"));
-    assert.ok(crdModels[0].meta.description.length > 0);
-    assert.equal(crdModels[0].sections.length, 1);
-    assert.equal(crdModels[0].sections[0].title, "Schema");
+    it("real CRD: correct meta and fields", () => {
+        assert.ok(crdModels.length >= 1);
+        assert.equal(crdModels[0].meta.kind, "Component");
+        assert.ok(crdModels[0].meta.apiVersions[0].includes("delivery.ocm.software"));
+        assert.ok(crdModels[0].meta.description.length > 0);
+        assert.equal(crdModels[0].sections.length, 1);
+        assert.equal(crdModels[0].sections[0].title, "Schema");
 
-    const names = crdModels[0].sections[0].fields.map((f) => f.name);
-    for (const f of ["apiVersion", "kind", "metadata", "spec", "status"]) {
-      assert.ok(names.includes(f), `missing: ${f}`);
-    }
+        const names = crdModels[0].sections[0].fields.map((f) => f.name);
+        for (const f of ["apiVersion", "kind", "metadata", "spec", "status"]) {
+            assert.ok(names.includes(f), `missing: ${f}`);
+        }
 
-    const spec = crdModels[0].sections[0].fields.find((f) => f.name === "spec")!;
-    assert.ok(spec.properties!.length > 0);
-  });
+        const spec = crdModels[0].sections[0].fields.find((f) => f.name === "spec")!;
+        assert.ok(spec.properties!.length > 0);
+    });
 
-  it("fields conform to SchemaField shape", () => {
-    function check(field: SchemaField) {
-      for (const k of ["name", "type", "description"] as const) assert.equal(typeof field[k], "string");
-      for (const k of ["required", "immutable"] as const) assert.equal(typeof field[k], "boolean");
-      if (field.properties) field.properties.forEach(check);
-    }
-    crdModels[0].sections[0].fields.forEach(check);
-  });
+    it("fields conform to SchemaField shape", () => {
+        function check(field: SchemaField) {
+            for (const k of ["name", "type", "description"] as const) {
+                assert.equal(typeof field[k], "string");
+            }
+            for (const k of ["required", "immutable"] as const) {
+                assert.equal(typeof field[k], "boolean");
+            }
+            if (field.properties) {
+                field.properties.forEach(check);
+            }
+        }
+        crdModels[0].sections[0].fields.forEach(check);
+    });
 
-  it("multi-CRD documents", () => {
-    const yaml = [
-      crd("Foo", "example.com", [{ name: "v1", props: { spec: "object" } }]),
-      crd("Bar", "example.com", [{ name: "v1", props: { spec: "object" } }]),
-    ].join("---\n");
-    const models = crdYamlToModels(yaml);
-    assert.equal(models.length, 2);
-    assert.equal(models[0].meta.kind, "Foo");
-    assert.equal(models[1].meta.kind, "Bar");
-  });
+    it("multi-CRD documents", () => {
+        const yaml = [
+            crd("Foo", "example.com", [{ name: "v1", props: { spec: "object" } }]),
+            crd("Bar", "example.com", [{ name: "v1", props: { spec: "object" } }]),
+        ].join("---\n");
+        const models = crdYamlToModels(yaml);
+        assert.equal(models.length, 2);
+        assert.equal(models[0].meta.kind, "Foo");
+        assert.equal(models[1].meta.kind, "Bar");
+    });
 
-  it("multi-version CRDs", () => {
-    const yaml = crd("Widget", "example.com", [
-      { name: "v1alpha1", storage: false, props: { color: "string" } },
-      { name: "v1", props: { color: "string", size: "integer" } },
-    ]);
-    const models = crdYamlToModels(yaml);
-    assert.equal(models.length, 2);
-    assert.equal(models[0].meta.apiVersions[0], "example.com/v1alpha1");
-    assert.equal(models[1].meta.apiVersions[0], "example.com/v1");
-  });
+    it("multi-version CRDs", () => {
+        const yaml = crd("Widget", "example.com", [
+            { name: "v1alpha1", storage: false, props: { color: "string" } },
+            { name: "v1", props: { color: "string", size: "integer" } },
+        ]);
+        const models = crdYamlToModels(yaml);
+        assert.equal(models.length, 2);
+        assert.equal(models[0].meta.apiVersions[0], "example.com/v1alpha1");
+        assert.equal(models[1].meta.apiVersions[0], "example.com/v1");
+    });
 
-  it("skips non-served versions", () => {
-    const yaml = crd("Thing", "example.com", [
-      { name: "v1alpha1", served: false, storage: false },
-      { name: "v1" },
-    ]);
-    const models = crdYamlToModels(yaml);
-    assert.equal(models.length, 1);
-    assert.equal(models[0].meta.apiVersions[0], "example.com/v1");
-  });
+    it("skips non-served versions", () => {
+        const yaml = crd("Thing", "example.com", [
+            { name: "v1alpha1", served: false, storage: false },
+            { name: "v1" },
+        ]);
+        const models = crdYamlToModels(yaml);
+        assert.equal(models.length, 1);
+        assert.equal(models[0].meta.apiVersions[0], "example.com/v1");
+    });
 
-  it("returns empty for non-CRD YAML", () => {
-    assert.equal(crdYamlToModels("apiVersion: v1\nkind: ConfigMap\n").length, 0);
-  });
+    it("returns empty for non-CRD YAML", () => {
+        assert.equal(crdYamlToModels("apiVersion: v1\nkind: ConfigMap\n").length, 0);
+    });
 });
 
 describe("isYamlUrl", () => {
-  it("detects .yaml", () => assert.equal(isYamlUrl("https://example.com/crd.yaml"), true));
-  it("detects .yml", () => assert.equal(isYamlUrl("https://example.com/crd.yml"), true));
-  it("rejects .json", () => assert.equal(isYamlUrl("https://example.com/s.json"), false));
+    it("detects .yaml", () => assert.equal(isYamlUrl("https://example.com/crd.yaml"), true));
+    it("detects .yml", () => assert.equal(isYamlUrl("https://example.com/crd.yml"), true));
+    it("rejects .json", () => assert.equal(isYamlUrl("https://example.com/s.json"), false));
 });

--- a/website/assets/js/schema/crd-yaml-converter.ts
+++ b/website/assets/js/schema/crd-yaml-converter.ts
@@ -10,47 +10,49 @@ import type { SchemaNode } from "./json-schema-converter.types.ts";
  * Extract SchemaMeta from a CRD document + version entry.
  */
 function extractCrdMeta(crd: CrdDocument, version: CrdVersion): SchemaMeta {
-  const schema = version.schema?.openAPIV3Schema || {};
-  return {
-    description: (schema as Record<string, unknown>).description as string || "",
-    apiVersions: [`${crd.spec.group}/${version.name}`],
-    kind: crd.spec.names?.kind || "",
-  };
+    const schema = version.schema?.openAPIV3Schema || {};
+    return {
+        description: (schema as Record<string, unknown>).description as string || "",
+        apiVersions: [`${crd.spec.group}/${version.name}`],
+        kind: crd.spec.names?.kind || "",
+    };
 }
 
 /**
  * Convert a single CRD version into a SchemaModel.
  */
 function versionToModel(crd: CrdDocument, version: CrdVersion): SchemaModel {
-  const schema = version.schema?.openAPIV3Schema;
-  if (!schema) {
-    return { meta: extractCrdMeta(crd, version), sections: [] };
-  }
-  const model = jsonSchemaToModel(schema as SchemaNode);
-  return { meta: extractCrdMeta(crd, version), sections: model.sections };
+    const schema = version.schema?.openAPIV3Schema;
+    if (!schema) {
+        return { meta: extractCrdMeta(crd, version), sections: [] };
+    }
+    const model = jsonSchemaToModel(schema as SchemaNode);
+    return { meta: extractCrdMeta(crd, version), sections: model.sections };
 }
 
 /** Convert a CRD YAML string into one or more SchemaModels. */
 export function crdYamlToModels(text: string): SchemaModel[] {
-  const docs = loadAll(text).filter(Boolean) as Record<string, unknown>[];
-  const crds = docs.filter((d) => d.kind === "CustomResourceDefinition") as unknown as CrdDocument[];
-  if (!crds.length) return [];
-
-  const models: SchemaModel[] = [];
-  for (const crd of crds) {
-    const versions = (crd.spec?.versions || []).filter((v) => v.served !== false);
-    for (const version of versions) {
-      models.push(versionToModel(crd, version));
+    const docs = loadAll(text).filter(Boolean) as Record<string, unknown>[];
+    const crds = docs.filter((d) => d.kind === "CustomResourceDefinition") as unknown as CrdDocument[];
+    if (!crds.length) {
+        return [];
     }
-  }
-  return models;
+
+    const models: SchemaModel[] = [];
+    for (const crd of crds) {
+        const versions = (crd.spec?.versions || []).filter((v) => v.served !== false);
+        for (const version of versions) {
+            models.push(versionToModel(crd, version));
+        }
+    }
+    return models;
 }
 
 /** Check whether a URL points to a YAML file based on its extension. */
 export function isYamlUrl(url: string): boolean {
-  try {
-    return /\.ya?ml$/i.test(url);
-  } catch {
-    return false;
-  }
+    try {
+        return /\.ya?ml$/i.test(url);
+    } catch {
+        return false;
+    }
 }

--- a/website/assets/js/schema/crd-yaml-converter.types.ts
+++ b/website/assets/js/schema/crd-yaml-converter.types.ts
@@ -1,29 +1,29 @@
 /** Kubernetes CRD YAML input types. */
 
 export interface CrdDocument {
-  apiVersion: string;
-  kind: string;
-  metadata: Record<string, unknown>;
-  spec: CrdSpec;
+    apiVersion: string;
+    kind: string;
+    metadata: Record<string, unknown>;
+    spec: CrdSpec;
 }
 
 export interface CrdSpec {
-  group: string;
-  names: CrdNames;
-  scope?: string;
-  versions: CrdVersion[];
+    group: string;
+    names: CrdNames;
+    scope?: string;
+    versions: CrdVersion[];
 }
 
 export interface CrdNames {
-  kind: string;
-  plural: string;
-  singular: string;
-  listKind?: string;
+    kind: string;
+    plural: string;
+    singular: string;
+    listKind?: string;
 }
 
 export interface CrdVersion {
-  name: string;
-  served: boolean;
-  storage: boolean;
-  schema?: { openAPIV3Schema?: Record<string, unknown> };
+    name: string;
+    served: boolean;
+    storage: boolean;
+    schema?: { openAPIV3Schema?: Record<string, unknown> };
 }

--- a/website/assets/js/schema/json-schema-converter.test.ts
+++ b/website/assets/js/schema/json-schema-converter.test.ts
@@ -10,306 +10,310 @@ let descriptorModel: ReturnType<typeof jsonSchemaToModel>;
 let constructorModel: ReturnType<typeof jsonSchemaToModel>;
 
 before(async () => {
-  const [descResp, consResp] = await Promise.all([fetch(DESCRIPTOR_URL), fetch(CONSTRUCTOR_URL)]);
-  assert.ok(descResp.ok, `Failed to fetch descriptor: ${descResp.status}`);
-  assert.ok(consResp.ok, `Failed to fetch constructor: ${consResp.status}`);
-  descriptorModel = jsonSchemaToModel(await descResp.json());
-  constructorModel = jsonSchemaToModel(await consResp.json());
+    const [descResp, consResp] = await Promise.all([fetch(DESCRIPTOR_URL), fetch(CONSTRUCTOR_URL)]);
+    assert.ok(descResp.ok, `Failed to fetch descriptor: ${descResp.status}`);
+    assert.ok(consResp.ok, `Failed to fetch constructor: ${consResp.status}`);
+    descriptorModel = jsonSchemaToModel(await descResp.json());
+    constructorModel = jsonSchemaToModel(await consResp.json());
 });
 
 /** Recursively assert all fields match the SchemaField shape. */
 function checkFieldShape(field: SchemaField) {
-  assert.equal(typeof field.name, "string");
-  assert.equal(typeof field.type, "string");
-  assert.equal(typeof field.description, "string");
-  assert.ok(Array.isArray(field.constValues));
-  field.constValues.forEach((value) => assert.equal(typeof value, "string"));
-  assert.ok(Array.isArray(field.deprecatedConstValues));
-  field.deprecatedConstValues.forEach((value) => assert.equal(typeof value, "string"));
-  assert.equal(typeof field.required, "boolean");
-  assert.equal(typeof field.immutable, "boolean");
-  if (field.properties) field.properties.forEach(checkFieldShape);
-  if (field.variants) {
-    field.variants.forEach((v) => {
-      assert.equal(typeof v.title, "string");
-      assert.equal(typeof v.type, "string");
-      assert.equal(typeof v.description, "string");
-      if (v.properties) v.properties.forEach(checkFieldShape);
-    });
-  }
+    assert.equal(typeof field.name, "string");
+    assert.equal(typeof field.type, "string");
+    assert.equal(typeof field.description, "string");
+    assert.ok(Array.isArray(field.constValues));
+    field.constValues.forEach((value) => assert.equal(typeof value, "string"));
+    assert.ok(Array.isArray(field.deprecatedConstValues));
+    field.deprecatedConstValues.forEach((value) => assert.equal(typeof value, "string"));
+    assert.equal(typeof field.required, "boolean");
+    assert.equal(typeof field.immutable, "boolean");
+    if (field.properties) {
+        field.properties.forEach(checkFieldShape);
+    }
+    if (field.variants) {
+        field.variants.forEach((v) => {
+            assert.equal(typeof v.title, "string");
+            assert.equal(typeof v.type, "string");
+            assert.equal(typeof v.description, "string");
+            if (v.properties) {
+                v.properties.forEach(checkFieldShape);
+            }
+        });
+    }
 }
 
 describe("descriptor schema", () => {
-  it("single section with expected fields", () => {
-    assert.equal(descriptorModel.sections.length, 1);
-    assert.equal(descriptorModel.sections[0].title, "Schema");
-    const names = descriptorModel.sections[0].fields.map((f) => f.name);
-    for (const f of ["meta", "component", "signatures", "nestedDigests"]) {
-      assert.ok(names.includes(f), `missing: ${f}`);
-    }
-  });
+    it("single section with expected fields", () => {
+        assert.equal(descriptorModel.sections.length, 1);
+        assert.equal(descriptorModel.sections[0].title, "Schema");
+        const names = descriptorModel.sections[0].fields.map((f) => f.name);
+        for (const f of ["meta", "component", "signatures", "nestedDigests"]) {
+            assert.ok(names.includes(f), `missing: ${f}`);
+        }
+    });
 
-  it("resolves nested $ref (meta.schemaVersion, component.resources)", () => {
-    const meta = descriptorModel.sections[0].fields.find((f) => f.name === "meta")!;
-    assert.ok(meta.properties!.length > 0);
-    assert.ok(meta.properties!.some((f) => f.name === "schemaVersion"));
+    it("resolves nested $ref (meta.schemaVersion, component.resources)", () => {
+        const meta = descriptorModel.sections[0].fields.find((f) => f.name === "meta")!;
+        assert.ok(meta.properties!.length > 0);
+        assert.ok(meta.properties!.some((f) => f.name === "schemaVersion"));
 
-    const component = descriptorModel.sections[0].fields.find((f) => f.name === "component")!;
-    const resources = component.properties!.find((f) => f.name === "resources")!;
-    assert.match(resources.type, /\[\]/);
-    assert.ok(resources.properties!.length > 0);
-  });
+        const component = descriptorModel.sections[0].fields.find((f) => f.name === "component")!;
+        const resources = component.properties!.find((f) => f.name === "resources")!;
+        assert.match(resources.type, /\[\]/);
+        assert.ok(resources.properties!.length > 0);
+    });
 
-  it("nullable oneOf collapses without variants (digest)", () => {
-    const component = descriptorModel.sections[0].fields.find((f) => f.name === "component")!;
-    const digest = component.properties!.find((f) => f.name === "resources")!
-      .properties!.find((f) => f.name === "digest")!;
-    assert.equal(digest.type, "object");
-    assert.ok(digest.properties!.length > 0);
-    assert.equal(digest.variants, null);
-  });
+    it("nullable oneOf collapses without variants (digest)", () => {
+        const component = descriptorModel.sections[0].fields.find((f) => f.name === "component")!;
+        const digest = component.properties!.find((f) => f.name === "resources")!
+            .properties!.find((f) => f.name === "digest")!;
+        assert.equal(digest.type, "object");
+        assert.ok(digest.properties!.length > 0);
+        assert.equal(digest.variants, null);
+    });
 
-  it("all fields conform to SchemaField shape", () => {
-    descriptorModel.sections[0].fields.forEach(checkFieldShape);
-  });
+    it("all fields conform to SchemaField shape", () => {
+        descriptorModel.sections[0].fields.forEach(checkFieldShape);
+    });
 
-  it("meta has description", () => {
-    assert.ok(descriptorModel.meta.description.length > 0);
-  });
+    it("meta has description", () => {
+        assert.ok(descriptorModel.meta.description.length > 0);
+    });
 });
 
 describe("constructor schema", () => {
-  it("two variant sections from root oneOf", () => {
-    assert.equal(constructorModel.sections.length, 2);
-    assert.match(constructorModel.sections[0].title, /Variant 1/);
-    assert.match(constructorModel.sections[1].title, /Variant 2/);
-  });
+    it("two variant sections from root oneOf", () => {
+        assert.equal(constructorModel.sections.length, 2);
+        assert.match(constructorModel.sections[0].title, /Variant 1/);
+        assert.match(constructorModel.sections[1].title, /Variant 2/);
+    });
 
-  it("variant 1: components array", () => {
-    const fields = constructorModel.sections[0].fields;
-    assert.equal(fields.length, 1);
-    assert.equal(fields[0].name, "components");
-    assert.match(fields[0].type, /\[\]/);
-  });
+    it("variant 1: components array", () => {
+        const fields = constructorModel.sections[0].fields;
+        assert.equal(fields.length, 1);
+        assert.equal(fields[0].name, "components");
+        assert.match(fields[0].type, /\[\]/);
+    });
 
-  it("variant 2: direct component fields with polymorphic resources/sources", () => {
-    const names = constructorModel.sections[1].fields.map((f) => f.name);
-    for (const f of ["name", "version", "provider", "resources"]) {
-      assert.ok(names.includes(f), `missing: ${f}`);
-    }
+    it("variant 2: direct component fields with polymorphic resources/sources", () => {
+        const names = constructorModel.sections[1].fields.map((f) => f.name);
+        for (const f of ["name", "version", "provider", "resources"]) {
+            assert.ok(names.includes(f), `missing: ${f}`);
+        }
 
-    const resources = constructorModel.sections[1].fields.find((f) => f.name === "resources")!;
-    assert.ok(resources.variants!.length >= 2, "resources should have access/input variants");
+        const resources = constructorModel.sections[1].fields.find((f) => f.name === "resources")!;
+        assert.ok(resources.variants!.length >= 2, "resources should have access/input variants");
 
-    const sources = constructorModel.sections[1].fields.find((f) => f.name === "sources")!;
-    assert.ok(sources.variants!.length >= 2, "sources should have access/input variants");
-  });
+        const sources = constructorModel.sections[1].fields.find((f) => f.name === "sources")!;
+        assert.ok(sources.variants!.length >= 2, "sources should have access/input variants");
+    });
 
-  it("variants include shared fields from parent", () => {
-    const sources = constructorModel.sections[1].fields.find((f) => f.name === "sources")!;
-    for (const v of sources.variants!) {
-      const names = v.properties!.map((f) => f.name);
-      assert.ok(names.includes("name"), `variant "${v.title}" missing shared "name"`);
-      assert.ok(names.includes("type"), `variant "${v.title}" missing shared "type"`);
-    }
-  });
+    it("variants include shared fields from parent", () => {
+        const sources = constructorModel.sections[1].fields.find((f) => f.name === "sources")!;
+        for (const v of sources.variants!) {
+            const names = v.properties!.map((f) => f.name);
+            assert.ok(names.includes("name"), `variant "${v.title}" missing shared "name"`);
+            assert.ok(names.includes("type"), `variant "${v.title}" missing shared "type"`);
+        }
+    });
 
-  it("meta has description", () => {
-    assert.ok(constructorModel.meta.description.length > 0);
-  });
+    it("meta has description", () => {
+        assert.ok(constructorModel.meta.description.length > 0);
+    });
 });
 
 describe("edge cases", () => {
-  it("empty schema", () => {
-    const model = jsonSchemaToModel({});
-    assert.ok(model.meta);
-    assert.equal(model.sections.length, 0);
-  });
-
-  it("simple properties", () => {
-    const model = jsonSchemaToModel({
-      type: "object",
-      properties: { foo: { type: "string", description: "a foo" } },
-    });
-    assert.equal(model.sections[0].fields[0].name, "foo");
-    assert.equal(model.sections[0].fields[0].type, "string");
-  });
-
-  it("immutable via x-kubernetes-validations", () => {
-    const model = jsonSchemaToModel({
-      type: "object",
-      properties: {
-        name: { type: "string", "x-kubernetes-validations": [{ rule: "self == oldSelf" }] },
-      },
-    });
-    assert.equal(model.sections[0].fields[0].immutable, true);
-  });
-
-  it("required flag", () => {
-    const model = jsonSchemaToModel({
-      type: "object", required: ["a"],
-      properties: { a: { type: "string" }, b: { type: "string" } },
-    });
-    assert.equal(model.sections[0].fields.find((f) => f.name === "a")!.required, true);
-    assert.equal(model.sections[0].fields.find((f) => f.name === "b")!.required, false);
-  });
-
-  it("circular $ref", () => {
-    const model = jsonSchemaToModel({
-      type: "object",
-      $defs: { loop: { $ref: "#/$defs/loop" } },
-      properties: { x: { $ref: "#/$defs/loop" } },
-    });
-    assert.equal(model.sections[0].fields.find((f) => f.name === "x")!.type, "object");
-  });
-
-  it("polymorphic oneOf → variants (no shared props)", () => {
-    const model = jsonSchemaToModel({
-      type: "object",
-      properties: {
-        access: {
-          oneOf: [
-            { type: "object", required: ["localPath"], properties: { localPath: { type: "string" } } },
-            { type: "object", required: ["imageRef"], properties: { imageRef: { type: "string" } } },
-          ],
-        },
-      },
-    });
-    const access = model.sections[0].fields.find((f) => f.name === "access")!;
-    assert.equal(access.properties, null);
-    assert.equal(access.variants!.length, 2);
-    assert.equal(access.variants![0].title, "localPath");
-    assert.equal(access.variants![1].title, "imageRef");
-  });
-
-  it("polymorphic oneOf with shared parent props merges and filters", () => {
-    const model = jsonSchemaToModel({
-      type: "object",
-      properties: {
-        source: {
-          type: "object",
-          properties: { name: { type: "string" }, type: { type: "string" } },
-          required: ["name"],
-          oneOf: [
-            { type: "object", required: ["access"], properties: { access: { type: "object" } } },
-            { type: "object", required: ["input"], properties: { input: { type: "object" } } },
-          ],
-        },
-      },
-    });
-    const source = model.sections[0].fields.find((f) => f.name === "source")!;
-    assert.equal(source.variants!.length, 2);
-    for (const v of source.variants!) {
-      const names = v.properties!.map((f) => f.name);
-      assert.ok(names.includes("name"), `shared "name" missing in ${v.title}`);
-      assert.ok(names.includes("type"), `shared "type" missing in ${v.title}`);
-    }
-    // Distinguishing props filtered out (redundant with tab title)
-    assert.ok(!source.variants![0].properties!.some((f) => f.name === "access"));
-    assert.ok(!source.variants![1].properties!.some((f) => f.name === "input"));
-  });
-
-  it("nullable oneOf collapses without variants", () => {
-    const model = jsonSchemaToModel({
-      type: "object",
-      properties: {
-        label: { oneOf: [{ type: "null" }, { type: "string", description: "a label" }] },
-      },
-    });
-    const label = model.sections[0].fields.find((f) => f.name === "label")!;
-    assert.equal(label.type, "string");
-    assert.equal(label.description, "a label");
-    assert.equal(label.variants, null);
-  });
-
-  it("type const-only oneOf collapses into active and deprecated values", () => {
-    const model = jsonSchemaToModel({
-      type: "object",
-      properties: {
-        type: {
-          $ref: "#/$defs/runtimeType",
-          oneOf: [
-            { const: "RSA/v1" },
-            { deprecated: true, const: "RSA/v1alpha1" },
-            { deprecated: true, const: "RSA" },
-          ],
-        },
-      },
-      required: ["type"],
-      $defs: {
-        runtimeType: {
-          type: "string",
-          description: "Type represents a structured type.",
-        },
-      },
+    it("empty schema", () => {
+        const model = jsonSchemaToModel({});
+        assert.ok(model.meta);
+        assert.equal(model.sections.length, 0);
     });
 
-    const type = model.sections[0].fields.find((f) => f.name === "type")!;
-    assert.equal(type.type, "string");
-    assert.equal(type.description, "Type represents a structured type.");
-    assert.deepEqual(type.constValues, ["RSA/v1"]);
-    assert.deepEqual(type.deprecatedConstValues, ["RSA/v1alpha1", "RSA"]);
-    assert.equal(type.variants, null);
-  });
-
-  it("non-type const-only oneOf remains polymorphic", () => {
-    const model = jsonSchemaToModel({
-      type: "object",
-      properties: {
-        mode: {
-          oneOf: [
-            { const: "active" },
-            { deprecated: true, const: "legacy" },
-          ],
-        },
-      },
+    it("simple properties", () => {
+        const model = jsonSchemaToModel({
+            type: "object",
+            properties: { foo: { type: "string", description: "a foo" } },
+        });
+        assert.equal(model.sections[0].fields[0].name, "foo");
+        assert.equal(model.sections[0].fields[0].type, "string");
     });
 
-    const mode = model.sections[0].fields.find((f) => f.name === "mode")!;
-    assert.deepEqual(mode.constValues, []);
-    assert.deepEqual(mode.deprecatedConstValues, []);
-    assert.equal(mode.variants!.length, 2);
-  });
-
-  it("type oneOf with multiple active consts lists all values without variants", () => {
-    const model = jsonSchemaToModel({
-      type: "object",
-      properties: {
-        type: {
-          oneOf: [
-            { const: "DirectCredentials/v1" },
-            { const: "Credentials/v1" },
-            { deprecated: true, const: "Credentials" },
-            { deprecated: true, const: "DirectCredentials" },
-          ],
-        },
-      },
-      required: ["type"],
+    it("immutable via x-kubernetes-validations", () => {
+        const model = jsonSchemaToModel({
+            type: "object",
+            properties: {
+                name: { type: "string", "x-kubernetes-validations": [{ rule: "self == oldSelf" }] },
+            },
+        });
+        assert.equal(model.sections[0].fields[0].immutable, true);
     });
 
-    const type = model.sections[0].fields.find((f) => f.name === "type")!;
-    assert.deepEqual(type.constValues, ["DirectCredentials/v1", "Credentials/v1"]);
-    assert.deepEqual(type.deprecatedConstValues, ["Credentials", "DirectCredentials"]);
-    assert.equal(type.variants, null);
-  });
-
-  it("type oneOf with only deprecated consts has no active value", () => {
-    const model = jsonSchemaToModel({
-      type: "object",
-      properties: {
-        type: {
-          oneOf: [
-            { deprecated: true, const: "RSA/v1alpha1" },
-            { deprecated: true, const: "RSA" },
-          ],
-        },
-      },
-      required: ["type"],
+    it("required flag", () => {
+        const model = jsonSchemaToModel({
+            type: "object", required: ["a"],
+            properties: { a: { type: "string" }, b: { type: "string" } },
+        });
+        assert.equal(model.sections[0].fields.find((f) => f.name === "a")!.required, true);
+        assert.equal(model.sections[0].fields.find((f) => f.name === "b")!.required, false);
     });
 
-    const type = model.sections[0].fields.find((f) => f.name === "type")!;
-    assert.deepEqual(type.constValues, []);
-    assert.deepEqual(type.deprecatedConstValues, ["RSA/v1alpha1", "RSA"]);
-    assert.equal(type.variants, null);
-  });
+    it("circular $ref", () => {
+        const model = jsonSchemaToModel({
+            type: "object",
+            $defs: { loop: { $ref: "#/$defs/loop" } },
+            properties: { x: { $ref: "#/$defs/loop" } },
+        });
+        assert.equal(model.sections[0].fields.find((f) => f.name === "x")!.type, "object");
+    });
+
+    it("polymorphic oneOf → variants (no shared props)", () => {
+        const model = jsonSchemaToModel({
+            type: "object",
+            properties: {
+                access: {
+                    oneOf: [
+                        { type: "object", required: ["localPath"], properties: { localPath: { type: "string" } } },
+                        { type: "object", required: ["imageRef"], properties: { imageRef: { type: "string" } } },
+                    ],
+                },
+            },
+        });
+        const access = model.sections[0].fields.find((f) => f.name === "access")!;
+        assert.equal(access.properties, null);
+        assert.equal(access.variants!.length, 2);
+        assert.equal(access.variants![0].title, "localPath");
+        assert.equal(access.variants![1].title, "imageRef");
+    });
+
+    it("polymorphic oneOf with shared parent props merges and filters", () => {
+        const model = jsonSchemaToModel({
+            type: "object",
+            properties: {
+                source: {
+                    type: "object",
+                    properties: { name: { type: "string" }, type: { type: "string" } },
+                    required: ["name"],
+                    oneOf: [
+                        { type: "object", required: ["access"], properties: { access: { type: "object" } } },
+                        { type: "object", required: ["input"], properties: { input: { type: "object" } } },
+                    ],
+                },
+            },
+        });
+        const source = model.sections[0].fields.find((f) => f.name === "source")!;
+        assert.equal(source.variants!.length, 2);
+        for (const v of source.variants!) {
+            const names = v.properties!.map((f) => f.name);
+            assert.ok(names.includes("name"), `shared "name" missing in ${v.title}`);
+            assert.ok(names.includes("type"), `shared "type" missing in ${v.title}`);
+        }
+        // Distinguishing props filtered out (redundant with tab title)
+        assert.ok(!source.variants![0].properties!.some((f) => f.name === "access"));
+        assert.ok(!source.variants![1].properties!.some((f) => f.name === "input"));
+    });
+
+    it("nullable oneOf collapses without variants", () => {
+        const model = jsonSchemaToModel({
+            type: "object",
+            properties: {
+                label: { oneOf: [{ type: "null" }, { type: "string", description: "a label" }] },
+            },
+        });
+        const label = model.sections[0].fields.find((f) => f.name === "label")!;
+        assert.equal(label.type, "string");
+        assert.equal(label.description, "a label");
+        assert.equal(label.variants, null);
+    });
+
+    it("type const-only oneOf collapses into active and deprecated values", () => {
+        const model = jsonSchemaToModel({
+            type: "object",
+            properties: {
+                type: {
+                    $ref: "#/$defs/runtimeType",
+                    oneOf: [
+                        { const: "RSA/v1" },
+                        { deprecated: true, const: "RSA/v1alpha1" },
+                        { deprecated: true, const: "RSA" },
+                    ],
+                },
+            },
+            required: ["type"],
+            $defs: {
+                runtimeType: {
+                    type: "string",
+                    description: "Type represents a structured type.",
+                },
+            },
+        });
+
+        const type = model.sections[0].fields.find((f) => f.name === "type")!;
+        assert.equal(type.type, "string");
+        assert.equal(type.description, "Type represents a structured type.");
+        assert.deepEqual(type.constValues, ["RSA/v1"]);
+        assert.deepEqual(type.deprecatedConstValues, ["RSA/v1alpha1", "RSA"]);
+        assert.equal(type.variants, null);
+    });
+
+    it("non-type const-only oneOf remains polymorphic", () => {
+        const model = jsonSchemaToModel({
+            type: "object",
+            properties: {
+                mode: {
+                    oneOf: [
+                        { const: "active" },
+                        { deprecated: true, const: "legacy" },
+                    ],
+                },
+            },
+        });
+
+        const mode = model.sections[0].fields.find((f) => f.name === "mode")!;
+        assert.deepEqual(mode.constValues, []);
+        assert.deepEqual(mode.deprecatedConstValues, []);
+        assert.equal(mode.variants!.length, 2);
+    });
+
+    it("type oneOf with multiple active consts lists all values without variants", () => {
+        const model = jsonSchemaToModel({
+            type: "object",
+            properties: {
+                type: {
+                    oneOf: [
+                        { const: "DirectCredentials/v1" },
+                        { const: "Credentials/v1" },
+                        { deprecated: true, const: "Credentials" },
+                        { deprecated: true, const: "DirectCredentials" },
+                    ],
+                },
+            },
+            required: ["type"],
+        });
+
+        const type = model.sections[0].fields.find((f) => f.name === "type")!;
+        assert.deepEqual(type.constValues, ["DirectCredentials/v1", "Credentials/v1"]);
+        assert.deepEqual(type.deprecatedConstValues, ["Credentials", "DirectCredentials"]);
+        assert.equal(type.variants, null);
+    });
+
+    it("type oneOf with only deprecated consts has no active value", () => {
+        const model = jsonSchemaToModel({
+            type: "object",
+            properties: {
+                type: {
+                    oneOf: [
+                        { deprecated: true, const: "RSA/v1alpha1" },
+                        { deprecated: true, const: "RSA" },
+                    ],
+                },
+            },
+            required: ["type"],
+        });
+
+        const type = model.sections[0].fields.find((f) => f.name === "type")!;
+        assert.deepEqual(type.constValues, []);
+        assert.deepEqual(type.deprecatedConstValues, ["RSA/v1alpha1", "RSA"]);
+        assert.equal(type.variants, null);
+    });
 });

--- a/website/assets/js/schema/json-schema-converter.ts
+++ b/website/assets/js/schema/json-schema-converter.ts
@@ -7,17 +7,23 @@ import type {SchemaField, FieldVariant, SchemaSection, SchemaMeta, SchemaModel} 
  * Follow a `$ref` pointer. Does NOT collapse oneOf/anyOf.
  */
 function resolveRef(node: SchemaNode, root: SchemaNode, seen = new Set<string>()): SchemaNode {
-    if (!node || typeof node !== "object") return node || {};
+    if (!node || typeof node !== "object") {
+        return node || {};
+    }
 
     if (node.$ref) {
-        if (seen.has(node.$ref)) return {type: "object", description: "(circular)"};
+        if (seen.has(node.$ref)) {
+            return {type: "object", description: "(circular)"};
+        }
         seen.add(node.$ref);
 
         let target: Record<string, unknown> = root as Record<string, unknown>;
         for (const raw of node.$ref.replace("#/", "").split("/")) {
             const p = raw.replace(/~1/g, "/").replace(/~0/g, "~");
             target = target?.[p] as Record<string, unknown>;
-            if (!target) return {};
+            if (!target) {
+                return {};
+            }
         }
 
         const {$ref: _, ...siblings} = node;
@@ -35,7 +41,9 @@ function classifyUnion(branches: SchemaNode[]): { kind: "nullable"; resolved: Sc
     branches: SchemaNode[]
 } {
     const nonNull = branches.filter((b) => b && b.type !== "null");
-    if (nonNull.length === 1) return {kind: "nullable", resolved: nonNull[0]};
+    if (nonNull.length === 1) {
+        return {kind: "nullable", resolved: nonNull[0]};
+    }
     return {kind: "polymorphic", branches: nonNull.length ? nonNull : branches};
 }
 
@@ -61,7 +69,9 @@ function resolve(node: SchemaNode, root: SchemaNode, seen = new Set<string>()): 
 }
 
 function normalizeType(type: string | string[] | undefined): string {
-    if (Array.isArray(type)) return type.find((t) => t !== "null") || type[0] || "object";
+    if (Array.isArray(type)) {
+        return type.find((t) => t !== "null") || type[0] || "object";
+    }
     return type || "object";
 }
 
@@ -83,7 +93,9 @@ function constStrings(branches: SchemaNode[]): string[] {
 function constAliasUnion(node: SchemaNode): { kw: "oneOf" | "anyOf"; branches: SchemaNode[] } | null {
     for (const kw of ["oneOf", "anyOf"] as const) {
         const branches = node[kw];
-        if (Array.isArray(branches) && branches.length && branches.every(isConstAliasBranch)) return {kw, branches};
+        if (Array.isArray(branches) && branches.length && branches.every(isConstAliasBranch)) {
+            return {kw, branches};
+        }
     }
     return null;
 }
@@ -105,7 +117,9 @@ function constAliasesFrom(node: SchemaNode): { constValues: string[]; deprecated
 
 function withoutConstAliasUnion(node: SchemaNode): SchemaNode {
     const union = constAliasUnion(node);
-    if (!union) return node;
+    if (!union) {
+        return node;
+    }
 
     const {[union.kw]: _, ...rest} = node;
     return rest;
@@ -115,7 +129,9 @@ function withoutConstAliasUnion(node: SchemaNode): SchemaNode {
  * Merge shared parent properties into a oneOf/anyOf branch.
  */
 function mergeParentInto(branch: SchemaNode, parent: SchemaNode, _kw: "oneOf" | "anyOf"): SchemaNode {
-    if (!parent.properties && !parent.required) return branch;
+    if (!parent.properties && !parent.required) {
+        return branch;
+    }
     return {
         ...branch,
         properties: {...parent.properties, ...branch.properties},
@@ -129,7 +145,9 @@ function mergeParentInto(branch: SchemaNode, parent: SchemaNode, _kw: "oneOf" | 
 function variantTitle(branch: SchemaNode, index: number): string {
     if (branch.required?.length) {
         const distinctive = branch.required.find((r) => !["type", "name", "version"].includes(r));
-        if (distinctive) return distinctive;
+        if (distinctive) {
+            return distinctive;
+        }
     }
     const t = normalizeType(branch.type);
     return t !== "object" ? t : `Variant ${index + 1}`;

--- a/website/assets/js/schema/json-schema-converter.types.ts
+++ b/website/assets/js/schema/json-schema-converter.types.ts
@@ -1,19 +1,19 @@
 /** JSON Schema input types (JSON Schema / OpenAPI v3 nodes). */
 
 export interface SchemaNode {
-  type?: string | string[];
-  title?: string;
-  description?: string;
-  $ref?: string;
-  properties?: Record<string, SchemaNode>;
-  required?: string[];
-  items?: SchemaNode;
-  oneOf?: SchemaNode[];
-  anyOf?: SchemaNode[];
-  enum?: string[];
-  const?: string;
-  $defs?: Record<string, SchemaNode>;
-  "x-kubernetes-validations"?: Array<{ rule?: string }>;
-  spec?: { versions?: Array<{ schema?: { openAPIV3Schema?: SchemaNode } }> };
-  [key: string]: unknown;
+    type?: string | string[];
+    title?: string;
+    description?: string;
+    $ref?: string;
+    properties?: Record<string, SchemaNode>;
+    required?: string[];
+    items?: SchemaNode;
+    oneOf?: SchemaNode[];
+    anyOf?: SchemaNode[];
+    enum?: string[];
+    const?: string;
+    $defs?: Record<string, SchemaNode>;
+    "x-kubernetes-validations"?: Array<{ rule?: string }>;
+    spec?: { versions?: Array<{ schema?: { openAPIV3Schema?: SchemaNode } }> };
+    [key: string]: unknown;
 }

--- a/website/assets/js/schema/schema-model.types.ts
+++ b/website/assets/js/schema/schema-model.types.ts
@@ -1,37 +1,37 @@
 /** View-model types for the schema renderer. */
 
 export interface SchemaField {
-  name: string;
-  type: string;
-  description: string;
-  constValues: string[];
-  deprecatedConstValues: string[];
-  required: boolean;
-  immutable: boolean;
-  properties: SchemaField[] | null;
-  variants: FieldVariant[] | null;
+    name: string;
+    type: string;
+    description: string;
+    constValues: string[];
+    deprecatedConstValues: string[];
+    required: boolean;
+    immutable: boolean;
+    properties: SchemaField[] | null;
+    variants: FieldVariant[] | null;
 }
 
 export interface FieldVariant {
-  title: string;
-  type: string;
-  description: string;
-  properties: SchemaField[] | null;
+    title: string;
+    type: string;
+    description: string;
+    properties: SchemaField[] | null;
 }
 
 export interface SchemaSection {
-  title: string;
-  description: string;
-  fields: SchemaField[];
+    title: string;
+    description: string;
+    fields: SchemaField[];
 }
 
 export interface SchemaMeta {
-  description: string;
-  apiVersions: string[];
-  kind: string;
+    description: string;
+    apiVersions: string[];
+    kind: string;
 }
 
 export interface SchemaModel {
-  meta: SchemaMeta;
-  sections: SchemaSection[];
+    meta: SchemaMeta;
+    sections: SchemaSection[];
 }

--- a/website/assets/js/schema/schema-renderer.tsx
+++ b/website/assets/js/schema/schema-renderer.tsx
@@ -68,16 +68,16 @@ function FieldRow({field, depth = 0, parentPath = ""}: {field: SchemaFieldType; 
             <tr className="sr-field-row" id={fieldPath}>
                 <td className={`sr-field-name sr-depth-${Math.min(depth, 8)}`}>
                     <div className="sr-field-name-inner">
-            <span className="sr-expand-space">
-              {expandable && (
-                  <button className="sr-expand-btn" type="button"
-                           aria-expanded={expanded}
-                           aria-label={`${expanded ? "Collapse" : "Expand"} ${field.name}`}
-                           onClick={() => setExpanded(!expanded)}>
-                       {expanded ? "−" : "+"}
-                   </button>
-              )}
-            </span>
+                        <span className="sr-expand-space">
+                            {expandable && (
+                                <button className="sr-expand-btn" type="button"
+                                    aria-expanded={expanded}
+                                    aria-label={`${expanded ? "Collapse" : "Expand"} ${field.name}`}
+                                    onClick={() => setExpanded(!expanded)}>
+                                    {expanded ? "−" : "+"}
+                                </button>
+                            )}
+                        </span>
                         <code className="sr-field-code">{field.name}</code>
                         <a className="sr-field-anchor" href={`#${fieldPath}`}>#</a>
                         {field.required && <span className="badge sr-badge--required">required</span>}
@@ -152,7 +152,9 @@ function VariantRows({variants, depth, parentPath = ""}: {variants: FieldVariant
 }
 
 function FieldTable({title, description, fields, footer}: {title: string; description: string; fields: SchemaFieldType[]; footer?: ComponentChildren}) {
-    if (!fields?.length) return null;
+    if (!fields?.length) {
+        return null;
+    }
     return (
         <div className="sr-section">
             <h3 id={slugify(title)}>{title}<a className="sr-anchor" href={`#${slugify(title)}`}>#</a></h3>
@@ -160,14 +162,14 @@ function FieldTable({title, description, fields, footer}: {title: string; descri
             <div className="sr-table-wrap">
                 <table className="sr-table">
                     <thead>
-                    <tr>
-                        <th>Field</th>
-                        <th>Type</th>
-                        <th className="sr-col-hidden">Description</th>
-                    </tr>
+                        <tr>
+                            <th>Field</th>
+                            <th>Type</th>
+                            <th className="sr-col-hidden">Description</th>
+                        </tr>
                     </thead>
                     <tbody>
-                    {fields.map((f) => <FieldRow key={f.name} field={f}/>)}
+                        {fields.map((f) => <FieldRow key={f.name} field={f}/>)}
                     </tbody>
                 </table>
             </div>
@@ -212,8 +214,8 @@ function SchemaView({model, schemaUrl}: {model: SchemaModelType; schemaUrl: stri
             <SchemaHeader meta={model.meta}/>
             {model.sections.map((section, i) => (
                 <FieldTable key={section.title} title={section.title}
-                            description={section.description} fields={section.fields}
-                            footer={i === lastWithFields ? footer : undefined}/>
+                    description={section.description} fields={section.fields}
+                    footer={i === lastWithFields ? footer : undefined}/>
             ))}
             {lastWithFields === -1 && footer}
         </>
@@ -248,7 +250,9 @@ function SchemaRenderer({schemaUrl}: {schemaUrl: string}) {
 
         fetch(schemaUrl, {signal: controller.signal})
             .then((res) => {
-                if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                if (!res.ok) {
+                    throw new Error(`HTTP ${res.status}`);
+                }
                 return res.text();
             })
             .then((text) => {
@@ -256,7 +260,9 @@ function SchemaRenderer({schemaUrl}: {schemaUrl: string}) {
                 setState("done");
             })
             .catch((err) => {
-                if (err.name === "AbortError") return;
+                if (err.name === "AbortError") {
+                    return;
+                }
                 setError(err.message);
                 setState("error");
             })
@@ -269,7 +275,9 @@ function SchemaRenderer({schemaUrl}: {schemaUrl: string}) {
     }, [schemaUrl]);
 
     useEffect(() => {
-        if (state !== "done") return;
+        if (state !== "done") {
+            return;
+        }
         document.getElementById(window.location.hash.slice(1))?.scrollIntoView();
     }, [state]);
 
@@ -293,7 +301,7 @@ function SchemaRenderer({schemaUrl}: {schemaUrl: string}) {
 
             {state === "done" && models.map((model, i) => (
                 <SchemaView key={`${model.meta.kind}-${model.meta.apiVersions[0] ?? i}`}
-                            model={model} schemaUrl={schemaUrl}/>
+                    model={model} schemaUrl={schemaUrl}/>
             ))}
         </div>
     );

--- a/website/assets/js/tabs.js
+++ b/website/assets/js/tabs.js
@@ -22,16 +22,18 @@
 import { Tab } from 'bootstrap';
 
 function toggleTabs(event) {
-  event.preventDefault();
-  const targetKey = event.currentTarget.getAttribute('data-toggle-tab');
-  if (!targetKey) return;
+    event.preventDefault();
+    const targetKey = event.currentTarget.getAttribute('data-toggle-tab');
+    if (!targetKey) {
+        return;
+    }
 
-  const selectedTabs = document.querySelectorAll(`[data-toggle-tab="${CSS.escape(targetKey)}"]`);
-  for (const tab of selectedTabs) {
-    Tab.getOrCreateInstance(tab).show();
-  }
+    const selectedTabs = document.querySelectorAll(`[data-toggle-tab="${CSS.escape(targetKey)}"]`);
+    for (const tab of selectedTabs) {
+        Tab.getOrCreateInstance(tab).show();
+    }
 }
 
 for (const tab of document.querySelectorAll('[data-toggle-tab]')) {
-  tab.addEventListener('click', toggleTabs);
+    tab.addEventListener('click', toggleTabs);
 }

--- a/website/config/postcss.config.js
+++ b/website/config/postcss.config.js
@@ -2,5 +2,5 @@
 // Doks and theme assets will work without additional plugins.
 // If needed later, add plugins like 'autoprefixer' here.
 module.exports = {
-  plugins: []
+    plugins: []
 };

--- a/website/eslint.config.mts
+++ b/website/eslint.config.mts
@@ -13,6 +13,9 @@ export default defineConfig([
     tseslint.configs.recommended,
     {
         rules: {
+            "curly": "error",
+            "indent": ["error", 4],
+            "brace-style": ["error", "1tbs"],
             "@typescript-eslint/no-unused-vars": ["error", {argsIgnorePattern: "^_", varsIgnorePattern: "^_"}],
         }
     },

--- a/website/eslint.config.mts
+++ b/website/eslint.config.mts
@@ -1,12 +1,13 @@
 import js from "@eslint/js";
 import globals from "globals";
 import tseslint from "typescript-eslint";
+import stylistic from "@stylistic/eslint-plugin";
 import {defineConfig} from "eslint/config";
 
 export default defineConfig([
     {
         files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
-        plugins: {js},
+        plugins: {js, "@stylistic": stylistic},
         extends: ["js/recommended"],
         languageOptions: {globals: {...globals.browser, ...globals.node}}
     },
@@ -14,8 +15,8 @@ export default defineConfig([
     {
         rules: {
             "curly": "error",
-            "indent": ["error", 4],
-            "brace-style": ["error", "1tbs"],
+            "@stylistic/indent": ["error", 4],
+            "@stylistic/brace-style": ["error", "1tbs"],
             "@typescript-eslint/no-unused-vars": ["error", {argsIgnorePattern: "^_", varsIgnorePattern: "^_"}],
         }
     },

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -23,6 +23,7 @@
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
+        "@stylistic/eslint-plugin": "^5.10.0",
         "@types/node": "25.9.5",
         "eslint": "10.8.1",
         "globals": "17.11.0",
@@ -2278,6 +2279,58 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
+      "integrity": "sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/types": "^8.56.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "estraverse": "^5.3.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": "^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@stylistic/eslint-plugin/node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@tabler/icons": {

--- a/website/package.json
+++ b/website/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
+    "@stylistic/eslint-plugin": "^5.10.0",
     "@types/node": "25.9.5",
     "eslint": "10.8.1",
     "globals": "17.11.0",

--- a/website/scripts/link-dart-sass.js
+++ b/website/scripts/link-dart-sass.js
@@ -18,55 +18,55 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const PLATFORM_MAP = {
-  'darwin-arm64': 'sass-embedded-darwin-arm64',
-  'darwin-x64': 'sass-embedded-darwin-x64',
-  'linux-x64': 'sass-embedded-linux-x64',
-  'linux-arm64': 'sass-embedded-linux-arm64',
+    'darwin-arm64': 'sass-embedded-darwin-arm64',
+    'darwin-x64': 'sass-embedded-darwin-x64',
+    'linux-x64': 'sass-embedded-linux-x64',
+    'linux-arm64': 'sass-embedded-linux-arm64',
 };
 
 function main() {
-  const key = `${process.platform}-${process.arch}`;
-  const pkg = PLATFORM_MAP[key];
-  if (!pkg) {
-    throw new Error(
-      `Unsupported platform: ${key}. ` +
+    const key = `${process.platform}-${process.arch}`;
+    const pkg = PLATFORM_MAP[key];
+    if (!pkg) {
+        throw new Error(
+            `Unsupported platform: ${key}. ` +
       `Supported: ${Object.keys(PLATFORM_MAP).join(', ')}. ` +
       'Install the standalone Dart Sass binary manually.'
-    );
-  }
+        );
+    }
 
-  const nodeModules = path.resolve(__dirname, '../node_modules');
-  const nativeSass = path.join(nodeModules, pkg, 'dart-sass', 'sass');
+    const nodeModules = path.resolve(__dirname, '../node_modules');
+    const nativeSass = path.join(nodeModules, pkg, 'dart-sass', 'sass');
 
-  if (!fs.existsSync(nativeSass)) {
-    throw new Error(
-      `Native Dart Sass binary not found at ${nativeSass}. ` +
+    if (!fs.existsSync(nativeSass)) {
+        throw new Error(
+            `Native Dart Sass binary not found at ${nativeSass}. ` +
       `Ensure "${pkg}" is installed (it is an optional dependency of sass-embedded).`
-    );
-  }
+        );
+    }
 
-  const binDir = path.join(nodeModules, '.bin');
-  const linkPath = path.join(binDir, 'sass');
+    const binDir = path.join(nodeModules, '.bin');
+    const linkPath = path.join(binDir, 'sass');
 
-  // Remove existing entry (JS wrapper or stale symlink).
-  // Use lstat to detect broken symlinks that existsSync would miss.
-  try {
-    fs.lstatSync(linkPath);
-    fs.unlinkSync(linkPath);
-  } catch {
+    // Remove existing entry (JS wrapper or stale symlink).
+    // Use lstat to detect broken symlinks that existsSync would miss.
+    try {
+        fs.lstatSync(linkPath);
+        fs.unlinkSync(linkPath);
+    } catch {
     // linkPath does not exist -- nothing to remove
-  }
+    }
 
-  // Create relative symlink so it stays valid if the repo is moved
-  const relTarget = path.relative(binDir, nativeSass);
-  fs.symlinkSync(relTarget, linkPath);
+    // Create relative symlink so it stays valid if the repo is moved
+    const relTarget = path.relative(binDir, nativeSass);
+    fs.symlinkSync(relTarget, linkPath);
 
-  console.log(`Linked native Dart Sass: node_modules/.bin/sass -> ${relTarget}`);
+    console.log(`Linked native Dart Sass: node_modules/.bin/sass -> ${relTarget}`);
 }
 
 try {
-  main();
+    main();
 } catch (err) {
-  console.error(`link-dart-sass: ${err.message}`);
-  process.exit(1);
+    console.error(`link-dart-sass: ${err.message}`);
+    process.exit(1);
 }

--- a/website/scripts/register-docs-version.js
+++ b/website/scripts/register-docs-version.js
@@ -53,7 +53,9 @@ function compareSemver(a, b) {
     for (let i = 0; i < len; i++) {
         const av = pa[i] || 0;
         const bv = pb[i] || 0;
-        if (av !== bv) return av - bv;
+        if (av !== bv) {
+            return av - bv;
+        }
     }
     return 0;
 }
@@ -83,24 +85,34 @@ function assignVersionWeights(existingVersions, newVersion) {
     const semverKeys = [];
 
     for (const key of Object.keys(versions)) {
-        if (key === 'main') hasMain = true;
-        else if (key === 'legacy') hasLegacy = true;
-        else semverKeys.push(key);
+        if (key === 'main') {
+            hasMain = true;
+        } else if (key === 'legacy') {
+            hasLegacy = true;
+        } else {
+            semverKeys.push(key);
+        }
     }
 
-    if (!alreadyExists) semverKeys.push(newVersion);
+    if (!alreadyExists) {
+        semverKeys.push(newVersion);
+    }
     semverKeys.sort((a, b) => compareSemver(b, a)); // descending
 
     const result = {};
     let weight = 1;
 
-    if (hasMain) result.main = { weight: weight++ };
+    if (hasMain) {
+        result.main = { weight: weight++ };
+    }
 
     for (const sv of semverKeys) {
         result[sv] = { weight: weight++ };
     }
 
-    if (hasLegacy) result.legacy = { weight: weight };
+    if (hasLegacy) {
+        result.legacy = { weight: weight };
+    }
 
     return result;
 }
@@ -118,7 +130,9 @@ function parseArguments(args) {
 
     for (let i = 0; i < args.length; i++) {
         if (args[i] === '--cli-gomod') {
-            if (i + 1 >= args.length) throw new Error('--cli-gomod requires a path argument');
+            if (i + 1 >= args.length) {
+                throw new Error('--cli-gomod requires a path argument');
+            }
             flags.cliGomod = args[++i];
         } else if (args[i].startsWith('--')) {
             throw new Error(`Unknown flag: ${args[i]}`);
@@ -127,8 +141,12 @@ function parseArguments(args) {
         }
     }
 
-    if (positionals.length === 0) throw new Error('Missing version. Usage: register-docs-version.js X.Y.Z --cli-gomod <path>');
-    if (positionals.length > 1) throw new Error(`Expected exactly one version argument, got ${positionals.length}: ${positionals.join(', ')}`);
+    if (positionals.length === 0) {
+        throw new Error('Missing version. Usage: register-docs-version.js X.Y.Z --cli-gomod <path>');
+    }
+    if (positionals.length > 1) {
+        throw new Error(`Expected exactly one version argument, got ${positionals.length}: ${positionals.join(', ')}`);
+    }
 
     const fullVersion = positionals[0];
     const versionPattern = /^\d+\.\d+\.\d+$/;
@@ -409,7 +427,9 @@ function buildModuleBlocks(version, fullVersion, deps) {
  */
 function retireOldestVersion(versions) {
     const semverKeys = Object.keys(versions).filter(k => !SPECIAL_VERSIONS.has(k));
-    if (semverKeys.length <= MAX_MINOR_VERSIONS) return null;
+    if (semverKeys.length <= MAX_MINOR_VERSIONS) {
+        return null;
+    }
 
     semverKeys.sort((a, b) => compareSemver(a, b)); // ascending
     const oldest = semverKeys[0];
@@ -430,13 +450,17 @@ function retireOldestVersion(versions) {
  * @returns {boolean} true if any tags were updated
  */
 function updateImportTags(parsed, version, fullVersion, deps) {
-    if (!parsed?.imports) return false;
+    if (!parsed?.imports) {
+        return false;
+    }
 
     let changed = false;
 
     for (const imp of parsed.imports) {
         const matchesVersion = imp?.mounts?.some(m => m?.sites?.matrix?.versions?.includes(version));
-        if (!matchesVersion) continue;
+        if (!matchesVersion) {
+            continue;
+        }
 
         let newTag = null;
         if (imp.path.endsWith('/website') ||
@@ -478,7 +502,9 @@ function updateImportTags(parsed, version, fullVersion, deps) {
 
 // Remove all imports for a given version from module.yaml parsed object
 function removeImportsForVersion(parsed, version) {
-    if (!parsed?.imports) return;
+    if (!parsed?.imports) {
+        return;
+    }
     parsed.imports = parsed.imports.filter(
         imp => !imp?.mounts?.some(m => m?.sites?.matrix?.versions?.includes(version))
     );


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Website scripts are inconsistently formatted, add some sane defaults for [brace-style](https://eslint.style/rules/brace-style), [indent](https://eslint.style/rules/indent), and [curly](https://eslint.org/docs/latest/rules/curly).
Then apply auto-fixes

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Testing


##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] If touching multiple modules, `go work` is enabled (see `go.work`)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
