### PR TITLE
chore(docs): manually release documentation for 0.15.0

### DIFF
--- a/website/config/_default/hugo.yaml
+++ b/website/config/_default/hugo.yaml
@@ -20,7 +20,7 @@ defaultContentLanguageInSubdir: false
 editPage: false
 lastMod: false
 defaultContentVersionInSubdir: false
-defaultContentVersion: '0.14'
+defaultContentVersion: '0.15'
 pagination:
   pagerSize: 10
 params:
@@ -88,20 +88,22 @@ imaging:
 versions:
   main:
     weight: 1
-  '0.14':
+  '0.15':
     weight: 2
-  '0.13':
+  '0.14':
     weight: 3
-  '0.12':
+  '0.13':
     weight: 4
-  '0.11':
+  '0.12':
     weight: 5
-  '0.10':
+  '0.11':
     weight: 6
-  '0.9':
+  '0.10':
     weight: 7
-  legacy:
+  '0.9':
     weight: 8
+  legacy:
+    weight: 9
 services:
   rss:
     limit: 20

--- a/website/config/_default/module.yaml
+++ b/website/config/_default/module.yaml
@@ -899,3 +899,110 @@ imports:
           matrix:
             versions:
               - '0.14'
+  - path: ocm.software/open-component-model/website
+    version: v0.15.0
+    ignoreImports: true
+    ignoreConfig: true
+    mounts:
+      - files:
+          - '**'
+          - '!blog/**'
+        source: content/
+        target: content
+        sites:
+          matrix:
+            versions:
+              - '0.15'
+  - path: ocm.software/open-component-model/cli
+    version: v0.15.0
+    mounts:
+      - source: docs/reference
+        target: content/docs/reference/ocm-cli
+        sites:
+          matrix:
+            versions:
+              - '0.15'
+  - path: ocm.software/open-component-model/bindings/go
+    version: v0.0.13
+    mounts:
+      - source: constructor/spec/v1/resources
+        target: static/0.15/schemas/bindings/go/constructor
+        sites:
+          matrix:
+            versions:
+              - '0.15'
+      - source: descriptor/v2/resources
+        target: static/0.15/schemas/bindings/go/descriptor/v2
+        sites:
+          matrix:
+            versions:
+              - '0.15'
+      - source: github/spec/credentials/v1/schemas
+        target: static/0.15/schemas/bindings/go/credentials/github/v1
+        sites:
+          matrix:
+            versions:
+              - '0.15'
+      - source: http/spec/config/v1alpha1/schemas
+        target: static/0.15/schemas/bindings/go/http
+        sites:
+          matrix:
+            versions:
+              - '0.15'
+      - source: oci/spec/credentials/v1/schemas
+        target: static/0.15/schemas/bindings/go/credentials/oci/v1
+        sites:
+          matrix:
+            versions:
+              - '0.15'
+      - source: helm/spec/credentials/v1/schemas
+        target: static/0.15/schemas/bindings/go/credentials/helm/v1
+        sites:
+          matrix:
+            versions:
+              - '0.15'
+      - source: rsa/spec/credentials/v1/schemas
+        target: static/0.15/schemas/bindings/go/credentials/rsa/v1
+        sites:
+          matrix:
+            versions:
+              - '0.15'
+      - source: gpg/spec/credentials/v1alpha1/schemas
+        target: static/0.15/schemas/bindings/go/credentials/gpg/v1alpha1
+        sites:
+          matrix:
+            versions:
+              - '0.15'
+      - source: sigstore/spec/credentials/oidcidentitytoken/v1alpha1/schemas
+        target: static/0.15/schemas/bindings/go/credentials/sigstore/oidcidentitytoken/v1alpha1
+        sites:
+          matrix:
+            versions:
+              - '0.15'
+      - source: sigstore/spec/credentials/trustedroot/v1alpha1/schemas
+        target: static/0.15/schemas/bindings/go/credentials/sigstore/trustedroot/v1alpha1
+        sites:
+          matrix:
+            versions:
+              - '0.15'
+      - source: credentials/spec/config/v1/schemas
+        target: static/0.15/schemas/bindings/go/credentials/direct/v1
+        sites:
+          matrix:
+            versions:
+              - '0.15'
+      - source: wget/spec/credentials/v1/schemas
+        target: static/0.15/schemas/bindings/go/credentials/wget/v1
+        sites:
+          matrix:
+            versions:
+              - '0.15'
+  - path: ocm.software/open-component-model/kubernetes/controller
+    version: v0.15.0
+    mounts:
+      - source: config/crd/bases
+        target: static/0.15/schemas/kubernetes/controller
+        sites:
+          matrix:
+            versions:
+              - '0.15'

--- a/website/config/_default/module.yaml
+++ b/website/config/_default/module.yaml
@@ -923,7 +923,7 @@ imports:
             versions:
               - '0.15'
   - path: ocm.software/open-component-model/bindings/go
-    version: v0.0.13
+    version: v0.0.8
     mounts:
       - source: constructor/spec/v1/resources
         target: static/0.15/schemas/bindings/go/constructor


### PR DESCRIPTION
Release ocm v2 `0.15.0` [failed](https://github.com/open-component-model/open-component-model/actions/runs/32859801161/job/101986803880) in its last step "Open website update PR". The reason for this is that it checks out the `main` branch and wants to install go based on `cli/go.mod`. However, that file does not exist anymore since the `cli` module was moved to `bindings/go`.

We first tried to fix this by moving that doc-job from the release workflow to its own workflow with an input-parameter (https://github.com/open-component-model/open-component-model/pull/3582, https://github.com/open-component-model/open-component-model/pull/3583; especially the fact that we could not easily re-run the docs generation was the reason for this).

However, this did not solve another problem where we want to import `bindings/go` with the passed version. But for the release `0.15.0` we did not started with the lock-step release for `bindings/go`. Thus, the used version for `bindings/go` was `0.0.8` (we decided to only push patch-versions until the lock-step release is ready).

Instead of fixing the generator script, we decided to fix it manually. This is ugly, and if we need to patch `0.15.0`, we will need to do it again. But implementing such a edge-case into the workflow and/or script feels a bit too much.