### PR TITLE
chore: Fix create-then-write race in `createLockFile`

### DIFF
--- a/bindings/go/plugin/client/sdk/plugin.go
+++ b/bindings/go/plugin/client/sdk/plugin.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"sync/atomic"
 	"syscall"
@@ -366,20 +367,30 @@ func (p *Plugin) removeFiles(loc string, lockFile string) error {
 }
 
 // createLockFile creates a lock file and puts the current process PID into the file.
+// The PID is written to a temporary file first which is then atomically renamed
+// into place so concurrent observers either see no lock file or a complete one.
 func (p *Plugin) createLockFile(loc string) (err error) {
 	lockFile := loc + ".lock"
-	file, err := os.Create(lockFile)
+	tmp, err := os.CreateTemp(filepath.Dir(lockFile), ".lock-*")
 	if err != nil {
-		return fmt.Errorf("could not create lock file: %w", err)
+		return fmt.Errorf("could not create temporary lock file: %w", err)
 	}
-
 	defer func() {
-		err = errors.Join(err, file.Close())
+		if err != nil {
+			err = errors.Join(err, os.Remove(tmp.Name()))
+		}
 	}()
 
 	pid := strconv.Itoa(os.Getpid())
-	if _, err = file.Write([]byte(pid)); err != nil {
+	if _, err = tmp.WriteString(pid); err != nil {
+		_ = tmp.Close()
 		return fmt.Errorf("could not write lock file: %w", err)
+	}
+	if err = tmp.Close(); err != nil {
+		return fmt.Errorf("could not close temporary lock file: %w", err)
+	}
+	if err = os.Rename(tmp.Name(), lockFile); err != nil {
+		return fmt.Errorf("could not move lock file into place: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
#### What this PR does / why we need it
Observed flakyness in unit-test between flakyness between https://github.com/open-component-model/open-component-model/actions/runs/32502215237/attempts/1?pr=3434 and https://github.com/open-component-model/open-component-model/actions/runs/32502215237/job/96836193331?pr=3434 

Error was in `TestLockFileCreationAndCleanup`                                                           
 ```
   expected: "13552"                                                                                                                                                                       
   actual  : ""                                                                                                                                                                            
 ```                                                                                                                                                             
The lock file existed but was empty when the test read it.
Cause is a create-then-write race in `createLockFile`. Fix is to publish the lock atomically: write the PID to a temp file in the same directory, close it, then `os.Rename` it into place. Observers now see either no lock file or a complete one

#### Which issue(s) this PR fixes

#### Testing


##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
