### PR TITLE
chore: Make sigstore integration tests work in same runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,29 +369,6 @@ jobs:
           MODULE: ${{ matrix.module }}
         run: task "${MODULE}:test/integration"
 
-  # Sigstore integration tests require a full scaffolding cluster (Fulcio, Rekor,
-  # CT-Log, TSA) and short-lived OIDC tokens. This setup is handled by the
-  # Taskfile and cannot share a job with the other integration tests.
-  run_sigstore_integration:
-    name: "Sigstore Integration Tests"
-    runs-on: ubuntu-24.04-arm
-    steps:
-      - name: Install Task
-        uses: arduino/setup-task@c0bc642852239c2689f73f4ea6459c29405f3c52 # v3.0.0
-        with:
-          version: 3.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - name: Setup Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
-        with:
-          go-version-file: '${{ github.workspace }}/bindings/go/go.mod'
-          cache-dependency-path: '${{ github.workspace }}/bindings/go/go.sum'
-      - name: Run Tests
-        run: task "bindings/go/sigstore/integration:test/integration"
-
   run_unit_tests:
     name: "Unit Tests"
     needs: discover_modules
@@ -464,7 +441,6 @@ jobs:
       - generate
       - run_unit_tests
       - run_integration_tests
-      - run_sigstore_integration
       - golangci_lint
       - dependency_table_verify
     if: ${{ failure() }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,10 +8,9 @@ output: prefixed
 includes:
   tools:
     taskfile: ./tools.Taskfile.yml
-  # bindings/go is a single Go module. Unit tests are run via `bindings/go:test`.
-  # Integration tests that only need Docker are run via `bindings/go:test/integration`.
-  # Sigstore integration requires a dedicated scaffolding cluster and runs as a
-  # separate CI job. The other integration includes are for local convenience.
+  # bindings/go is a single Go module. Unit tests are run via `bindings/go:test`,
+  # integration tests via `bindings/go:test/integration`.
+  # The other integration includes are for local convenience.
   # The generator include provides code generation tasks used by `task generate`.
   bindings/go:
     optional: true

--- a/bindings/go/Taskfile.yml
+++ b/bindings/go/Taskfile.yml
@@ -19,5 +19,12 @@ tasks:
       - go test -short -skip "Integration" -count=1 $(go list ./... | grep -v /integration) {{.CLI_ARGS}}
 
   test/integration:
+    set: [errexit]
+    vars:
+      SIGSTORE_INTEGRATION_DIR: '{{.TASKFILE_DIR}}/sigstore/integration'
     cmds:
-      - go test -run "Integration" -count=1 $(go list ./... | grep -v /sigstore/integration)
+      - task -d '{{.SIGSTORE_INTEGRATION_DIR}}' setup
+      - |
+        export PATH="{{.SIGSTORE_INTEGRATION_DIR}}/tmp/bin:$PATH"
+        . "{{.SIGSTORE_INTEGRATION_DIR}}/tmp/sigstore-env.sh"
+        go test -run "Integration" -count=1 ./...

--- a/bindings/go/sigstore/integration/Taskfile.yml
+++ b/bindings/go/sigstore/integration/Taskfile.yml
@@ -9,7 +9,11 @@ vars:
     sh: . ../signing/handler/internal/.env && echo "$COSIGN_VERSION"
   SCAFFOLDING_VERSION:
     sh: . ./.env && echo "$SCAFFOLDING_VERSION"
-  SIGSTORE_ENV_FILE: 'tmp/sigstore-env.sh'
+  # Absolute paths rooted via TASKFILE_DIR to make any call path (taskfiles in root,
+  # bindings/go, or this one) work identically.
+  SIGSTORE_ENV_FILE: '{{.TASKFILE_DIR}}/tmp/sigstore-env.sh'
+  SIGSTORE_ENV_DIR: '{{.TASKFILE_DIR}}/tmp/sigstore'
+  SIGSTORE_BIN_DIR: '{{.TASKFILE_DIR}}/tmp/bin'
   SIGSTORE_BRIDGE_PORT: '8080'
   SCAFFOLDING_URL: 'https://github.com/sigstore/scaffolding/releases/download/{{.SCAFFOLDING_VERSION}}'
 
@@ -125,13 +129,13 @@ tasks:
         lsof -ti :{{.SIGSTORE_BRIDGE_PORT}} >/dev/null 2>&1 || { echo "port-forward failed to start" >&2; exit 1; }
 
   scaffolding:env:
-    desc: "Extract sigstore env vars from running cluster into tmp/sigstore-env.sh"
+    desc: "Extract sigstore env vars from running cluster into the SIGSTORE_ENV_FILE"
     deps: [scaffolding:setup, scaffolding:bridge, cosign:install]
     cmds:
-      - mkdir -p tmp
-      - cmd: PATH="{{.ROOT_DIR}}/tmp/bin:$PATH" SIGSTORE_BRIDGE_PORT={{.SIGSTORE_BRIDGE_PORT}} bash hack/extract-sigstore-env.sh > {{.SIGSTORE_ENV_FILE}}
+      - mkdir -p "{{.TASKFILE_DIR}}/tmp" "{{.SIGSTORE_ENV_DIR}}"
+      - cmd: PATH="{{.SIGSTORE_BIN_DIR}}:$PATH" SIGSTORE_ENV_DIR="{{.SIGSTORE_ENV_DIR}}" SIGSTORE_BRIDGE_PORT={{.SIGSTORE_BRIDGE_PORT}} bash {{.TASKFILE_DIR}}/hack/extract-sigstore-env.sh > {{.SIGSTORE_ENV_FILE}}
         platforms: [darwin]
-      - cmd: PATH="{{.ROOT_DIR}}/tmp/bin:$PATH" bash hack/extract-sigstore-env.sh > {{.SIGSTORE_ENV_FILE}}
+      - cmd: PATH="{{.SIGSTORE_BIN_DIR}}:$PATH" SIGSTORE_ENV_DIR="{{.SIGSTORE_ENV_DIR}}" bash {{.TASKFILE_DIR}}/hack/extract-sigstore-env.sh > {{.SIGSTORE_ENV_FILE}}
         platforms: [linux]
 
   scaffolding:refresh:
@@ -166,7 +170,7 @@ tasks:
     requires:
       vars: [COSIGN_VERSION]
     vars:
-      BIN: '{{.ROOT_DIR}}/tmp/bin/cosign'
+      BIN: '{{.SIGSTORE_BIN_DIR}}/cosign'
     status:
       - 'cosign version 2>&1 | grep -qF "{{.COSIGN_VERSION}}"'
     cmds:
@@ -175,17 +179,22 @@ tasks:
         ARCH=$(uname -m)
         case "$ARCH" in x86_64) ARCH=amd64;; aarch64|arm64) ARCH=arm64;; esac
         URL="https://github.com/sigstore/cosign/releases/download/{{.COSIGN_VERSION}}/cosign-${OS}-${ARCH}"
