### PR TITLE
fix: #1254 allow non digest processor available for custom resources [2/2]

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -16,7 +16,7 @@ require (
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
-	ocm.software/open-component-model/bindings/go v0.0.4
+	ocm.software/open-component-model/bindings/go v0.0.5
 	sigs.k8s.io/yaml v1.6.0
 )
 

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -354,8 +354,8 @@ k8s.io/kube-openapi v0.0.0-20260520065146-aa012df4f4af h1:zLXA2Irn14q2/06WMkxViy
 k8s.io/kube-openapi v0.0.0-20260520065146-aa012df4f4af/go.mod h1:V/QaCUYDa+0QpcHhVVc5l99Uz56wEMEXBSj9oCDkNDY=
 k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3 h1:jVkFFVfXdXP74B/zbO3hM3hpSFD0xvhQ5U686DPurkE=
 k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3/go.mod h1:M2s5JB1lIYP3jzZdorPLHXIPJzt9vv2muW5a6L9DtNM=
-ocm.software/open-component-model/bindings/go v0.0.4 h1:LmEdvMh3+DGqonVVLjyy38ujlo3VKvX7y7ghF4lAGQs=
-ocm.software/open-component-model/bindings/go v0.0.4/go.mod h1:1skODZB9z85IRkqQF+HBaLWp2PnW/iridWiO5p+6SAs=
+ocm.software/open-component-model/bindings/go v0.0.5 h1:RfWQ+1V20E8YPYlZwGKVdppBC9fSkMSZ4UApnuKNcgM=
+ocm.software/open-component-model/bindings/go v0.0.5/go.mod h1:+HkDEA0uBfwI99dRbfudSp2rGAAvLLjjKtGqOgMvAtc=
 oras.land/oras-go/v2 v2.6.2 h1:N04RXngAp1LJKTG6ifz3xHPipasEkWr+hFmInja5YKo=
 oras.land/oras-go/v2 v2.6.2/go.mod h1:PlTtg4JTDJkDe8yVHpM2wz7/YDc00GVas+i4jAW2TZ4=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=

--- a/cli/integration/add_component_version_integration_test.go
+++ b/cli/integration/add_component_version_integration_test.go
@@ -504,6 +504,63 @@ components:
 	})
 }
 
+func Test_Integration_AddComponentVersion_UnknownAccessType(t *testing.T) {
+	t.Parallel()
+	r := require.New(t)
+	ctx := t.Context()
+
+	componentName := "ocm.software/unknown-access-component"
+	componentVersion := "v1.0.0"
+
+	// The access type is not known to the CLI, so no digest processor can be resolved for it.
+	// Adding the component version must still succeed and keep the access as specified.
+	constructorContent := fmt.Sprintf(`components:
+- name: %s
+  version: %s
+  provider:
+    name: ocm.software
+  resources:
+  - name: mycustomresource
+    version: v1.0.0
+    type: blob
+    access:
+      type: MyCustomAccessType/v1
+      url: my.custom.domain.com/access
+`, componentName, componentVersion)
+
+	tempDir := t.TempDir()
+	constructorPath := filepath.Join(tempDir, "constructor.yaml")
+	r.NoError(os.WriteFile(constructorPath, []byte(constructorContent), os.ModePerm))
+
+	ctfDir := filepath.Join(tempDir, "ctf")
+
+	addCMD := cmd.New()
+	addCMD.SetArgs([]string{
+		"add",
+		"component-version",
+		"--repository", fmt.Sprintf("ctf::%s", ctfDir),
+		"--constructor", constructorPath,
+	})
+	r.NoError(addCMD.ExecuteContext(ctx), "add cv with an access type unknown to ocm should succeed")
+
+	fs, err := filesystem.NewFS(ctfDir, os.O_RDONLY)
+	r.NoError(err)
+	archive := ctf.NewFileSystemCTF(fs)
+	repo, err := oci.NewRepository(ocictf.WithCTF(ocictf.NewFromCTF(archive)))
+	r.NoError(err)
+
+	desc, err := repo.GetComponentVersion(ctx, componentName, componentVersion)
+	r.NoError(err)
+	r.Len(desc.Component.Resources, 1)
+
+	resource := desc.Component.Resources[0]
+	r.Equal("mycustomresource", resource.Name)
+	r.Equal(descriptor.ExternalRelation, resource.Relation)
+	r.NotNil(resource.Access)
+	r.Equal("MyCustomAccessType/v1", resource.Access.GetType().String())
+	r.Nil(resource.Digest, "a resource without a digest processor must be stored without a digest")
+}
+
 func Test_Integration_HelmInput_LocalPath(t *testing.T) {
 	t.Parallel()
 	r := require.New(t)

--- a/cli/integration/go.mod
+++ b/cli/integration/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/registry v0.43.0
 	golang.org/x/crypto v0.54.0
 	helm.sh/helm/v4 v4.2.3
-	ocm.software/open-component-model/bindings/go v0.0.4
+	ocm.software/open-component-model/bindings/go v0.0.5
 	ocm.software/open-component-model/cli v0.13.0
 	oras.land/oras-go/v2 v2.6.2
 )

--- a/cli/integration/go.sum
+++ b/cli/integration/go.sum
@@ -418,8 +418,8 @@ k8s.io/kube-openapi v0.0.0-20260520065146-aa012df4f4af h1:zLXA2Irn14q2/06WMkxViy
 k8s.io/kube-openapi v0.0.0-20260520065146-aa012df4f4af/go.mod h1:V/QaCUYDa+0QpcHhVVc5l99Uz56wEMEXBSj9oCDkNDY=
 k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3 h1:jVkFFVfXdXP74B/zbO3hM3hpSFD0xvhQ5U686DPurkE=
 k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3/go.mod h1:M2s5JB1lIYP3jzZdorPLHXIPJzt9vv2muW5a6L9DtNM=
-ocm.software/open-component-model/bindings/go v0.0.4 h1:LmEdvMh3+DGqonVVLjyy38ujlo3VKvX7y7ghF4lAGQs=
-ocm.software/open-component-model/bindings/go v0.0.4/go.mod h1:1skODZB9z85IRkqQF+HBaLWp2PnW/iridWiO5p+6SAs=
+ocm.software/open-component-model/bindings/go v0.0.5 h1:RfWQ+1V20E8YPYlZwGKVdppBC9fSkMSZ4UApnuKNcgM=
+ocm.software/open-component-model/bindings/go v0.0.5/go.mod h1:+HkDEA0uBfwI99dRbfudSp2rGAAvLLjjKtGqOgMvAtc=
 oras.land/oras-go/v2 v2.6.2 h1:N04RXngAp1LJKTG6ifz3xHPipasEkWr+hFmInja5YKo=
 oras.land/oras-go/v2 v2.6.2/go.mod h1:PlTtg4JTDJkDe8yVHpM2wz7/YDc00GVas+i4jAW2TZ4=
 pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Digest processing fails hard right now for custom access types and known types without a digest processor.
This PR loosens the requirement of a digest processor requirement and allows custom types in `add cv` that do not have a digest processor in our code-base by design for access types.

#### Which issue(s) this PR fixes
Contributes: https://github.com/open-component-model/ocm-project/issues/1254

#### Testing

##### How to test the changes

- unit and integration tests
- additional cli add cv test case with a custom resource

##### Verification

- [x] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [x] Tests pass locally (`task test` and `task test/integration` if applicable)
- [x] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
