### PR TITLE
fix: double close of the read handle in GetV1FileBlob

### DIFF
--- a/bindings/go/input/file/blob.go
+++ b/bindings/go/input/file/blob.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/gabriel-vasile/mimetype"
@@ -41,7 +42,7 @@ var _ interface {
 // The function performs the following steps:
 //  1. Validates that the file path is not empty
 //  2. Reads the file from the filesystem using filesystem.GetBlobInWorkingDirectory
-//  3. Detects the media type using mimetype.DetectFile if not explicitly provided
+//  3. Detects the media type from the file content if not explicitly provided
 //  4. Wraps the blob with InputFileBlob to provide media type awareness
 //  5. Applies gzip compression with [compression.Compress] if the Compress flag is set
 func GetV1FileBlob(file v1.File, workingDirectory string) (blob.ReadOnlyBlob, error) {
@@ -56,22 +57,7 @@ func GetV1FileBlob(file v1.File, workingDirectory string) (blob.ReadOnlyBlob, er
 
 	mediaType := file.MediaType
 	if mediaType == "" {
-		readCloser, err := b.ReadCloser()
-		if err != nil {
-			return nil, err
-		}
-		// see https://github.com/gabriel-vasile/mimetype/blob/master/supported_mimes.md for supported types
-		mime, err := mimetype.DetectReader(readCloser)
-		cErr := readCloser.Close()
-		if err != nil {
-			return nil, err
-		}
-		if cErr != nil {
-			return nil, cErr
-		}
-		mediaType = mime.String()
-		err = readCloser.Close()
-		if err != nil {
+		if mediaType, err = detectMediaType(b); err != nil {
 			return nil, err
 		}
 	}
@@ -83,4 +69,23 @@ func GetV1FileBlob(file v1.File, workingDirectory string) (blob.ReadOnlyBlob, er
 	}
 
 	return data, nil
+}
+
+// detectMediaType determines the media type of the given blob by inspecting its content.
+func detectMediaType(b *filesystem.Blob) (_ string, err error) {
+	readCloser, err := b.ReadCloser()
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		err = errors.Join(err, readCloser.Close())
+	}()
+
+	// see https://github.com/gabriel-vasile/mimetype/blob/master/supported_mimes.md for supported types
+	mime, err := mimetype.DetectReader(readCloser)
+	if err != nil {
+		return "", err
+	}
+
+	return mime.String(), nil
 }

--- a/bindings/go/input/file/blob_test.go
+++ b/bindings/go/input/file/blob_test.go
@@ -441,3 +441,97 @@ func TestScheme_ResolvesAllFileInputAliases(t *testing.T) {
 		})
 	}
 }
+
+// TestGetV1FileBlob_MediaTypeDetection covers the branch where the media type is not set
+// explicitly and therefore has to be detected from the file content.
+func TestGetV1FileBlob_MediaTypeDetection(t *testing.T) {
+	tests := []struct {
+		name              string
+		fileName          string
+		fileData          []byte
+		compress          bool
+		expectedMediaType string
+	}{
+		{
+			name:              "text file",
+			fileName:          "test.txt",
+			fileData:          []byte("Hello, World!"),
+			expectedMediaType: "text/plain; charset=utf-8",
+		},
+		{
+			name:              "json file",
+			fileName:          "test.json",
+			fileData:          []byte(`{"key": "value"}`),
+			expectedMediaType: "application/json",
+		},
+		{
+			name:              "gzip file",
+			fileName:          "test.gz",
+			fileData:          gzipped(t, []byte("Hello, World!")),
+			expectedMediaType: "application/gzip",
+		},
+		{
+			name:              "text file with compression",
+			fileName:          "test.txt",
+			fileData:          []byte("Hello, World!"),
+			compress:          true,
+			expectedMediaType: "text/plain; charset=utf-8+gzip",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := require.New(t)
+
+			tempDir := t.TempDir()
+			filePath := filepath.Join(tempDir, tt.fileName)
+			r.NoError(os.WriteFile(filePath, tt.fileData, 0o600))
+
+			fileSpec := v1.File{
+				Type:     runtime.NewUnversionedType("file"),
+				Path:     filePath,
+				Compress: tt.compress,
+			}
+
+			b, err := file.GetV1FileBlob(fileSpec, tempDir)
+			r.NoError(err)
+			r.NotNil(b)
+
+			mediaTypeAware, ok := b.(blob.MediaTypeAware)
+			r.True(ok, "blob must expose its media type")
+			mediaType, known := mediaTypeAware.MediaType()
+			r.True(known)
+			r.Equal(tt.expectedMediaType, mediaType)
+
+			// The blob must still be readable after media type detection.
+			reader, err := b.ReadCloser()
+			r.NoError(err)
+			defer func() { r.NoError(reader.Close()) }()
+
+			data, err := io.ReadAll(reader)
+			r.NoError(err)
+			if tt.compress {
+				gzReader, err := gzip.NewReader(bytes.NewReader(data))
+				r.NoError(err)
+				defer func() { r.NoError(gzReader.Close()) }()
+				data, err = io.ReadAll(gzReader)
+				r.NoError(err)
+			}
+			r.Equal(tt.fileData, data)
+		})
+	}
+}
+
+// gzipped returns the gzip compressed representation of data.
+func gzipped(t *testing.T, data []byte) []byte {
+	t.Helper()
+	r := require.New(t)
+
+	var buf bytes.Buffer
+	writer := gzip.NewWriter(&buf)
+	_, err := writer.Write(data)
+	r.NoError(err)
+	r.NoError(writer.Close())
+
+	return buf.Bytes()
+}


