### PR TITLE
chore: Fix `creator` string referencing old path

### DIFF
--- a/bindings/go/kubernetes/controller/internal/setup/plugins.go
+++ b/bindings/go/kubernetes/controller/internal/setup/plugins.go
@@ -27,7 +27,7 @@ import (
 )
 
 // creator controller user-agent.
-const creator = "ocm.software/open-component-model/kubernetes/controller"
+const creator = "ocm.software/open-component-model/bindings/go/kubernetes/controller"
 
 // PluginOptions since TempDir is dependent on the Pod and mounted temp folder
 // we set it separately from the ocm config. Also, filesystem config is not allowed.


### PR DESCRIPTION
#### What this PR does / why we need it
Missed it when merging #3515 into #3522 
#### Which issue(s) this PR fixes


##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
