### PR TITLE
chore: Update `RELEASE_PROCESS.md` to reflect monolithic bindings

### DIFF
--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -104,7 +104,7 @@ The website integrates into the same workflow run, after `promote_and_release_fi
 * The `website/v0.X.Y` tag is created at the same commit as the canonical tag — same `ADDITIONAL_TAGS` step that emits `cli/` and `kubernetes/controller/` tags.
 * A separate `create_website_update_pr` job then opens a PR to `main` updating `website/config/_default/{hugo.yaml,module.yaml}` to pin the new minor's Hugo module imports to the just-created `website/v0.X.Y` tag. The PR uses the OCMBot app token, signed commits, and `add-paths: website/config/`.
 
-* Binding versions (constructor, descriptor) referenced by the docs are resolved from the released `cli/v0.X.Y` go.mod, not from `main`. This guarantees the docs site for `v0.X.Y` matches what the released CLI was built against.
+* Binding schema versions referenced by the docs are resolved from the released `cli/v0.X.Y` `go.mod`, not from `main`. For releases `>=v0.15` this is a single `bindings/go` module; older releases resolve individual per-package modules. The script auto-detects this and ensures the docs site for `v0.X.Y` matches what the released CLI was built against.
 * On a **minor release** (`Z=0`) the script adds a new version entry under `versions` in `hugo.yaml` and a new set of import blocks in `module.yaml`.
 * On a **patch release** (`Z>0`) the script updates the existing minor's import tags in `module.yaml` in place; `hugo.yaml` is unchanged.
 * When more than 10 minors would be live, the oldest is retired (entry removed from `hugo.yaml`, imports removed from `module.yaml`). Retirement logic lives in `website/scripts/register-docs-version.js`.


### PR DESCRIPTION
#### What this PR does / why we need it
Last part that was still missing for https://github.com/open-component-model/ocm-project/issues/1209

Most of the release process does not mention the bindings structure, its only this one sentence
#### Which issue(s) this PR fixes


##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
