### PR TITLE
fix(oci): allow digest-only uploads in the materialized upload path

### DIFF
--- a/bindings/go/oci/repository.go
+++ b/bindings/go/oci/repository.go
@@ -620,10 +620,10 @@ func (repo *Repository) getStore(ctx context.Context, component string, version 
 
 // UploadResource uploads a [*descriptor.Resource] to the repository.
 // The target access image reference may carry a tag, a digest, or neither:
-// a tag is applied on upload, otherwise the access is pinned to the pushed
-// digest. Uploads without a tag are logged as a warning because retention
-// of the artifact then depends on the target registry's garbage collection
-// policy.
+// a tag is applied on upload, a digest-only reference is preserved as-is,
+// and a reference carrying neither is pinned to the pushed digest. Uploads
+// without a tag are logged as a warning because retention of the artifact
+// then depends on the target registry's garbage collection policy.
 func (repo *Repository) UploadResource(ctx context.Context, res *descriptor.Resource, b blob.ReadOnlyBlob) (newRes *descriptor.Resource, err error) {
 	ctx = slogcontext.NewCtx(ctx, repo.logger)
 	done := log.Operation(ctx, "upload resource", log.IdentityLogAttr("resource", res.ToIdentity()))

--- a/bindings/go/oci/repository.go
+++ b/bindings/go/oci/repository.go
@@ -1153,6 +1153,9 @@ func (repo *Repository) UploadResourceStream(ctx context.Context, res *descripto
 		if err := store.Tag(ctx, rs.Root(), ref.Tag); err != nil {
 			return nil, fmt.Errorf("failed to tag artifact with tag %q: %w", ref.Tag, err)
 		}
+	} else {
+		slogcontext.Warn(ctx, "uploading OCI artifact without a tag, retention depends on the target registry's garbage collection policy",
+			"imageReference", access.ImageReference)
 	}
 
 	res = res.DeepCopy()

--- a/bindings/go/oci/repository.go
+++ b/bindings/go/oci/repository.go
@@ -296,6 +296,11 @@ func (repo *Repository) processOCIImageDigest(ctx context.Context, res *descript
 	if err != nil {
 		return nil, fmt.Errorf("error parsing image reference %q: %w", typed.ImageReference, err)
 	}
+	if resolved.Tag == "" {
+		slogcontext.Warn(ctx, "resource access references an image without a tag; the artifact may be garbage collected if the registry only retains tagged manifests, and copies will be uploaded untagged",
+			"imageReference", typed.ImageReference,
+			log.IdentityLogAttr("resource", res.ToIdentity()))
+	}
 
 	var pinnedDigest digest.Digest
 	if dig, err := resolved.Digest(); err == nil {

--- a/bindings/go/oci/repository.go
+++ b/bindings/go/oci/repository.go
@@ -297,7 +297,7 @@ func (repo *Repository) processOCIImageDigest(ctx context.Context, res *descript
 		return nil, fmt.Errorf("error parsing image reference %q: %w", typed.ImageReference, err)
 	}
 	if resolved.Tag == "" {
-		slogcontext.Warn(ctx, "resource access references an image without a tag; the artifact may be garbage collected if the registry only retains tagged manifests, and copies will be uploaded untagged",
+		slogcontext.Warn(ctx, "resource access references an image without a tag; if it is transferred and uploaded as oci image, it will be untagged, retention depends on the target registry's garbage collection policy",
 			"imageReference", typed.ImageReference,
 			log.IdentityLogAttr("resource", res.ToIdentity()))
 	}

--- a/bindings/go/oci/repository.go
+++ b/bindings/go/oci/repository.go
@@ -619,6 +619,11 @@ func (repo *Repository) getStore(ctx context.Context, component string, version 
 }
 
 // UploadResource uploads a [*descriptor.Resource] to the repository.
+// The target access image reference may carry a tag, a digest, or neither:
+// a tag is applied on upload, otherwise the access is pinned to the pushed
+// digest. Uploads without a tag are logged as a warning because retention
+// of the artifact then depends on the target registry's garbage collection
+// policy.
 func (repo *Repository) UploadResource(ctx context.Context, res *descriptor.Resource, b blob.ReadOnlyBlob) (newRes *descriptor.Resource, err error) {
 	ctx = slogcontext.NewCtx(ctx, repo.logger)
 	done := log.Operation(ctx, "upload resource", log.IdentityLogAttr("resource", res.ToIdentity()))
@@ -645,6 +650,8 @@ func (repo *Repository) UploadResource(ctx context.Context, res *descriptor.Reso
 }
 
 // UploadSource uploads a [*descriptor.Source] to the repository.
+// See [Repository.UploadResource] for the tag/digest handling of the target
+// access image reference.
 func (repo *Repository) UploadSource(ctx context.Context, src *descriptor.Source, b blob.ReadOnlyBlob) (newSrc *descriptor.Source, err error) {
 	ctx = slogcontext.NewCtx(ctx, repo.logger)
 	done := log.Operation(ctx, "upload source", log.IdentityLogAttr("source", src.ToIdentity()))
@@ -692,9 +699,6 @@ func (repo *Repository) uploadOCIImage(ctx context.Context, newAccess runtime.Ty
 	if err != nil {
 		return ociImageSpecV1.Descriptor{}, nil, fmt.Errorf("failed to parse target access image reference %q: %w", access.ImageReference, err)
 	}
-	if err := ref.ValidateReferenceAsTag(); err != nil {
-		return ociImageSpecV1.Descriptor{}, nil, fmt.Errorf("can only copy %q if it is tagged: %w", access.ImageReference, err)
-	}
 
 	extendedOpts := oras.ExtendedCopyGraphOptions{
 		CopyGraphOptions: repo.resourceCopyOptions.CopyGraphOptions,
@@ -703,8 +707,19 @@ func (repo *Repository) uploadOCIImage(ctx context.Context, newAccess runtime.Ty
 		return ociImageSpecV1.Descriptor{}, nil, fmt.Errorf("failed to upload resource via copy: %w", err)
 	}
 
-	if err := store.Tag(ctx, main, ref.Tag); err != nil {
-		return ociImageSpecV1.Descriptor{}, nil, fmt.Errorf("failed to tag main artifact with tag %q: %w", ref.Tag, err)
+	if ref.Tag != "" {
+		if err := store.Tag(ctx, main, ref.Tag); err != nil {
+			return ociImageSpecV1.Descriptor{}, nil, fmt.Errorf("failed to tag main artifact with tag %q: %w", ref.Tag, err)
+		}
+	} else {
+		slogcontext.Warn(ctx, "uploading OCI artifact without a tag, retention depends on the target registry's garbage collection policy",
+			"imageReference", access.ImageReference)
+	}
+
+	// if we don't have a pinned access we can pin it now.
+	if ref.Reference.Reference == "" {
+		ref.Reference.Reference = main.Digest.String()
+		access.ImageReference = ref.String()
 	}
 
 	return main, &access, nil

--- a/bindings/go/oci/repository_test.go
+++ b/bindings/go/oci/repository_test.go
@@ -2975,6 +2975,25 @@ func TestRepository_UploadResource_DigestOnlyAccess(t *testing.T) {
 		r.ErrorIs(err, errdef.ErrNotFound, "no tag must be present for a digest-only upload")
 	})
 
+	t.Run("digest-only reference is preserved as-is and not tagged", func(t *testing.T) {
+		r := require.New(t)
+		b, manifest := newLayoutBlob(t)
+
+		ref := "ghcr.io/acme/dst-digest@" + manifest.Digest.String()
+		updated, err := repo.UploadResource(t.Context(), newResource(ref), b)
+		r.NoError(err)
+		r.Equal(ref, updated.Access.(*v1.OCIImage).ImageReference,
+			"a digest-only reference must be preserved, not re-pinned")
+
+		dstStore, err := store.StoreForReference(t.Context(), ref)
+		r.NoError(err)
+		resolved, err := dstStore.Resolve(t.Context(), manifest.Digest.String())
+		r.NoError(err)
+		r.Equal(manifest.Digest, resolved.Digest)
+		_, err = dstStore.Resolve(t.Context(), "latest")
+		r.ErrorIs(err, errdef.ErrNotFound, "no tag must be created for a digest-only upload")
+	})
+
 	t.Run("tagged access is applied as a tag and not re-pinned", func(t *testing.T) {
 		r := require.New(t)
 		b, manifest := newLayoutBlob(t)

--- a/bindings/go/oci/repository_test.go
+++ b/bindings/go/oci/repository_test.go
@@ -2913,3 +2913,80 @@ func TestRepository_AddOwnership_RawBlobSubjectSkipped(t *testing.T) {
 	r.NoError(err)
 	r.Nil(body, "a raw-blob subject must yield no ownership referrer")
 }
+
+// TestRepository_UploadResource_DigestOnlyAccess verifies that the
+// materialized upload path accepts digest-only and bare image references
+// (mirroring UploadResourceStream): no tag is applied, a warning is logged,
+// and the resulting access is pinned to the pushed digest when the reference
+// did not already carry one.
+func TestRepository_UploadResource_DigestOnlyAccess(t *testing.T) {
+	r := require.New(t)
+
+	fs, err := filesystem.NewFS(t.TempDir(), os.O_RDWR)
+	r.NoError(err)
+	store := ocictf.NewFromCTF(ctf.NewFileSystemCTF(fs))
+	repo := Repository(t, oci.WithResolver(store))
+
+	newLayoutBlob := func(t *testing.T) (blob.ReadOnlyBlob, ociImageSpecV1.Descriptor) {
+		t.Helper()
+		var buf bytes.Buffer
+		w, err := tar.NewOCILayoutWriterWithTempFile(&buf, t.TempDir())
+		require.NoError(t, err)
+		layer := content.NewDescriptorFromBytes(ociImageSpecV1.MediaTypeImageLayer, []byte("layer"))
+		require.NoError(t, w.Push(t.Context(), layer, bytes.NewReader([]byte("layer"))))
+		manifest, err := oras.PackManifest(t.Context(), w, oras.PackManifestVersion1_1, "application/artifact", oras.PackManifestOptions{
+			Layers: []ociImageSpecV1.Descriptor{layer},
+		})
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+		return inmemory.New(bytes.NewReader(buf.Bytes())), manifest
+	}
+
+	newResource := func(ref string) *descriptor.Resource {
+		return &descriptor.Resource{
+			Relation:    descriptor.LocalRelation,
+			ElementMeta: descriptor.ElementMeta{ObjectMeta: descriptor.ObjectMeta{Name: "img", Version: "1.0.0"}},
+			Type:        "ociImage",
+			Access: &v1.OCIImage{
+				Type:           runtime.NewVersionedType(v1.OCIImageType, v1.Version),
+				ImageReference: ref,
+			},
+		}
+	}
+
+	t.Run("bare reference uploads untagged and pins the pushed digest", func(t *testing.T) {
+		r := require.New(t)
+		b, manifest := newLayoutBlob(t)
+
+		updated, err := repo.UploadResource(t.Context(), newResource("ghcr.io/acme/dst"), b)
+		r.NoError(err)
+
+		access, ok := updated.Access.(*v1.OCIImage)
+		r.True(ok, "expected an OCIImage access, got %T", updated.Access)
+		r.Equal("ghcr.io/acme/dst@"+manifest.Digest.String(), access.ImageReference,
+			"the access must be pinned to the pushed digest")
+
+		dstStore, err := store.StoreForReference(t.Context(), "ghcr.io/acme/dst")
+		r.NoError(err)
+		exists, err := dstStore.Exists(t.Context(), manifest)
+		r.NoError(err)
+		r.True(exists, "the pushed root must be content-addressable")
+		_, err = dstStore.Resolve(t.Context(), "latest")
+		r.ErrorIs(err, errdef.ErrNotFound, "no tag must be present for a digest-only upload")
+	})
+
+	t.Run("tagged access is applied as a tag and not re-pinned", func(t *testing.T) {
+		r := require.New(t)
+		b, manifest := newLayoutBlob(t)
+
+		updated, err := repo.UploadResource(t.Context(), newResource("ghcr.io/acme/dst-tagged:v1"), b)
+		r.NoError(err)
+		r.Equal("ghcr.io/acme/dst-tagged:v1", updated.Access.(*v1.OCIImage).ImageReference)
+
+		dstStore, err := store.StoreForReference(t.Context(), "ghcr.io/acme/dst-tagged")
+		r.NoError(err)
+		resolved, err := dstStore.Resolve(t.Context(), "v1")
+		r.NoError(err)
+		r.Equal(manifest.Digest, resolved.Digest, "the tag must point at the pushed root")
+	})
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
uploadOCIImage (used by UploadResource/UploadSource) hard-errored when the target ImageReference carried no tag, while UploadResourceStream tolerated digest-only references, pinned the pushed digest, and tagged only when one was present. This made the two upload paths behave inconsistently for the same access (e.g. ctf->oci transfers with --upload-as ociArtifact failed where oci->oci streaming succeeded).

Drop the tag gate and mirror the streaming behavior: tag only when the reference carries one, pin the pushed digest into the access when it carries neither tag nor digest, and log a warning when the upload goes out untagged since retention then depends on the target registry's garbage collection policy.

This behavior was discovered during the investigation of https://github.com/open-component-model/open-component-model/pull/3588.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Testing

##### How to test the changes

<!--
Required files to test the changes:

.ocmconfig
```yaml
type: generic.config.ocm.software/v1
configurations:
  - type: credentials.config.ocm.software
    repositories:
      - repository:
          type: DockerConfig/v1
          dockerConfigFile: "~/.docker/config.json"
```

Commands that test the change:

```bash
ocm get cv xxx

ocm transfer xxx
```
-->

##### Verification

- [x] I have added/updated tests for my changes (see [Test Requirements](../CONTRIBUTING.md#test-requirements))
- [x] Tests pass locally (`task test` and `task test/integration` if applicable)
- [x] My changes do not decrease test coverage
- [x] I have tested the changes locally by running `ocm`
