### PR TITLE
fix(oci): hint that repository names must be lowercase

### DIFF
--- a/bindings/go/oci/looseref/parse.go
+++ b/bindings/go/oci/looseref/parse.go
@@ -126,6 +126,9 @@ func validateReference(ref LooseReference) error {
 
 	if ref.Repository != "" {
 		if err := ref.ValidateRepository(); err != nil {
+			if ref.Repository != strings.ToLower(ref.Repository) {
+				return fmt.Errorf("%w: repository names must be lowercase", err)
+			}
 			return err
 		}
 	}

--- a/bindings/go/oci/looseref/parse_test.go
+++ b/bindings/go/oci/looseref/parse_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/registry"
 )
 
@@ -200,6 +201,13 @@ func TestParseReferenceUglies(t *testing.T) {
 			require.Errorf(t, err, "ParseReference() expected an error, but got reg=%v,repo=%v,ref=%v", ref.Registry, ref.Repository, ref.Reference)
 		})
 	}
+}
+
+func TestParseReferenceUppercaseRepositoryHint(t *testing.T) {
+	_, err := ParseReference("ghcr.io/UpperCaseUser/example")
+	require.Error(t, err)
+	require.ErrorIs(t, err, errdef.ErrInvalidReference)
+	require.ErrorContains(t, err, "repository names must be lowercase")
 }
 
 func TestLooseReferenceString(t *testing.T) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

`ocm transfer component-version` fails with a bare `invalid repository "..."`
error when the target reference contains uppercase letters, e.g. a GHCR
namespace derived from a mixed-case username. The message does not tell the
user what to change.

Appends a `repository names must be lowercase` hint to the validation error
in `looseref.ParseReference` when the repository part contains uppercase
letters.

#### Which issue(s) this PR fixes

Fixes: https://github.com/open-component-model/open-component-model/issues/3060