### PR TITLE
fix: #1254 allow non digest processor available for custom resources [1/2]

### DIFF
--- a/bindings/go/constructor/construct.go
+++ b/bindings/go/constructor/construct.go
@@ -422,8 +422,15 @@ func (c *DefaultConstructor) processResource(ctx context.Context, targetRepo Tar
 		res = constructor.ConvertToDescriptorResource(resource)
 
 		if c.opts.ResourceDigestProcessorProvider != nil {
-			var digestProcessor ResourceDigestProcessor
-			if digestProcessor, err = c.opts.GetDigestProcessor(ctx, res); err == nil {
+			digestProcessor, digestProcessorErr := c.opts.GetDigestProcessor(ctx, res)
+			if digestProcessor == nil {
+				logger.WarnContext(ctx, "no digest processor available for access type, the resource is added without a digest",
+					"access_type", res.Access.GetType())
+			} else if digestProcessorErr != nil {
+				logger.WarnContext(ctx, "error getting digest processor for access type, the resource is added without a digest",
+					"access_type", res.Access.GetType(),
+					"error", digestProcessorErr)
+			} else {
 				logger.Debug("processing resource digest")
 				var creds ocmruntime.Typed
 				if c.opts.Resolver != nil {

--- a/bindings/go/constructor/construct.go
+++ b/bindings/go/constructor/construct.go
@@ -423,13 +423,13 @@ func (c *DefaultConstructor) processResource(ctx context.Context, targetRepo Tar
 
 		if c.opts.ResourceDigestProcessorProvider != nil {
 			digestProcessor, digestProcessorErr := c.opts.GetDigestProcessor(ctx, res)
-			if digestProcessor == nil {
-				logger.WarnContext(ctx, "no digest processor available for access type, the resource is added without a digest",
-					"access_type", res.Access.GetType())
-			} else if digestProcessorErr != nil {
+			if digestProcessorErr != nil {
 				logger.WarnContext(ctx, "error getting digest processor for access type, the resource is added without a digest",
 					"access_type", res.Access.GetType(),
 					"error", digestProcessorErr)
+			} else if digestProcessor == nil {
+				logger.WarnContext(ctx, "no digest processor available for access type, the resource is added without a digest",
+					"access_type", res.Access.GetType())
 			} else {
 				logger.Debug("processing resource digest")
 				var creds ocmruntime.Typed

--- a/bindings/go/constructor/construct.go
+++ b/bindings/go/constructor/construct.go
@@ -423,14 +423,15 @@ func (c *DefaultConstructor) processResource(ctx context.Context, targetRepo Tar
 
 		if c.opts.ResourceDigestProcessorProvider != nil {
 			digestProcessor, digestProcessorErr := c.opts.GetDigestProcessor(ctx, res)
-			if digestProcessorErr != nil {
+			switch {
+			case digestProcessorErr != nil:
 				logger.WarnContext(ctx, "error getting digest processor for access type, the resource is added without a digest",
 					"access_type", res.Access.GetType(),
 					"error", digestProcessorErr)
-			} else if digestProcessor == nil {
+			case digestProcessor == nil:
 				logger.WarnContext(ctx, "no digest processor available for access type, the resource is added without a digest",
 					"access_type", res.Access.GetType())
-			} else {
+			default:
 				logger.Debug("processing resource digest")
 				var creds ocmruntime.Typed
 				if c.opts.Resolver != nil {

--- a/bindings/go/constructor/construct_resource_test.go
+++ b/bindings/go/constructor/construct_resource_test.go
@@ -443,6 +443,37 @@ func TestConstructWithAccessTypeWithoutDigestProcessor(t *testing.T) {
 	assert.Len(t, mockTargetRepo.addedVersions, 1)
 }
 
+func TestConstructWithNilDigestProcessor(t *testing.T) {
+	// A provider that returns neither a processor nor an error must not panic the construction.
+	constructor := setupTestComponent(t, `
+      - name: test-resource
+        version: v1.0.0
+        relation: external
+        type: blob
+        access:
+          type: MyCustomAccessType/v1
+          url: my.custom.domain.com/access
+`)
+
+	mockTargetRepo := newMockTargetRepository()
+
+	opts := Options{
+		TargetRepositoryProvider:        &mockTargetRepositoryProvider{repo: mockTargetRepo},
+		ResourceDigestProcessorProvider: &mockDigestProcessorProvider{},
+	}
+
+	constructorInstance := NewDefaultConstructor(constructor, opts)
+	graph := constructorInstance.GetGraph()
+
+	require.NoError(t, constructorInstance.Construct(context.Background()))
+	descs := collectDescriptors(t, graph)
+	require.Len(t, descs, 1)
+
+	resource := descs[0].Component.Resources[0]
+	require.NotNil(t, resource.Access)
+	assert.Nil(t, resource.Digest, "a resource without a digest processor must be stored without a digest")
+}
+
 func TestConstructWithInvalidInputMethod(t *testing.T) {
 	constructor := setupTestComponent(t, `
       - name: test-resource

--- a/bindings/go/constructor/construct_resource_test.go
+++ b/bindings/go/constructor/construct_resource_test.go
@@ -398,6 +398,51 @@ func TestConstructWithResourceDigest(t *testing.T) {
 	assert.Len(t, mockTargetRepo.addedVersions, 1)
 }
 
+func TestConstructWithAccessTypeWithoutDigestProcessor(t *testing.T) {
+	// An access type unknown to OCM has no digest processor available. This must not fail the
+	// construction, the resource is added without a digest instead.
+	mockDigestProvider := &mockDigestProcessorProvider{
+		err: fmt.Errorf("failed to get plugin for typ %q", "MyCustomAccessType/v1"),
+	}
+
+	constructor := setupTestComponent(t, `
+      - name: test-resource
+        version: v1.0.0
+        relation: external
+        type: blob
+        access:
+          type: MyCustomAccessType/v1
+          url: my.custom.domain.com/access
+`)
+
+	mockTargetRepo := newMockTargetRepository()
+
+	opts := Options{
+		TargetRepositoryProvider:        &mockTargetRepositoryProvider{repo: mockTargetRepo},
+		ResourceDigestProcessorProvider: mockDigestProvider,
+	}
+
+	constructorInstance := NewDefaultConstructor(constructor, opts)
+	graph := constructorInstance.GetGraph()
+
+	require.NoError(t, constructorInstance.Construct(context.Background()))
+	descs := collectDescriptors(t, graph)
+	require.Len(t, descs, 1)
+
+	desc := descs[0]
+	verifyBasicComponent(t, desc)
+
+	resource := desc.Component.Resources[0]
+	assert.Equal(t, "test-resource", resource.Name)
+	assert.Equal(t, descriptor.ExternalRelation, resource.Relation)
+	require.NotNil(t, resource.Access)
+	assert.Equal(t, "MyCustomAccessType/v1", resource.Access.GetType().String())
+	assert.Nil(t, resource.Digest, "a resource without a digest processor must be stored without a digest")
+
+	assert.Len(t, mockTargetRepo.addedLocalResources, 0)
+	assert.Len(t, mockTargetRepo.addedVersions, 1)
+}
+
 func TestConstructWithInvalidInputMethod(t *testing.T) {
 	constructor := setupTestComponent(t, `
       - name: test-resource

--- a/bindings/go/constructor/mocks_test.go
+++ b/bindings/go/constructor/mocks_test.go
@@ -259,9 +259,13 @@ func (m *mockDigestProcessor) ProcessResourceDigest(ctx context.Context, resourc
 
 type mockDigestProcessorProvider struct {
 	processor ResourceDigestProcessor
+	err       error
 }
 
 func (m *mockDigestProcessorProvider) GetDigestProcessor(ctx context.Context, resource *descriptor.Resource) (ResourceDigestProcessor, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
 	return m.processor, nil
 }
 

--- a/bindings/go/constructor/options.go
+++ b/bindings/go/constructor/options.go
@@ -40,6 +40,8 @@ type Options struct {
 	// to get the digest processor for the component specification when processing resources by reference to amend
 	// digest information.
 	// The ResourceDigestProcessorProvider is OPTIONAL, if not provided, the constructor library will not resolve digests.
+	// Resources whose access type has no digest processor are added without a digest and only cause a warning,
+	// so that component versions can reference access types unknown to the constructor.
 	ResourceDigestProcessorProvider
 
 	// While constructing a component version, the constructor library will use the given credential provider


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Digest processing fails hard right now for custom access types and known types without a digest processor.
This PR loosens the requirement of a digest processor requirement and allows custom types in `add cv` that do not have a digest processor in our code-base by design for access types.

See https://github.com/open-component-model/open-component-model/pull/3417 for the full change

#### Which issue(s) this PR fixes
Contributes: https://github.com/open-component-model/ocm-project/issues/1254

#### Testing

##### How to test the changes

- unit and integration tests
- additional cli add cv test case with a custom resource (https://github.com/open-component-model/open-component-model/pull/3417)

##### Verification

- [x] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [x] Tests pass locally (`task test` and `task test/integration` if applicable)
- [x] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
