### PR TITLE
fix(ci): authenticate the GitHub integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,6 +363,7 @@ jobs:
       - name: Run Tests
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_USER: ${{ github.actor }}
           MODULE: ${{ matrix.module }}
         run: task "${MODULE}:test/integration"

--- a/bindings/go/github/integration/integration_test.go
+++ b/bindings/go/github/integration/integration_test.go
@@ -135,10 +135,20 @@ func assertOCMArchive(t *testing.T, downloaded blob.ReadOnlyBlob) {
 	assert.True(t, readmeFound, "the archive must contain the repository's README.md under the commit-prefixed root")
 }
 
+func requireCIToken(t *testing.T) {
+	t.Helper()
+	if os.Getenv("CI") != "" && os.Getenv("GITHUB_TOKEN") == "" {
+		t.Fatal("GITHUB_TOKEN must be set in CI: without it these requests go out anonymous " +
+			"and are rate limited at 60 per hour for the runner's shared IP")
+	}
+}
+
 func Test_Integration_GitHub(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
+
+	requireCIToken(t)
 
 	t.Run("resource", func(t *testing.T) {
 		processor := digest.NewDigestProcessor()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

The GitHub integration test fails at random in CI with a 403 from GitHub. It
never authenticated its API calls, so it ran on the 60-requests-per-hour limit
GitHub applies per IP address. Hosted runners share an egress address, so that
budget is usually already spent by unrelated traffic before the job starts:

```text
403 API rate limit exceeded for 135.18.238.0. [rate reset in 19m14s]
```

GitHub names an IP address in that message only for anonymous requests, which is
what identified the cause. Authenticating moves the run onto a private
5,000-per-hour budget, so it no longer depends on what other tenants on the same
address did.

The token never reached the test because of an env var name mismatch: the
workflow exports `GH_TOKEN`, the test reads `GITHUB_TOKEN`. Actions injects many
`GITHUB_*` variables on its own, but not `GITHUB_TOKEN`, so nothing set it. Both
names are needed in that job, since the OCI and CLI integration tests shell out
to the `gh` CLI and it reads `GH_TOKEN`. The workflow now exports `GITHUB_TOKEN`
alongside it instead of renaming.

- `.github/workflows/ci.yml`: export `GITHUB_TOKEN` in the integration test step.
- `bindings/go/github/integration`: fail fast when CI supplies no token. The
  client falls back to an anonymous request on purpose, so a missing token was
  otherwise invisible. The test now names the variable instead of letting it
  resurface later as a rate-limit error from an unrelated assertion. Local runs
  are unaffected and stay anonymous.

Verified locally: authenticated run passes all 8 subtests, and the authenticated
quota counter moves, which an anonymous run cannot do. Simulating CI without a
token fails immediately with the new message.

Signed-off-by: Piotr Janik <piotr.janik@sap.com>