-        mkdir -p "{{.ROOT_DIR}}/tmp/bin"
+        mkdir -p "{{.SIGSTORE_BIN_DIR}}"
         curl -fsSL "$URL" -o "{{.BIN}}"
         chmod +x "{{.BIN}}"
 
-  test/integration:
-    desc: "Run sigstore integration tests against scaffolding cluster"
+  setup:
+    desc: "Provision the sigstore scaffolding cluster and write the sourceable env file."
     deps: [scaffolding:env, cosign:install]
+
+  test/integration:
+    desc: "Run only the sigstore integration tests against a scaffolding cluster."
+    # Convenience target for local development
+    deps: [setup]
     set: [errexit]
     cmds:
       - |
-        export PATH="{{.ROOT_DIR}}/tmp/bin:$PATH"
+        export PATH="{{.SIGSTORE_BIN_DIR}}:$PATH"
         . {{.SIGSTORE_ENV_FILE}}
         go test -count=1 -run "{{.INTEGRATION_TEST_IDENTIFIER}}" -timeout 180s ./...
 
@@ -201,4 +210,4 @@ tasks:
         ignore_error: true
       - cmd: docker rm -f registry.local
         ignore_error: true
-      - rm -rf tmp
+      - rm -rf "{{.TASKFILE_DIR}}/tmp"


### PR DESCRIPTION
#### What this PR does / why we need it
Remove special handling for sigstore integration tests in CI

#### Which issue(s) this PR fixes
Part of post migration cleanup: https://github.com/open-component-model/ocm-project/issues/1212

#### Testing

##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
