### PR TITLE
fix(oci): resolve resources by exact identity before falling back to subset match

### DIFF
--- a/bindings/go/descriptor/runtime/artifact.go
+++ b/bindings/go/descriptor/runtime/artifact.go
@@ -43,3 +43,29 @@ func (r *Resource) GetType() string {
 func (r *Resource) GetAccess() runtime.Typed {
 	return r.Access
 }
+
+// FindArtifactsByIdentity returns the artifacts from candidates whose identity
+// matches the given identity. Exact equality is preferred over subset matching:
+// if any artifact's identity exactly equals the lookup identity, only those are
+// returned. Otherwise all artifacts whose identity is a superset of the lookup
+// identity (subset match) are returned.
+//
+// This allows callers to use a partial identity (e.g. {name, os, architecture}
+// without version) while still resolving correctly when multiple artifacts share
+// the same partial keys but differ by additional extraIdentity fields.
+func FindArtifactsByIdentity(identity runtime.Identity, candidates []Artifact) []Artifact {
+	var exact, subset []Artifact
+	for _, a := range candidates {
+		meta := a.GetElementMeta()
+		id := meta.ToIdentity()
+		if identity.Match(id, runtime.IdentityMatchingChainFn(runtime.IdentityEqual)) {
+			exact = append(exact, a)
+		} else if identity.Match(id, runtime.IdentityMatchingChainFn(runtime.IdentitySubset)) {
+			subset = append(subset, a)
+		}
+	}
+	if len(exact) > 0 {
+		return exact
+	}
+	return subset
+}

--- a/bindings/go/oci/repository.go
+++ b/bindings/go/oci/repository.go
@@ -523,34 +523,35 @@ func (repo *Repository) localArtifact(ctx context.Context, component, version st
 		return nil, nil, fmt.Errorf("failed to get component version: %w", err)
 	}
 
-	var exactCandidates, subsetCandidates []descriptor.Artifact
+	findCandidates := func(artifacts []descriptor.Artifact) []descriptor.Artifact {
+		var exact, subset []descriptor.Artifact
+		for _, a := range artifacts {
+			meta := a.GetElementMeta()
+			id := meta.ToIdentity()
+			if identity.Match(id, runtime.IdentityMatchingChainFn(runtime.IdentityEqual)) {
+				exact = append(exact, a)
+			} else if identity.Match(id, runtime.IdentityMatchingChainFn(runtime.IdentitySubset)) {
+				subset = append(subset, a)
+			}
+		}
+		if len(exact) > 0 {
+			return exact
+		}
+		return subset
+	}
+
+	var artifacts []descriptor.Artifact
 	switch kind {
 	case annotations.ArtifactKindResource:
-		for _, res := range desc.Component.Resources {
-			resIdentity := res.ToIdentity()
-			if identity.Match(resIdentity, runtime.IdentityMatchingChainFn(runtime.IdentityEqual)) {
-				exactCandidates = append(exactCandidates, &res)
-			} else if identity.Match(resIdentity, runtime.IdentityMatchingChainFn(runtime.IdentitySubset)) {
-				subsetCandidates = append(subsetCandidates, &res)
-			}
+		for i := range desc.Component.Resources {
+			artifacts = append(artifacts, &desc.Component.Resources[i])
 		}
 	case annotations.ArtifactKindSource:
-		for _, src := range desc.Component.Sources {
-			srcIdentity := src.ToIdentity()
-			if identity.Match(srcIdentity, runtime.IdentityMatchingChainFn(runtime.IdentityEqual)) {
-				exactCandidates = append(exactCandidates, &src)
-			} else if identity.Match(srcIdentity, runtime.IdentityMatchingChainFn(runtime.IdentitySubset)) {
-				subsetCandidates = append(subsetCandidates, &src)
-			}
+		for i := range desc.Component.Sources {
+			artifacts = append(artifacts, &desc.Component.Sources[i])
 		}
 	}
-	// Prefer exact matches; fall back to subset matches only when no exact match exists.
-	// This ensures resources sharing name+version but differing by extraIdentity are
-	// always resolved by exact identity, while partial lookups (no version) still work.
-	candidates := exactCandidates
-	if len(candidates) == 0 {
-		candidates = subsetCandidates
-	}
+	candidates := findCandidates(artifacts)
 	if len(candidates) != 1 {
 		return nil, nil, fmt.Errorf("found %d candidates while looking for %s %q, but expected exactly one", len(candidates), kind, identity)
 	}

--- a/bindings/go/oci/repository.go
+++ b/bindings/go/oci/repository.go
@@ -523,23 +523,6 @@ func (repo *Repository) localArtifact(ctx context.Context, component, version st
 		return nil, nil, fmt.Errorf("failed to get component version: %w", err)
 	}
 
-	findCandidates := func(artifacts []descriptor.Artifact) []descriptor.Artifact {
-		var exact, subset []descriptor.Artifact
-		for _, a := range artifacts {
-			meta := a.GetElementMeta()
-			id := meta.ToIdentity()
-			if identity.Match(id, runtime.IdentityMatchingChainFn(runtime.IdentityEqual)) {
-				exact = append(exact, a)
-			} else if identity.Match(id, runtime.IdentityMatchingChainFn(runtime.IdentitySubset)) {
-				subset = append(subset, a)
-			}
-		}
-		if len(exact) > 0 {
-			return exact
-		}
-		return subset
-	}
-
 	var artifacts []descriptor.Artifact
 	switch kind {
 	case annotations.ArtifactKindResource:
@@ -551,7 +534,7 @@ func (repo *Repository) localArtifact(ctx context.Context, component, version st
 			artifacts = append(artifacts, &desc.Component.Sources[i])
 		}
 	}
-	candidates := findCandidates(artifacts)
+	candidates := descriptor.FindArtifactsByIdentity(identity, artifacts)
 	if len(candidates) != 1 {
 		return nil, nil, fmt.Errorf("found %d candidates while looking for %s %q, but expected exactly one", len(candidates), kind, identity)
 	}

--- a/bindings/go/oci/repository.go
+++ b/bindings/go/oci/repository.go
@@ -523,20 +523,33 @@ func (repo *Repository) localArtifact(ctx context.Context, component, version st
 		return nil, nil, fmt.Errorf("failed to get component version: %w", err)
 	}
 
-	var candidates []descriptor.Artifact
+	var exactCandidates, subsetCandidates []descriptor.Artifact
 	switch kind {
 	case annotations.ArtifactKindResource:
 		for _, res := range desc.Component.Resources {
-			if identity.Match(res.ToIdentity(), runtime.IdentityMatchingChainFn(runtime.IdentitySubset)) {
-				candidates = append(candidates, &res)
+			resIdentity := res.ToIdentity()
+			if identity.Match(resIdentity, runtime.IdentityMatchingChainFn(runtime.IdentityEqual)) {
+				exactCandidates = append(exactCandidates, &res)
+			} else if identity.Match(resIdentity, runtime.IdentityMatchingChainFn(runtime.IdentitySubset)) {
+				subsetCandidates = append(subsetCandidates, &res)
 			}
 		}
 	case annotations.ArtifactKindSource:
 		for _, src := range desc.Component.Sources {
-			if identity.Match(src.ToIdentity(), runtime.IdentityMatchingChainFn(runtime.IdentitySubset)) {
-				candidates = append(candidates, &src)
+			srcIdentity := src.ToIdentity()
+			if identity.Match(srcIdentity, runtime.IdentityMatchingChainFn(runtime.IdentityEqual)) {
+				exactCandidates = append(exactCandidates, &src)
+			} else if identity.Match(srcIdentity, runtime.IdentityMatchingChainFn(runtime.IdentitySubset)) {
+				subsetCandidates = append(subsetCandidates, &src)
 			}
 		}
+	}
+	// Prefer exact matches; fall back to subset matches only when no exact match exists.
+	// This ensures resources sharing name+version but differing by extraIdentity are
+	// always resolved by exact identity, while partial lookups (no version) still work.
+	candidates := exactCandidates
+	if len(candidates) == 0 {
+		candidates = subsetCandidates
 	}
 	if len(candidates) != 1 {
 		return nil, nil, fmt.Errorf("found %d candidates while looking for %s %q, but expected exactly one", len(candidates), kind, identity)

--- a/bindings/go/oci/repository_test.go
+++ b/bindings/go/oci/repository_test.go
@@ -461,6 +461,121 @@ func TestRepository_GetLocalResource(t *testing.T) {
 	}
 }
 
+// TestRepository_GetLocalResource_MultipleResourcesSameNameVersion tests that GetLocalResource
+// correctly resolves a resource when multiple resources share the same name+version but differ
+// by extraIdentity. This is the bug described in the OCM spec issue where CTFGetLocalResource
+// lookup was matching all candidates instead of exactly one.
+func TestRepository_GetLocalResource_MultipleResourcesSameNameVersion(t *testing.T) {
+	r := require.New(t)
+	ctx := context.Background()
+
+	fs, err := filesystem.NewFS(t.TempDir(), os.O_RDWR)
+	r.NoError(err)
+	store := ocictf.NewFromCTF(ctf.NewFileSystemCTF(fs))
+	repo := Repository(t, ocictf.WithCTF(store))
+
+	desc := &descriptor.Descriptor{
+		Meta: descriptor.Meta{Version: "v2"},
+		Component: descriptor.Component{
+			Provider: descriptor.Provider{Name: "test-provider"},
+			ComponentMeta: descriptor.ComponentMeta{
+				ObjectMeta: descriptor.ObjectMeta{
+					Name:    "ocm.software/test-component",
+					Version: "1.0.0",
+				},
+			},
+		},
+	}
+
+	content1 := []byte("content for resource 1 - no extraIdentity")
+	content2 := []byte("content for resource 2 - type=helmChart")
+	content3 := []byte("content for resource 3 - type=helmChartImagemap")
+
+	res1 := &descriptor.Resource{
+		Relation: descriptor.LocalRelation,
+		ElementMeta: descriptor.ElementMeta{
+			ObjectMeta: descriptor.ObjectMeta{Name: "my-resource", Version: "v1.0.0"},
+		},
+		Type: "ociImage",
+		Access: &v2.LocalBlob{
+			LocalReference: digest.FromBytes(content1).String(),
+			MediaType:      "application/octet-stream",
+		},
+	}
+	res2 := &descriptor.Resource{
+		Relation: descriptor.LocalRelation,
+		ElementMeta: descriptor.ElementMeta{
+			ObjectMeta:    descriptor.ObjectMeta{Name: "my-resource", Version: "v1.0.0"},
+			ExtraIdentity: map[string]string{"type": "helmChart"},
+		},
+		Type: "helmChart",
+		Access: &v2.LocalBlob{
+			LocalReference: digest.FromBytes(content2).String(),
+			MediaType:      "application/octet-stream",
+		},
+	}
+	res3 := &descriptor.Resource{
+		Relation: descriptor.LocalRelation,
+		ElementMeta: descriptor.ElementMeta{
+			ObjectMeta:    descriptor.ObjectMeta{Name: "my-resource", Version: "v1.0.0"},
+			ExtraIdentity: map[string]string{"type": "helmChartImagemap"},
+		},
+		Type: "helmChart",
+		Access: &v2.LocalBlob{
+			LocalReference: digest.FromBytes(content3).String(),
+			MediaType:      "application/octet-stream",
+		},
+	}
+
+	newRes1, err := repo.AddLocalResource(ctx, desc.Component.Name, desc.Component.Version, res1, inmemory.New(bytes.NewReader(content1)))
+	r.NoError(err)
+	newRes2, err := repo.AddLocalResource(ctx, desc.Component.Name, desc.Component.Version, res2, inmemory.New(bytes.NewReader(content2)))
+	r.NoError(err)
+	newRes3, err := repo.AddLocalResource(ctx, desc.Component.Name, desc.Component.Version, res3, inmemory.New(bytes.NewReader(content3)))
+	r.NoError(err)
+
+	desc.Component.Resources = []descriptor.Resource{*newRes1, *newRes2, *newRes3}
+	r.NoError(repo.AddComponentVersion(ctx, desc))
+
+	tests := []struct {
+		name            string
+		identity        runtime.Identity
+		expectedContent []byte
+	}{
+		{
+			name:            "resource with no extraIdentity",
+			identity:        newRes1.ToIdentity(),
+			expectedContent: content1,
+		},
+		{
+			name:            "resource with type=helmChart extraIdentity",
+			identity:        newRes2.ToIdentity(),
+			expectedContent: content2,
+		},
+		{
+			name:            "resource with type=helmChartImagemap extraIdentity",
+			identity:        newRes3.ToIdentity(),
+			expectedContent: content3,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+			b, _, err := repo.GetLocalResource(ctx, desc.Component.Name, desc.Component.Version, tc.identity)
+			r.NoError(err, "GetLocalResource must resolve exactly one resource when extraIdentity distinguishes them")
+			r.NotNil(b)
+
+			reader, err := b.ReadCloser()
+			r.NoError(err)
+			defer reader.Close()
+			got, err := io.ReadAll(reader)
+			r.NoError(err)
+			r.Equal(string(tc.expectedContent), string(got))
+		})
+	}
+}
+
 func TestRepository_DownloadUploadResource(t *testing.T) {
 	artifactMediaType := "application/custom"
 	tests := []struct {


### PR DESCRIPTION
#### What this PR does / why we need it

`localArtifact` in the OCI repository used `IdentitySubset` matching when looking up resources by identity. A lookup key of `{name, version}` is a subset of any resource that has at least those two keys, so when a component version contains multiple resources sharing the same name+version but distinguished only by `extraIdentity`, all of them matched — causing "found N candidates, expected exactly one".

Fix by doing a two-pass candidate selection: exact equality (`IdentityEqual`) first, falling back to subset matching only when no exact match exists. This correctly resolves resources that share name+version but differ by `extraIdentity`, while preserving partial-identity lookups (e.g. `{name, os, architecture}` without `version`) used by existing callers.

#### Which issue(s) this PR fixes

<!--
Fixes #<issue number>
-->

#### Testing

##### How to test the changes

Save the repro script below and run it with a recent OCM binary:

```bash
OCM_BIN=/path/to/ocm bash ocm-bug-repro.sh
```

The script creates a component with 3 resources sharing `name=my-resource, version=v1.0.0` but different `extraIdentity`, transfers it into a CTF with `--copy-resources` (producing local blobs), then transfers from that CTF to a second CTF. Before this fix step 3 fails with "found 3 candidates"; after it completes successfully.

##### Verification

- [x] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [x] Tests pass locally (`task test` and `task test/integration` if applicable)
- [x] My changes do not decrease test coverage
- [x] I have tested the changes locally by running `ocm`