### PR DESCRIPTION
#### What this PR does / why we need it

`GetV1FileBlob` closed the same read handle twice when the media type has to be detected
(`file.MediaType == ""`). `filesystem.Blob.ReadCloser()` returns a fresh `*os.File`, so the second
`Close()` always fails with `os.ErrClosed` and that error is returned to the caller:

```
error getting file blob based on resource input specification:
close /tmp/.../test-file.txt: file already closed
```

This breaks every `ocm add componentversion` with a `file` input that does not set `mediaType`
explicitly. Introduced in bb13e9bf0 (#3423), which swapped `mimetype.DetectFile` for
`ReadCloser()` + `mimetype.DetectReader` and left a stray close behind.

Detection now lives in a small helper that closes exactly once via `defer` + `errors.Join`, matching
the idiom already used in `filesystem.CopyBlobToOSPath`.

`bindings/go` CI stayed green because every existing case in `input/file/blob_test.go` sets
`MediaType` explicitly, so the detection branch was never executed. It only surfaced in `cli`, which
pins the published module — hence the failure appearing on the `v0.0.5` -> `v0.0.6` bump in #3460
rather than on the merge of #3423.

#### Which issue(s) this PR fixes

Fixes the `cli` and `cli/integration` failures in
https://github.com/open-component-model/open-component-model/actions/runs/32707899492
(`Test_Add_Component_Version`, `Test_Add_Component_Version_Formats`, `Test_Add_Input_Type_Casing`,
`Test_Download_Resource`, `Test_Transfer_Component_Version_With_Local_Blob`,
`Test_Integration_ConstructorCompress`).

Note: #3460 pins `v0.0.6`, which contains the bug, so it needs a `bindings/go` release cut from this
fix before Renovate can re-bump it.

The `Test_Integration_VersionCheck_*` failures in that same run are unrelated — `versioncheck.Check`
hits `api.github.com` unauthenticated with a 5s timeout and got rate-limited. Not addressed here.

#### Testing

##### How to test the changes

```yaml
# constructor.yaml — note the resource has no mediaType
components:
  - name: ocm.software/examples-01
    version: 1.0.0
    provider:
      name: ocm.software
    resources:
      - name: my-file
        type: blob
        input:
          type: file
          path: ./test-file.txt
```

```bash
echo "hello" > test-file.txt
ocm add cv --repository ./transport-archive --constructor ./constructor.yaml
```

Fails on `main` with `file already closed`, succeeds with this change.

##### Verification

- [x] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [x] Tests pass locally (`task test` and `task test/integration` if applicable)
- [x] My changes do not decrease test coverage
- [x] I have tested the changes locally by running `ocm`

`TestGetV1FileBlob_MediaTypeDetection` covers the previously untested detection branch (text, JSON,
gzip, and detection combined with `compress: true`). It reproduces the exact CI error before the fix.
The `cli` unit tests listed above were additionally run against this tree via a temporary
`go mod edit -replace` and all pass.
