### PR TITLE
fix: unresolved relative path in `GetBlobFromPath`

### DIFF
--- a/bindings/go/blob/filesystem/blob_from_path.go
+++ b/bindings/go/blob/filesystem/blob_from_path.go
@@ -55,12 +55,14 @@ func GetBlobFromPath(ctx context.Context, path string, opt DirOptions) (blob.Rea
 		return nil, fmt.Errorf("path must not be empty")
 	}
 
-	// Ensure the path is within the working directory if specified
+	// Resolve path from within the working directory if specified
 	// Provides full path-traversal protection
 	if opt.WorkingDir != "" {
-		if _, err := ensurePathInWorkingDirectory(path, opt.WorkingDir); err != nil {
+		resolved, err := ensurePathInWorkingDirectory(path, opt.WorkingDir)
+		if err != nil {
 			return nil, fmt.Errorf("error ensuring path %q in working directory %q: %w", path, opt.WorkingDir, err)
 		}
+		path = resolved
 	}
 
 	// Check if path is a valid directory or single file.

--- a/bindings/go/blob/filesystem/blob_from_path_test.go
+++ b/bindings/go/blob/filesystem/blob_from_path_test.go
@@ -97,6 +97,10 @@ func TestGetBlobFromPath_RelativeDirectory(t *testing.T) {
 	b, err := filesystem.GetBlobFromPath(context.Background(), "testFolder", opt)
 	r.NoError(err)
 	r.NotNil(b)
+
+	reader, err := b.ReadCloser()
+	r.NoError(err)
+	defer func() { r.NoError(reader.Close()) }()
 }
 
 // PATTERN FILTERING: Include/exclude pattern functionality

--- a/bindings/go/blob/filesystem/blob_from_path_test.go
+++ b/bindings/go/blob/filesystem/blob_from_path_test.go
@@ -80,6 +80,25 @@ func TestGetBlobFromPath_SimpleDirectory(t *testing.T) {
 	r.Equal("content2", foundFiles["file2.txt"])
 }
 
+func TestGetBlobFromPath_RelativeDirectory(t *testing.T) {
+	r := require.New(t)
+
+	// Change working directory to explicitly not be in the working directory we pass via options
+	wd := t.TempDir()
+	t.Chdir(wd)
+
+	// Setup: create directory with multiple files
+	tmpDir := t.TempDir()
+	createTestFile(t, filepath.Join(tmpDir, "testFolder"), "file.txt", "content")
+
+	// Test: create blob from directory (should be TAR archive)
+	opt := filesystem.DirOptions{Reproducible: true}
+	opt.WorkingDir = tmpDir
+	b, err := filesystem.GetBlobFromPath(context.Background(), "testFolder", opt)
+	r.NoError(err)
+	r.NotNil(b)
+}
+
 // PATTERN FILTERING: Include/exclude pattern functionality
 func TestGetBlobFromPath_PatternSemantics(t *testing.T) {
 	r := require.New(t)

--- a/bindings/go/blob/filesystem/blob_from_path_test.go
+++ b/bindings/go/blob/filesystem/blob_from_path_test.go
@@ -2,7 +2,6 @@ package filesystem_test
 
 import (
 	"archive/tar"
-	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -26,7 +25,7 @@ func TestGetBlobFromPath_SingleFile(t *testing.T) {
 
 	// Test: create blob from single file (should be raw, not TAR)
 	opt := filesystem.DirOptions{Reproducible: true}
-	b, err := filesystem.GetBlobFromPath(context.Background(), testFile, opt)
+	b, err := filesystem.GetBlobFromPath(t.Context(), testFile, opt)
 	r.NoError(err)
 	r.NotNil(b)
 
@@ -50,7 +49,7 @@ func TestGetBlobFromPath_SimpleDirectory(t *testing.T) {
 
 	// Test: create blob from directory (should be TAR archive)
 	opt := filesystem.DirOptions{Reproducible: true}
-	b, err := filesystem.GetBlobFromPath(context.Background(), tmpDir, opt)
+	b, err := filesystem.GetBlobFromPath(t.Context(), tmpDir, opt)
 	r.NoError(err)
 	r.NotNil(b)
 
@@ -94,7 +93,7 @@ func TestGetBlobFromPath_RelativeDirectory(t *testing.T) {
 	// Test: create blob from directory (should be TAR archive)
 	opt := filesystem.DirOptions{Reproducible: true}
 	opt.WorkingDir = tmpDir
-	b, err := filesystem.GetBlobFromPath(context.Background(), "testFolder", opt)
+	b, err := filesystem.GetBlobFromPath(t.Context(), "testFolder", opt)
 	r.NoError(err)
 	r.NotNil(b)
 
@@ -161,7 +160,7 @@ func TestGetBlobFromPath_PatternSemantics(t *testing.T) {
 
 			// Test with patterns
 			opt := filesystem.DirOptions{IncludePatterns: tt.includePatterns, ExcludePatterns: tt.excludePatterns, Reproducible: true}
-			resultBlob, err := filesystem.GetBlobFromPath(context.Background(), tmpDir, opt)
+			resultBlob, err := filesystem.GetBlobFromPath(t.Context(), tmpDir, opt)
 			if tt.expectError {
 				r.Error(err)
 				return
@@ -184,13 +183,13 @@ func TestGetBlobFromPath_SingleFileWithPatterns(t *testing.T) {
 
 	// Test: patterns with single file should error
 	opt := filesystem.DirOptions{IncludePatterns: []string{"*.txt"}}
-	_, err := filesystem.GetBlobFromPath(context.Background(), testFile, opt)
+	_, err := filesystem.GetBlobFromPath(t.Context(), testFile, opt)
 	r.Error(err)
 	r.Contains(err.Error(), "include/exclude patterns are not supported for single files")
 
 	// Test: exclude patterns with single file should also error
 	opt = filesystem.DirOptions{ExcludePatterns: []string{"*.log"}}
-	_, err = filesystem.GetBlobFromPath(context.Background(), testFile, opt)
+	_, err = filesystem.GetBlobFromPath(t.Context(), testFile, opt)
 	r.Error(err)
 	r.Contains(err.Error(), "include/exclude patterns are not supported for single files")
 }
@@ -208,7 +207,7 @@ func TestGetBlobFromPath_PreserveDirectory(t *testing.T) {
 
 	// Test: preserve directory structure
 	opt := filesystem.DirOptions{Reproducible: true, PreserveDir: true}
-	b, err := filesystem.GetBlobFromPath(context.Background(), targetDir, opt)
+	b, err := filesystem.GetBlobFromPath(t.Context(), targetDir, opt)
 	r.NoError(err)
 
 	// Verify: entries are prefixed with directory name
@@ -259,7 +258,7 @@ func TestGetBlobFromPath_Compression(t *testing.T) {
 
 	// Test: compression enabled
 	opt := filesystem.DirOptions{Compress: true, MediaType: filesystem.DefaultTarMediaType}
-	b, err := filesystem.GetBlobFromPath(context.Background(), testFile, opt)
+	b, err := filesystem.GetBlobFromPath(t.Context(), testFile, opt)
 	r.NoError(err)
 
 	// Verify: content is gzip compressed
@@ -284,7 +283,7 @@ func TestGetBlobFromPath_MediaTypeHandling(t *testing.T) {
 		createTestFile(t, tmpDir, "file.txt", "content")
 
 		opt := filesystem.DirOptions{MediaType: "application/custom-tar"}
-		b, err := filesystem.GetBlobFromPath(context.Background(), tmpDir, opt)
+		b, err := filesystem.GetBlobFromPath(t.Context(), tmpDir, opt)
 		r.NoError(err)
 
 		mt, ok := b.(blob.MediaTypeAware)
@@ -298,7 +297,7 @@ func TestGetBlobFromPath_MediaTypeHandling(t *testing.T) {
 		testFile := createTestFile(t, tmpDir, "single.txt", "content")
 
 		opt := filesystem.DirOptions{MediaType: "text/plain"}
-		b, err := filesystem.GetBlobFromPath(context.Background(), testFile, opt)
+		b, err := filesystem.GetBlobFromPath(t.Context(), testFile, opt)
 		r.NoError(err)
 
 		mt, ok := b.(blob.MediaTypeAware)
@@ -320,7 +319,7 @@ func TestGetBlobFromPath_ReproducibleBuilds(t *testing.T) {
 
 	// Test: create blob with reproducible option
 	opt := filesystem.DirOptions{Reproducible: true}
-	blob1, err := filesystem.GetBlobFromPath(context.Background(), testFile, opt)
+	blob1, err := filesystem.GetBlobFromPath(t.Context(), testFile, opt)
 	r.NoError(err)
 
 	data1, err := readAllFromBlob(blob1)
@@ -331,7 +330,7 @@ func TestGetBlobFromPath_ReproducibleBuilds(t *testing.T) {
 	r.NoError(os.Chtimes(testFile, newTime, newTime))
 
 	// Test: create blob again after timestamp change
-	blob2, err := filesystem.GetBlobFromPath(context.Background(), testFile, opt)
+	blob2, err := filesystem.GetBlobFromPath(t.Context(), testFile, opt)
 	r.NoError(err)
 
 	data2, err := readAllFromBlob(blob2)
@@ -386,7 +385,7 @@ func TestGetBlobFromPath_ErrorCases(t *testing.T) {
 			r := require.New(t)
 
 			path, opt := tt.setupFunc(t)
-			_, err := filesystem.GetBlobFromPath(context.Background(), path, opt)
+			_, err := filesystem.GetBlobFromPath(t.Context(), path, opt)
 
 			if tt.expectError {
 				r.Error(err)
@@ -416,7 +415,7 @@ func TestGetBlobFromPath_SymlinkRejection(t *testing.T) {
 	}
 
 	// Test: symlinks should be rejected during blob reading
-	b, err := filesystem.GetBlobFromPath(context.Background(), tmpDir, filesystem.DirOptions{})
+	b, err := filesystem.GetBlobFromPath(t.Context(), tmpDir, filesystem.DirOptions{})
 	r.NoError(err, "blob creation should succeed initially")
 
 	// Verify: error occurs when reading blob content
@@ -435,7 +434,7 @@ func TestGetBlobFromPath_IncludeDirectoryOnly(t *testing.T) {
 
 	// Only include the directory itself
 	opt := filesystem.DirOptions{IncludePatterns: []string{"sub/dir"}, Reproducible: true}
-	b, err := filesystem.GetBlobFromPath(context.Background(), tmpDir, opt)
+	b, err := filesystem.GetBlobFromPath(t.Context(), tmpDir, opt)
 	r.NoError(err)
 	r.NotNil(b)
 
@@ -475,7 +474,7 @@ func TestGetBlobFromPath_PatternNormalization(t *testing.T) {
 
 	for _, inc := range cases {
 		opt := filesystem.DirOptions{IncludePatterns: inc, Reproducible: true}
-		resultBlob, err := filesystem.GetBlobFromPath(context.Background(), tmpDir, opt)
+		resultBlob, err := filesystem.GetBlobFromPath(t.Context(), tmpDir, opt)
 		r.NoError(err)
 		files := extractTarContents(t, resultBlob)
 		r.Contains(files, "sub/dir/file.txt")

--- a/bindings/go/blob/filesystem/file.go
+++ b/bindings/go/blob/filesystem/file.go
@@ -102,11 +102,10 @@ func ensurePathInWorkingDirectory(path, workingDirectory string) (_ string, retE
 	if err != nil {
 		return "", fmt.Errorf("failed to open path %q in root %q: %w", path, workingDirectory, err)
 	}
-	defer func() {
-		if cErr := resolved.Close(); retErr == nil && cErr != nil {
-			retErr = fmt.Errorf("failed to close path validation handle for %q: %w", path, cErr)
-		}
-	}()
+	err = resolved.Close()
+	if err != nil {
+		return "", fmt.Errorf("failed to close path validation handle for %q in root %q: %w", path, workingDirectory, err)
+	}
 
 	return filepath.Join(workingDirectory, path), nil
 }

--- a/bindings/go/blob/filesystem/file.go
+++ b/bindings/go/blob/filesystem/file.go
@@ -91,17 +91,22 @@ func GetBlobInWorkingDirectory(path, workingDir string) (*Blob, error) {
 // If the path is absolute, it checks if the path is valid within the working directory.
 // If the path is relative, it resolves it against the working directory and prevents escaping the working directory.
 // If the path cannot be resolved or is invalid, it returns an error.
-func ensurePathInWorkingDirectory(path, workingDirectory string) (_ string, err error) {
+func ensurePathInWorkingDirectory(path, workingDirectory string) (_ string, retErr error) {
 	if filepath.IsAbs(path) {
-		if path, err = filepath.Rel(workingDirectory, path); err != nil {
-			return "", fmt.Errorf("failed to create relative path for %q based on working directory %q: %w", path, workingDirectory, err)
+		if path, retErr = filepath.Rel(workingDirectory, path); retErr != nil {
+			return "", fmt.Errorf("failed to create relative path for %q based on working directory %q: %w", path, workingDirectory, retErr)
 		}
 	}
 
-	_, err = os.OpenInRoot(workingDirectory, path)
+	resolved, err := os.OpenInRoot(workingDirectory, path)
 	if err != nil {
 		return "", fmt.Errorf("failed to open path %q in root %q: %w", path, workingDirectory, err)
 	}
+	defer func() {
+		if cErr := resolved.Close(); retErr == nil && cErr != nil {
+			retErr = fmt.Errorf("failed to close path validation handle for %q: %w", path, cErr)
+		}
+	}()
 
 	return filepath.Join(workingDirectory, path), nil
 }

--- a/bindings/go/input/file/blob.go
+++ b/bindings/go/input/file/blob.go
@@ -62,7 +62,11 @@ func GetV1FileBlob(file v1.File, workingDirectory string) (blob.ReadOnlyBlob, er
 		}
 		// see https://github.com/gabriel-vasile/mimetype/blob/master/supported_mimes.md for supported types
 		mime, err := mimetype.DetectReader(readCloser)
+		cErr := readCloser.Close()
 		if err != nil {
+			return nil, err
+		}
+		if cErr != nil {
 			return nil, err
 		}
 		mediaType = mime.String()

--- a/bindings/go/input/file/blob.go
+++ b/bindings/go/input/file/blob.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/gabriel-vasile/mimetype"
 
@@ -57,7 +58,7 @@ func GetV1FileBlob(file v1.File, workingDirectory string) (blob.ReadOnlyBlob, er
 	mediaType := file.MediaType
 	if mediaType == "" {
 		// see https://github.com/gabriel-vasile/mimetype/blob/master/supported_mimes.md for supported types
-		mime, _ := mimetype.DetectFile(file.Path)
+		mime, _ := mimetype.DetectFile(filepath.Join(workingDirectory, file.Path))
 		mediaType = mime.String()
 	}
 

--- a/bindings/go/input/file/blob.go
+++ b/bindings/go/input/file/blob.go
@@ -56,12 +56,19 @@ func GetV1FileBlob(file v1.File, workingDirectory string) (blob.ReadOnlyBlob, er
 
 	mediaType := file.MediaType
 	if mediaType == "" {
-		readCloser, _ := b.ReadCloser()
-		if readCloser != nil {
-			// see https://github.com/gabriel-vasile/mimetype/blob/master/supported_mimes.md for supported types
-			mime, _ := mimetype.DetectReader(readCloser)
-			mediaType = mime.String()
-			_ = readCloser.Close()
+		readCloser, err := b.ReadCloser()
+		if err != nil {
+			return nil, err
+		}
+		// see https://github.com/gabriel-vasile/mimetype/blob/master/supported_mimes.md for supported types
+		mime, err := mimetype.DetectReader(readCloser)
+		if err != nil {
+			return nil, err
+		}
+		mediaType = mime.String()
+		err = readCloser.Close()
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/bindings/go/input/file/blob.go
+++ b/bindings/go/input/file/blob.go
@@ -67,7 +67,7 @@ func GetV1FileBlob(file v1.File, workingDirectory string) (blob.ReadOnlyBlob, er
 			return nil, err
 		}
 		if cErr != nil {
-			return nil, err
+			return nil, cErr
 		}
 		mediaType = mime.String()
 		err = readCloser.Close()

--- a/bindings/go/input/file/blob.go
+++ b/bindings/go/input/file/blob.go
@@ -2,7 +2,6 @@ package file
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/gabriel-vasile/mimetype"
 
@@ -57,9 +56,13 @@ func GetV1FileBlob(file v1.File, workingDirectory string) (blob.ReadOnlyBlob, er
 
 	mediaType := file.MediaType
 	if mediaType == "" {
-		// see https://github.com/gabriel-vasile/mimetype/blob/master/supported_mimes.md for supported types
-		mime, _ := mimetype.DetectFile(filepath.Join(workingDirectory, file.Path))
-		mediaType = mime.String()
+		readCloser, _ := b.ReadCloser()
+		if readCloser != nil {
+			// see https://github.com/gabriel-vasile/mimetype/blob/master/supported_mimes.md for supported types
+			mime, _ := mimetype.DetectReader(readCloser)
+			mediaType = mime.String()
+			_ = readCloser.Close()
+		}
 	}
 
 	data := blob.ReadOnlyBlob(&InputFileBlob{b, mediaType})


### PR DESCRIPTION
#### What this PR does / why we need it
`GetBlobFromPath` discards the result of `ensurePathInWorkingDirectory` and thus does not work correctly when passed a working directory and a relative path. Fix is to actually use the result of `ensurePathInWorkingDirectory`.

While working on that found and fixed two more issues:
* `ensurePathInWorkingDirectory` would leak because the handle returned by `os.OpenInRoot` was never closed
* `mimetype.DetectFile` used the raw path instead of resolving it from the working directory

#### Which issue(s) this PR fixes
Fixes https://github.com/open-component-model/open-component-model/issues/3420
#### Testing

##### How to test the changes

##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
