### PR TITLE
chore: Adjust actions to also run on main

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -1,6 +1,14 @@
 name: Markdown
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**/*.md'
+      - '.github/workflows/markdown.yml'
+      - '.github/config/linkspector-all.yaml'
+      - '.github/config/linkspector-changed.yaml'
   pull_request:
     branches:
       - main

--- a/.github/workflows/verify-github-scripts.yml
+++ b/.github/workflows/verify-github-scripts.yml
@@ -1,6 +1,12 @@
 name: "GitHub Scripts: Verify"
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/verify-github-scripts.yml'
+      - '.github/scripts/**'
   pull_request:
     branches:
       - main

--- a/.github/workflows/website-verify-scripts.yml
+++ b/.github/workflows/website-verify-scripts.yml
@@ -1,6 +1,16 @@
 name: "Website: Verify Scripts"
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/website-verify-scripts.yml'
+      - 'website/assets/js/**'
+      - 'website/scripts/**'
+      - 'website/eslint.config.*'
+      - 'website/package.json'
+      - 'website/package-lock.json'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
#### What this PR does / why we need it
Linting was broken on PRs (see https://github.com/open-component-model/open-component-model/pull/3414) but not on main, because linting (for the website) isn't executed on main

This PR adjusts the `on` blocks of three actions that all have the same pattern of only being executed in PRs without a clear reason. 

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Testing


##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
