### PR TITLE
chore: Don't crawl slack links in linkspector

### DIFF
--- a/.github/config/linkspector-changed.yaml
+++ b/.github/config/linkspector-changed.yaml
@@ -8,3 +8,6 @@ dirs:
 excludedDirs:
   - website
 modifiedFilesOnly: true
+ignorePatterns:
+  # Slack archives require a signed-in session and appears to block crawlers.
+  - pattern: "^https?://kubernetes\\.slack\\.com"


### PR DESCRIPTION
#### What this PR does / why we need it
https://github.com/open-component-model/open-component-model/pull/3522 touched https://github.com/open-component-model/open-component-model/blob/main/docs/community/SIGs/Runtime/SIG-Runtime-OVERVIEW.md and thus triggered the linkspector to check slack for the first time since https://github.com/open-component-model/open-component-model/actions/runs/31012401449 and apparently Slack has blocked access in the meantime (at least I can crawl the URL fine from my machine, so I assume its the IP range of the runners)

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Testing

##### How to test the changes

##### Verification

- [ ] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [ ] Tests pass locally (`task test` and `task test/integration` if applicable)
- [ ] My changes do not decrease test coverage
- [ ] I have tested the changes locally by running `ocm`
